### PR TITLE
fix: centralize 401 handling and prevent auto-logout on auth errors

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -321,16 +321,16 @@ export const appConfig: ApplicationConfig = {
       useFactory: mermaidOptionsFactory,
     },
     // Register HTTP interceptors (order matters - first registered runs first)
-    // 1. HttpLoggingInterceptor - logs all HTTP requests/responses and categorizes errors
-    {
-      provide: HTTP_INTERCEPTORS,
-      useClass: HttpLoggingInterceptor,
-      multi: true,
-    },
-    // 2. JwtInterceptor - handles JWT token attachment and auth-specific errors
+    // 1. JwtInterceptor - adds Authorization header first so it's visible in logs
     {
       provide: HTTP_INTERCEPTORS,
       useClass: JwtInterceptor,
+      multi: true,
+    },
+    // 2. HttpLoggingInterceptor - logs all HTTP requests/responses with auth header present
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: HttpLoggingInterceptor,
       multi: true,
     },
     // Initialize security monitoring

--- a/src/app/core/rxjs-imports.ts
+++ b/src/app/core/rxjs-imports.ts
@@ -20,5 +20,6 @@ export { catchError } from 'rxjs/internal/operators/catchError';
 export { switchMap } from 'rxjs/internal/operators/switchMap';
 export { takeUntil } from 'rxjs/internal/operators/takeUntil';
 export { throwError } from 'rxjs/internal/observable/throwError';
+export { shareReplay } from 'rxjs/internal/operators/shareReplay';
 
 // Add more operators as needed

--- a/src/app/core/services/api.service.ts
+++ b/src/app/core/services/api.service.ts
@@ -16,7 +16,7 @@
  */
 
 import { HttpClient, HttpErrorResponse, HttpContext } from '@angular/common/http';
-import { Injectable, Inject } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Observable, throwError, TimeoutError } from 'rxjs';
 import { catchError, retry, timeout } from 'rxjs/operators';
 import { Router } from '@angular/router';
@@ -24,7 +24,6 @@ import { MatDialog } from '@angular/material/dialog';
 
 import { LoggerService } from './logger.service';
 import { environment } from '../../../environments/environment';
-import { AUTH_SERVICE, IAuthService } from '../interfaces';
 import { SKIP_ERROR_HANDLING } from '../tokens/http-context.tokens';
 import {
   ValidationErrorDialogComponent,
@@ -48,7 +47,6 @@ export class ApiService {
     private http: HttpClient,
     private logger: LoggerService,
     private router: Router,
-    @Inject(AUTH_SERVICE) private authService: IAuthService,
     private dialog: MatDialog,
   ) {
     // this.logger.info(`API Service initialized with endpoint: ${this.apiUrl}`);
@@ -229,16 +227,11 @@ export class ApiService {
         this.logger.error(errorMessage, error);
 
         // Only handle specific error types if not skipped
+        // Note: 401 errors are handled exclusively by JwtInterceptor
         if (!skipErrorHandling) {
           if (error.status === 400) {
             // Handle validation errors
             this.handleValidationError(error);
-          } else if (error.status === 401) {
-            this.logger.warn('API returned 401 Unauthorized. Redirecting to login.');
-            this.authService.logout(); // Clear session
-            void this.router.navigate(['/login'], {
-              queryParams: { returnUrl: this.router.url, reason: 'unauthorized_api' },
-            });
           } else if (error.status === 403) {
             this.logger.warn('API returned 403 Forbidden. Redirecting to unauthorized page.');
             void this.router.navigate(['/unauthorized'], {

--- a/src/app/core/tokens/http-context.tokens.ts
+++ b/src/app/core/tokens/http-context.tokens.ts
@@ -5,3 +5,10 @@ import { HttpContextToken } from '@angular/common/http';
  * This is useful for endpoints where we want to handle errors differently than the default behavior
  */
 export const SKIP_ERROR_HANDLING = new HttpContextToken<boolean>(() => false);
+
+/**
+ * HTTP context token to mark a request as an auth retry attempt
+ * Prevents infinite retry loops when handling 401 errors - if a request with this
+ * flag set receives a 401, we don't attempt another refresh/retry
+ */
+export const IS_AUTH_RETRY = new HttpContextToken<boolean>(() => false);


### PR DESCRIPTION
## Summary

- Centralize all 401 handling in the JWT interceptor (removes duplicate handling from ApiService)
- Prevent automatic logout on 401 errors - let components decide how to handle
- Add `forceRefreshToken()` method that always refreshes regardless of token expiry
- Add request deduplication to prevent concurrent refresh calls
- Swap interceptor order so Authorization header is visible in debug logs
- Add `IS_AUTH_RETRY` context token to prevent infinite retry loops

## Problem

When invoking addons, the API returned 401 with "Invalid authentication context". The old behavior:
1. Tried to refresh with `getValidTokenIfAvailable()` which returned the same token (not near expiry)
2. Retried with same token → another 401
3. Immediately logged the user out

## Solution

- On 401, call `forceRefreshToken()` which always refreshes
- Mark retry requests with `IS_AUTH_RETRY` context to prevent infinite loops
- Propagate errors to components instead of auto-logout
- Emit auth errors via `authError$` observable for UI handling

## Files Changed

| File | Change |
|------|--------|
| `app.config.ts` | Swap interceptor order |
| `http-context.tokens.ts` | Add `IS_AUTH_RETRY` token |
| `rxjs-imports.ts` | Add `shareReplay` export |
| `auth.service.ts` | Add `forceRefreshToken()` method |
| `jwt.interceptor.ts` | Refactor 401 handling |
| `api.service.ts` | Remove duplicate 401 handling |
| `threat-model.resolver.ts` | Distinguish 401 vs 403 errors |

## Test plan

- [x] Run `pnpm run lint:all` - passes
- [x] Run `pnpm run build` - passes
- [x] Run `pnpm test` - all 2482 tests pass
- [ ] Manual test: Trigger 401 error, verify user stays logged in
- [ ] Manual test: Verify Authorization header appears in debug logs (redacted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)