### PR TITLE
fix: override lodash-es to 4.17.23 for CVE-2025-13465

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
   },
   "pnpm": {
     "overrides": {
+      "lodash-es": "^4.17.23",
       "http-proxy-middleware": "^3.0.5",
       "wrap-ansi@9.0.1": "9.0.0",
       "slice-ansi@7.1.1": "7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   http-proxy-middleware: ^3.0.5
+  lodash-es: ^4.17.23
   wrap-ansi@9.0.1: 9.0.0
   slice-ansi@7.1.1: 7.1.0
   node-forge: ^1.3.2
@@ -4785,11 +4786,8 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
-
-  lodash-es@4.17.22:
-    resolution: {integrity: sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==}
+  lodash-es@4.17.23:
+    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -7104,7 +7102,7 @@ snapshots:
 
   '@antv/x6-common@2.0.17':
     dependencies:
-      lodash-es: 4.17.22
+      lodash-es: 4.17.23
       utility-types: 3.11.0
 
   '@antv/x6-geometry@2.0.5': {}
@@ -7857,12 +7855,12 @@ snapshots:
     dependencies:
       '@chevrotain/gast': 11.0.3
       '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   '@chevrotain/gast@11.0.3':
     dependencies:
       '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   '@chevrotain/regexp-to-ast@11.0.3': {}
 
@@ -9770,7 +9768,7 @@ snapshots:
   chevrotain-allstar@0.3.1(chevrotain@11.0.3):
     dependencies:
       chevrotain: 11.0.3
-      lodash-es: 4.17.22
+      lodash-es: 4.17.23
 
   chevrotain@11.0.3:
     dependencies:
@@ -9779,7 +9777,7 @@ snapshots:
       '@chevrotain/regexp-to-ast': 11.0.3
       '@chevrotain/types': 11.0.3
       '@chevrotain/utils': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   chokidar@3.6.0:
     dependencies:
@@ -10195,7 +10193,7 @@ snapshots:
   dagre-d3-es@7.0.13:
     dependencies:
       d3: 7.9.0
-      lodash-es: 4.17.22
+      lodash-es: 4.17.23
 
   data-urls@6.0.0:
     dependencies:
@@ -11580,9 +11578,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.17.21: {}
-
-  lodash-es@4.17.22: {}
+  lodash-es@4.17.23: {}
 
   lodash.debounce@4.0.8: {}
 
@@ -11706,7 +11702,7 @@ snapshots:
       dompurify: 3.3.1
       katex: 0.16.27
       khroma: 2.1.0
-      lodash-es: 4.17.22
+      lodash-es: 4.17.23
       marked: 16.4.2
       roughjs: 4.6.6
       stylis: 4.3.6


### PR DESCRIPTION
## Summary
- Adds pnpm override to force `lodash-es` to version 4.17.23, fixing CVE-2025-13465 (prototype pollution in `_.unset` and `_.omit`)
- Addresses [Dependabot alert #42](https://github.com/ericfitz/tmi-ux/security/dependabot/42)
- The vulnerable versions (4.17.21/4.17.22) were transitive dependencies from `@antv/x6-common` and `chevrotain` (via mermaid)

## Test plan
- [x] `pnpm why lodash-es` confirms all instances resolve to 4.17.23
- [x] Build succeeds
- [x] All 2482 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)