### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "rxjs": "~7.8.2",
     "tslib": "^2.8.1",
     "uuid": "^11.1.0",
-    "zone.js": "~0.15.1"
+    "zone.js": "~0.15.1",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@analogjs/vite-plugin-angular": "^1.20.1",

--- a/server.js
+++ b/server.js
@@ -1,11 +1,23 @@
 import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import rateLimit from 'express-rate-limit';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const app = express();
+
+// Set up a basic rate limiter: max 100 requests per 15 minutes per IP
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+});
+
+// Apply the rate limiter to all requests
+app.use(limiter);
 
 // Serve static files from the Angular app build output
 app.use(express.static(path.join(__dirname, 'dist/tmi-ux')));

--- a/src/app/shared/services/cell-data-extraction.service.ts
+++ b/src/app/shared/services/cell-data-extraction.service.ts
@@ -233,7 +233,13 @@ export class CellDataExtractionService {
 
         // 1. Check if value contains actual text (not just whitespace or HTML)
         if (storedCell.value && typeof storedCell.value === 'string') {
-          const cleanValue = storedCell.value.replace(/<[^>]*>/g, '').trim(); // Remove HTML tags
+          let cleanValue = storedCell.value;
+          let previousValue;
+          do {
+            previousValue = cleanValue;
+            cleanValue = cleanValue.replace(/<[^>]*>/g, '');
+          } while (cleanValue !== previousValue);
+          cleanValue = cleanValue.trim(); // Remove leading/trailing whitespace after tags are gone
           if (cleanValue && cleanValue !== storedCell.id) {
             label = cleanValue;
           }


### PR DESCRIPTION
Potential fix for [https://github.com/ericfitz/tmi-ux/security/code-scanning/6](https://github.com/ericfitz/tmi-ux/security/code-scanning/6)

The best way to fix this problem is to introduce rate-limiting middleware into the Express app, protecting all routes (including static files and the wildcard route that sends `index.html`). The most common and robust approach is to use the widely-adopted `express-rate-limit` package.

1. Install `express-rate-limit` as a dependency.
2. In `server.js`, import `express-rate-limit`.
3. Before any routes, configure and apply the rate limiter middleware with a suitable threshold (e.g., 100 requests per 15 minutes per IP—adjust as needed).
4. No changes to the actual file-serving logic are required; just ensure the limiter is applied early enough.

**Lines to change/add:**
- Import `express-rate-limit` near the top.
- Add a rate limiter setup and apply it with `app.use(limiter);` before serving static files and routes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
