### PR TITLE
feat(admin): UI for viewing system + threat-model audit logs (#679)

### DIFF
--- a/docs/superpowers/plans/2026-06-15-admin-audit-ui.md
+++ b/docs/superpowers/plans/2026-06-15-admin-audit-ui.md
@@ -1,0 +1,750 @@
+# Admin Audit-Log UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an admin-only UI (tmi-ux#679) for reading the system audit log and the cross-threat-model audit log, with bidirectional cursor pagination, `around` permalink context, filters, a route-driven detail panel, and CSV/NDJSON export — against the now-fully-published server contract (tmi#464 on tmi `dev/1.4.0`).
+
+**Architecture:** Self-contained feature under `src/app/pages/admin/audit/`. A shell (`AuditLogsPageComponent`) with a `mat-tab-nav-bar` hosts two deep-linkable child views (system, threat-models). Each view composes a config-driven filter bar + a cursor-paged table + a route-driven detail panel rendered in the view's own `<router-outlet>` (child route `:entryId`) so the table stays alive. One `AdminAuditService` wraps the four list/get endpoints plus a blob export. Read-only; no step-up. Existing per-TM audit trail page is untouched.
+
+**Tech Stack:** Angular standalone components, OnPush, Material, Transloco i18n, RxJS, Vitest. Server contract: `GET /admin/audit/system(/{entry_id})` and `GET /admin/audit/threat_models(/{entry_id})`, response `{ entries, total, limit, next_cursor, prev_cursor }`; pagination via opaque `cursor` (direction embedded) **or** `around={entry_id}`; system-only `format=csv|ndjson` streamed export.
+
+---
+
+## Contract reference (verified against tmi `dev/1.4.0` `api-schema/tmi-openapi.json` on 2026-06-15)
+
+**List response (both streams):** `{ entries: T[], total: number, limit: number, next_cursor?: string|null, prev_cursor?: string|null }`.
+- `next_cursor` = older page (forward); `prev_cursor` = newer page (backward). `null`/absent = no more pages that direction. Client passes whichever cursor back via `cursor=` without interpreting direction.
+
+**System filters:** `actor_email`, `actor_provider`, `created_after` (RFC3339), `created_before`, `http_method` (enum `POST|PUT|PATCH|DELETE`), `path_prefix`, `field_path`.
+**TM filters:** `actor_email`, `actor_provider`, `created_after`, `created_before`, `change_type` (enum `created|updated|patched|deleted|rolled_back|restored`), `object_type` (enum `threat_model|diagram|threat|asset|document|note|repository`), `threat_model_id` (uuid).
+**Pagination params (both):** `limit` (1–100, default 50), `cursor` (opaque, mutually exclusive with `around`), `around` (uuid, mutually exclusive with `cursor`).
+**Export (system only):** `format=csv|ndjson` — streamed attachment, ignores cursor/limit/around, honors filters.
+
+**`SystemAuditEntry`:** `id` (uuid), `actor` (AuditActor), `http_method`, `http_path`, `field_path`, `created_at` (required); `old_value_redacted`, `new_value_redacted`, `change_summary` (nullable strings).
+**`AuditEntry` (TM)** and **`AuditActor`** already exist in `src/app/pages/tm/models/audit-trail.model.ts` — REUSE them. `AuditEntry`: `id, threat_model_id, object_type, object_id, version (number|null), change_type, actor, change_summary (string|null), created_at`.
+
+**Note on generated types:** `src/app/generated/api-types.d.ts` is generated from tmi `main` and does NOT yet contain the audit schemas (the endpoints live only on `dev/1.4.0`). Do NOT regenerate the whole file (it would pull the entire 1.4.0 API diff). Hand-write audit types, mirroring the existing `audit-trail.model.ts` convention.
+
+---
+
+## File structure
+
+Create under `src/app/pages/admin/audit/`:
+- `models/admin-audit.model.ts` — types (SystemAuditEntry, list responses, filter/page param types, view-config types). Reuses AuditEntry/AuditActor from tm models.
+- `admin-audit.service.ts` (+ `.spec.ts`) — API access.
+- `audit-logs-page.component.{ts,html,scss}` (+ `.spec.ts`) — shell: tab-nav-bar + router-outlet.
+- `components/audit-filter-bar.component.{ts,html,scss}` (+ `.spec.ts`) — config-driven filters + export menu.
+- `components/audit-table.component.{ts,html,scss}` (+ `.spec.ts`) — cursor-paged mat-table, Newer/Older, anchor highlight.
+- `components/audit-detail-panel.component.{ts,html,scss}` (+ `.spec.ts`) — route-driven detail, copy-permalink, view-in-context.
+- `views/system-audit-view.component.{ts,html,scss}` (+ `.spec.ts`) — system composition.
+- `views/tm-audit-view.component.{ts,html,scss}` (+ `.spec.ts`) — TM composition.
+
+Modify:
+- `src/app/core/services/api.service.ts` — add `getBlob()`.
+- `src/app/shared/utils/blob-download.util.ts` — new tiny helper `downloadBlob(blob, filename)`.
+- `src/app/app.routes.ts` — add audit routes under `/admin`.
+- `src/app/pages/admin/admin.component.ts` — add "Audit Logs" section card.
+- `src/app/pages/admin/settings/admin-settings.component.{ts,html}` — cross-reference "view in audit log" affordance.
+- `src/assets/i18n/en-US.json` — all new strings (then backfill all locales).
+
+---
+
+## Conventions (apply to every component)
+
+- Standalone, `changeDetection: ChangeDetectionStrategy.OnPush`. Import from `@app/shared/imports` (`COMMON_IMPORTS`, `CORE_MATERIAL_IMPORTS`, `FORM_MATERIAL_IMPORTS`, `DATA_MATERIAL_IMPORTS`, `FEEDBACK_MATERIAL_IMPORTS`) + `TranslocoModule`; add `MatAutocompleteModule`, `MatDatepickerModule`, `MatNativeDateModule` directly where needed.
+- Subscriptions: `private destroyRef = inject(DestroyRef)` + `.pipe(takeUntilDestroyed(this.destroyRef))`. Call `cdr.markForCheck()` after async state updates.
+- i18n: `[transloco]="'key'"` directive or `'key' | transloco` pipe. All user-facing strings localized.
+- Errors: `catchError` + `LoggerService` (`this.logger.error(...)`), never `console.log`.
+- `data-testid` attributes on interactive elements (match existing admin pages).
+- Reference exemplars: `admin-users.component` (table, filter, query-param mirroring), `admin-projects.component` (debounced autocomplete), `admin-surveys.component` (OnPush + DestroyRef), `reviewer-assignment-list.component` (date-range pickers).
+
+---
+
+### Task 1: Audit domain types
+
+**Files:**
+- Create: `src/app/pages/admin/audit/models/admin-audit.model.ts`
+
+- [ ] **Step 1: Write the types file**
+
+```typescript
+/**
+ * Types for the admin audit-log UI (tmi-ux#679), matching the server contract
+ * published on tmi dev/1.4.0 (tmi#398 + tmi#464). Hand-written because the
+ * generated api-types.d.ts is built from tmi main, which lacks these schemas.
+ */
+import { AuditActor, AuditChangeType, AuditEntry, AuditObjectType } from '@app/pages/tm/models/audit-trail.model';
+
+export { AuditActor, AuditChangeType, AuditEntry, AuditObjectType };
+
+/** HTTP methods recorded by the system audit log. */
+export type AuditHttpMethod = 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+/** A system audit entry: an immutable record of a successful /admin/* write. */
+export interface SystemAuditEntry {
+  id: string;
+  actor: AuditActor;
+  http_method: string;
+  http_path: string;
+  field_path: string;
+  old_value_redacted: string | null;
+  new_value_redacted: string | null;
+  change_summary: string | null;
+  created_at: string;
+}
+
+/** Common cursor-paginated list envelope returned by both audit list endpoints. */
+export interface AuditListResponse<T> {
+  entries: T[];
+  total: number;
+  limit: number;
+  /** Cursor for the next (older) page; null/absent when exhausted. */
+  next_cursor?: string | null;
+  /** Cursor for the previous (newer) page; null/absent at the newest end. */
+  prev_cursor?: string | null;
+}
+
+export type ListSystemAuditResponse = AuditListResponse<SystemAuditEntry>;
+export type ListTmAuditResponse = AuditListResponse<AuditEntry>;
+
+/** Active filters for the system audit list. All optional. */
+export interface SystemAuditFilter {
+  actor_email?: string;
+  actor_provider?: string;
+  created_after?: string;
+  created_before?: string;
+  http_method?: AuditHttpMethod;
+  path_prefix?: string;
+  field_path?: string;
+}
+
+/** Active filters for the threat-model audit list. All optional. */
+export interface TmAuditFilter {
+  actor_email?: string;
+  actor_provider?: string;
+  created_after?: string;
+  created_before?: string;
+  change_type?: AuditChangeType;
+  object_type?: AuditObjectType;
+  threat_model_id?: string;
+}
+
+export type AuditFilter = SystemAuditFilter | TmAuditFilter;
+
+/** Pagination request: forward/back cursor traversal OR around-anchor. Mutually exclusive cursor/around. */
+export interface AuditPageRequest {
+  limit?: number;
+  cursor?: string;
+  around?: string;
+}
+
+export type AuditExportFormat = 'csv' | 'ndjson';
+
+/** Which audit stream a shared component is operating on. */
+export type AuditStream = 'system' | 'tm';
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `pnpm exec tsc --noEmit -p tsconfig.json 2>&1 | grep admin-audit.model || echo "no errors in file"`
+Expected: `no errors in file`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/pages/admin/audit/models/admin-audit.model.ts
+git commit -m "feat(admin): add audit-log UI domain types (#679)"
+```
+
+---
+
+### Task 2: ApiService.getBlob + blob download util
+
+**Files:**
+- Modify: `src/app/core/services/api.service.ts` (add `getBlob` mirroring `getText` at ~line 100)
+- Create: `src/app/shared/utils/blob-download.util.ts`
+- Test: `src/app/shared/utils/blob-download.util.spec.ts`
+
+- [ ] **Step 1: Add `getBlob` to ApiService** (immediately after the existing `getText` method)
+
+```typescript
+  /**
+   * GET request that returns a Blob (for streamed file exports).
+   * @param endpoint The API endpoint (without the base URL)
+   * @param params Optional query parameters
+   */
+  getBlob(
+    endpoint: string,
+    params?: Record<string, string | number | boolean | ReadonlyArray<string | number | boolean>>,
+  ): Observable<Blob> {
+    const url = this.buildUrl(endpoint);
+
+    return this.http.get(url, { params, responseType: 'blob' }).pipe(
+      retry({
+        count: 1,
+        delay: (error: HttpErrorResponse) => this.getRetryDelay(error),
+      }),
+      catchError((error: HttpErrorResponse) => this.handleError(error, 'GET', endpoint)),
+    );
+  }
+```
+
+- [ ] **Step 2: Write the failing test for the download util**
+
+```typescript
+import '@angular/compiler';
+import { vi, expect, describe, it, beforeEach, afterEach } from 'vitest';
+import { downloadBlob } from './blob-download.util';
+
+describe('downloadBlob', () => {
+  let clickSpy: ReturnType<typeof vi.fn>;
+  let anchor: HTMLAnchorElement;
+
+  beforeEach(() => {
+    clickSpy = vi.fn();
+    anchor = document.createElement('a');
+    anchor.click = clickSpy;
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+    vi.spyOn(document.body, 'appendChild').mockImplementation(node => node);
+    vi.spyOn(document.body, 'removeChild').mockImplementation(node => node);
+    (URL as unknown as { createObjectURL: () => string }).createObjectURL = vi.fn(() => 'blob:mock');
+    (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('triggers an anchor download with the given filename and revokes the url', () => {
+    const blob = new Blob(['a,b,c'], { type: 'text/csv' });
+    downloadBlob(blob, 'export.csv');
+    expect(anchor.download).toBe('export.csv');
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock');
+  });
+});
+```
+
+- [ ] **Step 3: Run it, expect FAIL** (module not found)
+
+Run: `pnpm test -- src/app/shared/utils/blob-download.util.spec.ts`
+
+- [ ] **Step 4: Implement the util**
+
+```typescript
+/**
+ * Save a Blob to a file via a programmatic anchor download. Used for audit-log
+ * exports where the blob arrives asynchronously over HttpClient (so the File
+ * System Access picker, which needs a live user gesture, is not viable).
+ */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+```
+
+- [ ] **Step 5: Run test, expect PASS**
+
+Run: `pnpm test -- src/app/shared/utils/blob-download.util.spec.ts`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/core/services/api.service.ts src/app/shared/utils/blob-download.util.ts src/app/shared/utils/blob-download.util.spec.ts
+git commit -m "feat(core): add ApiService.getBlob and blob-download util (#679)"
+```
+
+---
+
+### Task 3: AdminAuditService
+
+**Files:**
+- Create: `src/app/pages/admin/audit/admin-audit.service.ts`
+- Test: `src/app/pages/admin/audit/admin-audit.service.spec.ts`
+
+Service injects `ApiService` + `LoggerService`. Uses `buildHttpParams` from `@app/shared/utils/http-params.util` to drop undefined/null. For paginated lists, merge filter + page request into one params object.
+
+- [ ] **Step 1: Write the failing tests** (mock ApiService directly, Vitest)
+
+```typescript
+import '@angular/compiler';
+import { vi, expect, describe, it, beforeEach } from 'vitest';
+import { of, throwError, lastValueFrom } from 'rxjs';
+import { AdminAuditService } from './admin-audit.service';
+
+describe('AdminAuditService', () => {
+  let service: AdminAuditService;
+  let api: { get: ReturnType<typeof vi.fn>; getBlob: ReturnType<typeof vi.fn> };
+  let logger: { debug: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    api = { get: vi.fn(), getBlob: vi.fn() };
+    logger = { debug: vi.fn(), error: vi.fn() };
+    service = new AdminAuditService(api as never, logger as never);
+  });
+
+  it('lists system entries, passing filter + page params, dropping empties', async () => {
+    api.get.mockReturnValue(of({ entries: [], total: 0, limit: 50, next_cursor: null }));
+    await lastValueFrom(
+      service.listSystem({ actor_email: 'a@b.c', http_method: 'PUT', path_prefix: '' }, { limit: 50, cursor: 'X' }),
+    );
+    expect(api.get).toHaveBeenCalledWith('admin/audit/system', {
+      actor_email: 'a@b.c',
+      http_method: 'PUT',
+      limit: 50,
+      cursor: 'X',
+    });
+  });
+
+  it('lists system entries in around mode', async () => {
+    api.get.mockReturnValue(of({ entries: [], total: 0, limit: 50 }));
+    await lastValueFrom(service.listSystem({}, { limit: 50, around: 'uuid-1' }));
+    expect(api.get).toHaveBeenCalledWith('admin/audit/system', { limit: 50, around: 'uuid-1' });
+  });
+
+  it('gets a single system entry by id', async () => {
+    api.get.mockReturnValue(of({ id: 'e1' }));
+    await lastValueFrom(service.getSystemEntry('e1'));
+    expect(api.get).toHaveBeenCalledWith('admin/audit/system/e1');
+  });
+
+  it('lists TM entries against the threat_models endpoint', async () => {
+    api.get.mockReturnValue(of({ entries: [], total: 0, limit: 50 }));
+    await lastValueFrom(service.listTm({ object_type: 'threat' }, { limit: 50 }));
+    expect(api.get).toHaveBeenCalledWith('admin/audit/threat_models', { object_type: 'threat', limit: 50 });
+  });
+
+  it('gets a single TM entry by id', async () => {
+    api.get.mockReturnValue(of({ id: 't1' }));
+    await lastValueFrom(service.getTmEntry('t1'));
+    expect(api.get).toHaveBeenCalledWith('admin/audit/threat_models/t1');
+  });
+
+  it('exports system audit as a blob with format param', async () => {
+    api.getBlob.mockReturnValue(of(new Blob(['x'])));
+    await lastValueFrom(service.exportSystem({ actor_email: 'a@b.c' }, 'ndjson'));
+    expect(api.getBlob).toHaveBeenCalledWith('admin/audit/system', { actor_email: 'a@b.c', format: 'ndjson' });
+  });
+
+  it('logs and rethrows on list error', async () => {
+    api.get.mockReturnValue(throwError(() => new Error('boom')));
+    await expect(lastValueFrom(service.listSystem({}, {}))).rejects.toThrow('boom');
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `pnpm test -- src/app/pages/admin/audit/admin-audit.service.spec.ts`
+
+- [ ] **Step 3: Implement the service**
+
+```typescript
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
+import { ApiService } from '@app/core/services/api.service';
+import { LoggerService } from '@app/core/services/logger.service';
+import { buildHttpParams } from '@app/shared/utils/http-params.util';
+import {
+  AuditEntry,
+  AuditExportFormat,
+  AuditPageRequest,
+  ListSystemAuditResponse,
+  ListTmAuditResponse,
+  SystemAuditEntry,
+  SystemAuditFilter,
+  TmAuditFilter,
+} from './models/admin-audit.model';
+
+const SYSTEM_PATH = 'admin/audit/system';
+const TM_PATH = 'admin/audit/threat_models';
+
+@Injectable({ providedIn: 'root' })
+export class AdminAuditService {
+  constructor(
+    private apiService: ApiService,
+    private logger: LoggerService,
+  ) {}
+
+  listSystem(filter: SystemAuditFilter, page: AuditPageRequest): Observable<ListSystemAuditResponse> {
+    const params = buildHttpParams({ ...filter, ...page });
+    return this.apiService.get<ListSystemAuditResponse>(SYSTEM_PATH, params).pipe(
+      tap(r => this.logger.debug('System audit entries loaded', { count: r.entries.length, total: r.total })),
+      catchError(error => {
+        this.logger.error('Failed to list system audit entries', error);
+        throw error;
+      }),
+    );
+  }
+
+  getSystemEntry(entryId: string): Observable<SystemAuditEntry> {
+    return this.apiService.get<SystemAuditEntry>(`${SYSTEM_PATH}/${entryId}`).pipe(
+      catchError(error => {
+        this.logger.error('Failed to get system audit entry', error);
+        throw error;
+      }),
+    );
+  }
+
+  listTm(filter: TmAuditFilter, page: AuditPageRequest): Observable<ListTmAuditResponse> {
+    const params = buildHttpParams({ ...filter, ...page });
+    return this.apiService.get<ListTmAuditResponse>(TM_PATH, params).pipe(
+      tap(r => this.logger.debug('TM audit entries loaded', { count: r.entries.length, total: r.total })),
+      catchError(error => {
+        this.logger.error('Failed to list threat-model audit entries', error);
+        throw error;
+      }),
+    );
+  }
+
+  getTmEntry(entryId: string): Observable<AuditEntry> {
+    return this.apiService.get<AuditEntry>(`${TM_PATH}/${entryId}`).pipe(
+      catchError(error => {
+        this.logger.error('Failed to get threat-model audit entry', error);
+        throw error;
+      }),
+    );
+  }
+
+  exportSystem(filter: SystemAuditFilter, format: AuditExportFormat): Observable<Blob> {
+    const params = buildHttpParams({ ...filter, format });
+    return this.apiService.getBlob(SYSTEM_PATH, params).pipe(
+      tap(() => this.logger.info('System audit export downloaded', { format })),
+      catchError(error => {
+        this.logger.error('Failed to export system audit', error);
+        throw error;
+      }),
+    );
+  }
+}
+```
+
+Note: `buildHttpParams` already returns `undefined` when empty and drops null/undefined values; the empty-string `path_prefix` in test 1 — confirm `buildHttpParams` drops empty strings. If it does NOT (it only drops null/undefined per the explored source), adjust the test expectation to include `path_prefix: ''`, OR strip empty strings in the service before building params. **Decision: strip empty strings in the service** so empty filter inputs don't send blank query params. Add a helper:
+
+```typescript
+function clean<T extends object>(obj: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined && v !== null && v !== ''),
+  ) as Partial<T>;
+}
+```
+and call `buildHttpParams(clean({ ...filter, ...page }))`. Keep test 1 expecting `path_prefix` absent.
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+Run: `pnpm test -- src/app/pages/admin/audit/admin-audit.service.spec.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/pages/admin/audit/admin-audit.service.ts src/app/pages/admin/audit/admin-audit.service.spec.ts
+git commit -m "feat(admin): add AdminAuditService for audit-log endpoints (#679)"
+```
+
+---
+
+### Task 4: Audit filter bar component
+
+**Files:**
+- Create: `src/app/pages/admin/audit/components/audit-filter-bar.component.{ts,html,scss}`
+- Test: `src/app/pages/admin/audit/components/audit-filter-bar.component.spec.ts`
+
+Config-driven so one component serves both streams. Inputs: `stream: AuditStream`, `initialFilter`. Output: `filterChange = new EventEmitter<AuditFilter>()` (debounced 300ms on text inputs; immediate on selects/dates) and `exportRequested = new EventEmitter<AuditExportFormat>()`. Actor field = debounced autocomplete against `UserAdminService.list({ ... })` (reuse the `admin-projects` autocomplete pattern; the existing admin-users actor search). Date pickers emit `created_after`/`created_before` as ISO strings (`$event.value?.toISOString()`). System shows http_method select + path_prefix + field_path; TM shows change_type select + object_type select + threat_model_id text. Export menu (CSV/NDJSON) visible only when `stream === 'system'`. Clear-filters button resets the form and emits an empty filter.
+
+- [ ] **Step 1: Write tests** covering: (a) emits a filter object combining set fields; (b) debounce on text fields (use fake timers / `vi.useFakeTimers()`); (c) clear-filters emits `{}`; (d) export menu present only for system; `exportRequested` emits the chosen format; (e) actor autocomplete calls the user search service on input. Follow the standalone-component test pattern (`runInInjectionContext` + `Injector.create` with mocked `DestroyRef`), mocking `UserAdminService`, `LoggerService`, `TranslocoService`.
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement** the component (`.ts`, `.html`, `.scss`). Use a reactive form group keyed by stream config. Map http_method enum values `['POST','PUT','PATCH','DELETE']`; change_type `['created','updated','patched','deleted','rolled_back','restored']`; object_type `['threat_model','diagram','threat','asset','document','note','repository']`. All labels via transloco keys under `admin.audit.filters.*`. Emit `filterChange` with only non-empty values (reuse the same `clean` rule). Debounce text inputs via a `Subject<void>` + `debounceTime(300)` + `takeUntilDestroyed`.
+
+- [ ] **Step 4: Run tests, expect PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/pages/admin/audit/components/audit-filter-bar.component.*
+git commit -m "feat(admin): add audit filter-bar component (#679)"
+```
+
+---
+
+### Task 5: Audit table component
+
+**Files:**
+- Create: `src/app/pages/admin/audit/components/audit-table.component.{ts,html,scss}`
+- Test: `src/app/pages/admin/audit/components/audit-table.component.spec.ts`
+
+Presentational. Inputs: `columns: AuditColumnDef[]` (define `AuditColumnDef { key: string; headerKey: string; cell: (row: unknown) => string }` in `admin-audit.model.ts` — add it in this task), `rows: unknown[]`, `loading: boolean`, `nextCursor: string | null | undefined`, `prevCursor: string | null | undefined`, `anchorId: string | null` (highlight row in around mode), `error: boolean`, `empty: boolean`. Outputs: `older = new EventEmitter<void>()`, `newer = new EventEmitter<void>()`, `rowClick = new EventEmitter<{ id: string }>()`, `retry = new EventEmitter<void>()`.
+
+Template: `mat-table` with dynamic `displayedColumns = columns.map(c => c.key)`; `‹ Newer` button disabled when `!prevCursor`; `Older ›` button disabled when `!nextCursor`; row gets class `anchor-row` when `row.id === anchorId`; distinct empty state ("no entries match these filters") vs error banner + retry (per design). `data-testid` on Newer/Older/rows.
+
+- [ ] **Step 1: Write tests:** (a) renders one row per `rows`; (b) Newer disabled when `prevCursor` null, enabled otherwise → emits `newer`; (c) Older disabled when `nextCursor` null → emits `older`; (d) row click emits `{ id }`; (e) `empty` shows empty message, `error` shows retry which emits `retry`; (f) anchor row gets `anchor-row` class. Use `createComponentFixture` from `@testing/component-test-harness` for DOM assertions.
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement.**
+
+- [ ] **Step 4: Run tests, expect PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/pages/admin/audit/components/audit-table.component.* src/app/pages/admin/audit/models/admin-audit.model.ts
+git commit -m "feat(admin): add cursor-paged audit table component (#679)"
+```
+
+---
+
+### Task 6: Audit detail panel component
+
+**Files:**
+- Create: `src/app/pages/admin/audit/components/audit-detail-panel.component.{ts,html,scss}`
+- Test: `src/app/pages/admin/audit/components/audit-detail-panel.component.spec.ts`
+
+Route-driven: reads `:entryId` from `ActivatedRoute.paramMap` and `stream` from `ActivatedRoute.snapshot.data['stream']` (set on the route). On param change, fetches via `AdminAuditService.getSystemEntry` or `getTmEntry`. Renders fields per stream (system: timestamp UTC absolute, full actor identity, method + path, field_path, redacted old/new values as-returned, change_summary; TM: timestamp, actor, threat-model link, object type/id, change_type, version, change_summary). Actions: **copy-permalink** (writes `window.location` absolute URL of the current route to clipboard via `navigator.clipboard.writeText`), **view-in-context** (emits/navigates to the parent list with `around={entryId}` — `router.navigate(['../'], { relativeTo, queryParams: { around: entryId } })` then close panel; the view component reacts to the `around` query param). Close button navigates back to the parent list route (`router.navigate(['../'], { relativeTo: route })`). 404 from `getXxxEntry` → show "entry not found" state. Logs errors via LoggerService.
+
+- [ ] **Step 1: Write tests:** (a) fetches system entry when `stream='system'`, renders its fields; (b) fetches TM entry when `stream='tm'`; (c) re-fetches when `:entryId` changes; (d) copy-permalink calls `navigator.clipboard.writeText` with the permalink; (e) view-in-context navigates with `around` query param; (f) 404 error shows not-found state. Mock `AdminAuditService`, `ActivatedRoute` (paramMap as a `BehaviorSubject`/`of`, `snapshot.data`), `Router`, `LoggerService`.
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement.**
+
+- [ ] **Step 4: Run tests, expect PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/pages/admin/audit/components/audit-detail-panel.component.*
+git commit -m "feat(admin): add route-driven audit detail panel (#679)"
+```
+
+---
+
+### Task 7: System audit view component
+
+**Files:**
+- Create: `src/app/pages/admin/audit/views/system-audit-view.component.{ts,html,scss}`
+- Test: `src/app/pages/admin/audit/views/system-audit-view.component.spec.ts`
+
+Composition + state owner for the system stream. Holds current `SystemAuditFilter`, current page request (cursor/around), `rows`, `total`, `next_cursor`, `prev_cursor`, `loading`, `error`, `anchorId`. Wires:
+- `<app-audit-filter-bar [stream]="'system'" (filterChange)=... (exportRequested)=...>`
+- `<app-audit-table [columns]=systemColumns [rows]=rows ... (older)=... (newer)=... (rowClick)=onRowClick($event)>`
+- `<router-outlet>` for the detail panel child route.
+
+Behavior:
+- **Load**: call `auditService.listSystem(filter, page)`; on success set rows/total/cursors; `markForCheck`.
+- **Filter change** → reset cursor/around (back to newest), reload, mirror filters into query params (`router.navigate([], { relativeTo, queryParams, queryParamsHandling: '', replaceUrl: true })`).
+- **Older** → `listSystem(filter, { limit, cursor: next_cursor })`. **Newer** → `{ cursor: prev_cursor }`.
+- **Around**: on init and on `around` query-param presence, call `listSystem(filter, { around })`, set `anchorId = around`.
+- **Row click** → `router.navigate([row.id], { relativeTo: route })` (opens detail in child outlet; table stays alive).
+- **Export** → `auditService.exportSystem(filter, format)` subscribe → `downloadBlob(blob, 'system-audit-<ISO>.<ext>')`; show snackbar on error.
+- Restore filters + around from query params on init (`route.queryParams`).
+- Column defs (`systemColumns: AuditColumnDef[]`): timestamp (`created_at`, formatted), actor (`actor.display_name` / `actor.email`), method+path (`http_method` + ` ` + `http_path`), field_path, change_summary.
+
+- [ ] **Step 1: Write tests:** (a) loads system entries on init and renders count; (b) filter change resets cursor and reloads + updates URL; (c) Older uses next_cursor, Newer uses prev_cursor; (d) around query param triggers around load and sets anchorId; (e) export calls service + downloadBlob (mock `blob-download.util`'s `downloadBlob`); (f) row click navigates to `[id]`. Mock `AdminAuditService`, `Router`, `ActivatedRoute`, `LoggerService`, `MatSnackBar`.
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement** (`.ts`, `.html`, `.scss`).
+
+- [ ] **Step 4: Run tests, expect PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/pages/admin/audit/views/system-audit-view.component.*
+git commit -m "feat(admin): add system audit view (#679)"
+```
+
+---
+
+### Task 8: Threat-model audit view component
+
+**Files:**
+- Create: `src/app/pages/admin/audit/views/tm-audit-view.component.{ts,html,scss}`
+- Test: `src/app/pages/admin/audit/views/tm-audit-view.component.spec.ts`
+
+Same structure as Task 7 but: `stream='tm'`, `auditService.listTm`/`getTmEntry`, `TmAuditFilter`, no export menu (filter bar hides it for non-system). Column defs (`tmColumns`): timestamp, actor, threat-model (`threat_model_id`), object type/id (`object_type` + `object_id`), change_type, change_summary. Same cursor/around/query-param/row-click behavior (minus export).
+
+- [ ] **Step 1: Write tests** mirroring Task 7's (a)–(d), (f) for the TM stream (no export test). 
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement.** To avoid duplication, factor shared list/cursor/around/query-param logic into a small base class or a reusable helper if it reads cleanly; otherwise accept the parallel structure (the two views differ in service calls, filter type, and columns). Prefer readability over premature abstraction (project guidance).
+
+- [ ] **Step 4: Run tests, expect PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/pages/admin/audit/views/tm-audit-view.component.*
+git commit -m "feat(admin): add threat-model audit view (#679)"
+```
+
+---
+
+### Task 9: Shell, routes, and admin section card
+
+**Files:**
+- Create: `src/app/pages/admin/audit/audit-logs-page.component.{ts,html,scss}`
+- Test: `src/app/pages/admin/audit/audit-logs-page.component.spec.ts`
+- Modify: `src/app/app.routes.ts`
+- Modify: `src/app/pages/admin/admin.component.ts`
+
+Shell: `mat-tab-nav-bar` with two links (`routerLink="system"`, `routerLink="threat-models"`, `routerLinkActive`) + `<router-outlet>`. Title "Audit Logs". Standalone, OnPush.
+
+Routes — add under the existing `/admin` `children` array in `app.routes.ts`:
+
+```typescript
+{
+  path: 'audit',
+  loadComponent: () =>
+    import(/* webpackChunkName: "admin-audit" */ './pages/admin/audit/audit-logs-page.component').then(
+      c => c.AuditLogsPageComponent,
+    ),
+  canActivate: [adminGuard],
+  children: [
+    { path: '', pathMatch: 'full', redirectTo: 'system' },
+    {
+      path: 'system',
+      loadComponent: () =>
+        import('./pages/admin/audit/views/system-audit-view.component').then(c => c.SystemAuditViewComponent),
+      children: [
+        {
+          path: ':entryId',
+          loadComponent: () =>
+            import('./pages/admin/audit/components/audit-detail-panel.component').then(
+              c => c.AuditDetailPanelComponent,
+            ),
+          data: { stream: 'system' },
+        },
+      ],
+    },
+    {
+      path: 'threat-models',
+      loadComponent: () =>
+        import('./pages/admin/audit/views/tm-audit-view.component').then(c => c.TmAuditViewComponent),
+      children: [
+        {
+          path: ':entryId',
+          loadComponent: () =>
+            import('./pages/admin/audit/components/audit-detail-panel.component').then(
+              c => c.AuditDetailPanelComponent,
+            ),
+          data: { stream: 'tm' },
+        },
+      ],
+    },
+  ],
+},
+```
+
+(Place `audit` BEFORE any catch-all; keep `canActivate: [adminGuard]` consistent with siblings. The parent `/admin` already has `canActivate: [authGuard]`.)
+
+Admin card — add to `adminSections` in `admin.component.ts`:
+
+```typescript
+{
+  title: 'admin.sections.audit.title',
+  description: 'admin.sections.audit.description',
+  icon: 'history',
+  action: 'audit',
+},
+```
+
+- [ ] **Step 1: Write a shell spec** verifying it renders the two tab links pointing to `system` and `threat-models`. Use `createComponentFixture` with router testing harness (provide `provideRouter([])` or mock `RouterLink`).
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement** shell component + add routes + admin card.
+
+- [ ] **Step 4: Verify** shell test passes AND the app builds the lazy chunks: `pnpm test -- src/app/pages/admin/audit/audit-logs-page.component.spec.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/pages/admin/audit/audit-logs-page.component.* src/app/app.routes.ts src/app/pages/admin/admin.component.ts
+git commit -m "feat(admin): wire audit-log shell, routes, and nav card (#679)"
+```
+
+---
+
+### Task 10: Cross-reference affordance on admin settings
+
+**Files:**
+- Modify: `src/app/pages/admin/settings/admin-settings.component.{ts,html}`
+
+Add a "view in audit log" action button on each settings row that mutates state. The button is a `mat-icon-button` (action-button convention: icon `history` or `fact_check` + `matTooltip` localized `admin.audit.viewInAuditLog`) with `[routerLink]="['/admin/audit/system']"` and `[queryParams]="{ field_path: <settingKey> }"`. The system view already restores `field_path` from query params (Task 7), so this pre-filters automatically.
+
+- [ ] **Step 1:** Read `admin-settings.component.html` to find the per-setting row template and the property holding the setting key/field path.
+
+- [ ] **Step 2:** Add the action button to each row, wired to the setting's key as `field_path`. Add the tooltip i18n key (added in Task 11).
+
+- [ ] **Step 3:** If `admin-settings.component.spec.ts` exists, add/adjust a test asserting the link + queryParams; otherwise add a minimal render assertion. Run it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/pages/admin/settings/admin-settings.component.*
+git commit -m "feat(admin): add 'view in audit log' affordance on settings rows (#679)"
+```
+
+---
+
+### Task 11: i18n — English strings + locale backfill
+
+**Files:**
+- Modify: `src/assets/i18n/en-US.json`
+- Modify: all other `src/assets/i18n/*.json` locale files (via backfill skill)
+
+- [ ] **Step 1:** Add all new keys to `en-US.json`. Required key groups (fill every key referenced in Tasks 4–10):
+  - `admin.sections.audit.title` = "Audit Logs", `admin.sections.audit.description` = "View system and threat-model audit logs."
+  - `admin.audit.title`, `admin.audit.tabs.system`, `admin.audit.tabs.threatModels`
+  - `admin.audit.columns.*`: timestamp, actor, request, fieldPath, changeSummary, threatModel, object, changeType, version
+  - `admin.audit.filters.*`: actor (label/placeholder), httpMethod, pathPrefix, fieldPath, changeType, objectType, threatModelId, createdAfter, createdBefore, clear; plus enum value labels for httpMethod/changeType/objectType
+  - `admin.audit.pagination.newer` = "Newer", `.older` = "Older"
+  - `admin.audit.export.menu`, `.csv`, `.ndjson`, `.error`
+  - `admin.audit.detail.*`: title, timestamp, actor, provider, providerId, method, path, fieldPath, oldValue, newValue, changeSummary, threatModel, objectType, objectId, changeType, version, copyPermalink, copied, viewInContext, close, notFound
+  - `admin.audit.empty` = "No entries match these filters.", `admin.audit.error` = "Audit query failed.", `admin.audit.retry` = "Retry"
+  - `admin.audit.viewInAuditLog` = "View in audit log"
+
+  Keep keys alphabetized within their object if the file is sorted (match existing convention). Reuse `common.*` keys (e.g. `common.close`, `common.clear`, `common.actions`) where they already exist instead of duplicating.
+
+- [ ] **Step 2:** Validate the English file parses and the i18n check passes: `pnpm run lint:all` (or the project's i18n check script) — fix any missing-key/usage errors.
+
+- [ ] **Step 3:** Backfill translations across all locales. Use the `localization-backfill` skill (it reads the project i18n config, translates every missing key from the master locale, preserving placeholders).
+
+- [ ] **Step 4:** Verify coverage with the `validate-localization-coverage` skill; address any gaps.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/assets/i18n/
+git commit -m "feat(i18n): add audit-log UI strings and backfill locales (#679)"
+```
+
+---
+
+### Task 12: Final verification & finish
+
+- [ ] **Step 1: Lint** — `pnpm run lint:all`; fix all issues.
+- [ ] **Step 2: Build** — `pnpm run build`; fix ALL build errors (pre-existing or new).
+- [ ] **Step 3: Test** — `pnpm test`; all green. Troubleshoot to root cause, never skip.
+- [ ] **Step 4: Code review** — run `superpowers:requesting-code-review` over the branch diff; address findings.
+- [ ] **Step 5: Manual smoke (optional if server reachable)** — log in as admin, open `/admin/audit/system`, exercise filter, Older/Newer, row→detail permalink, view-in-context (around), CSV + NDJSON export, then `/admin/audit/threat-models`. Confirm non-admin is redirected with `error=admin_required`.
+- [ ] **Step 6:** Push branch; open PR against `dev/1.4.0` referencing tmi-ux#679. Note in the PR that this implements the full contract (bidirectional cursors, around, export) now that tmi#464 has landed on the server. Do NOT close #679 until merged.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** system view ✓ (T7), TM view ✓ (T8), filters ✓ (T4), columns ✓ (T5/T7/T8), row detail + permalink ✓ (T6), export ✓ (T3/T7), bidirectional pagination ✓ (T5/T7/T8), around ✓ (T6/T7/T8), routes/nav/guard ✓ (T9), cross-reference affordance ✓ (T10), empty/error states ✓ (T5), i18n ✓ (T11), tests throughout. Step-up explicitly out of scope per decision.
+- **Type consistency:** `AuditListResponse<T>`, `SystemAuditFilter`/`TmAuditFilter`, `AuditPageRequest`, `AuditColumnDef`, `AuditStream`, `AuditExportFormat` defined in T1/T5 and reused verbatim in T3–T10. Service methods `listSystem/getSystemEntry/listTm/getTmEntry/exportSystem` named consistently across T3 and T6–T10.
+- **Contract drift handled:** response field is `entries` (not `items`); date params `created_after`/`created_before` (not `from`/`to`); `total`/`limit` present and ignored for display except optional count.
+- **Open detail:** the single `AuditDetailPanelComponent` branches on `route.data.stream`; system/TM field sets differ but share the shell. If the branch grows unwieldy during T6, splitting into two presentational sub-templates is acceptable.

--- a/scripts/i18n_style/lists.json
+++ b/scripts/i18n_style/lists.json
@@ -50,7 +50,9 @@
     "CI/CD",
     "JSONL",
     "US",
-    "TMs"
+    "TMs",
+    "CSV",
+    "NDJSON"
   ],
   "domain_nouns": [
     "threat model",

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -188,25 +188,25 @@ export const routes: Routes = [
       {
         path: 'audit',
         loadComponent: () =>
-          import('./pages/admin/audit/audit-logs-page.component').then(
-            c => c.AuditLogsPageComponent,
-          ),
+          import(
+            /* webpackChunkName: "admin-audit" */ './pages/admin/audit/audit-logs-page.component'
+          ).then(c => c.AuditLogsPageComponent),
         canActivate: [adminGuard],
         children: [
           { path: '', pathMatch: 'full', redirectTo: 'system' },
           {
             path: 'system',
             loadComponent: () =>
-              import('./pages/admin/audit/views/system-audit-view.component').then(
-                c => c.SystemAuditViewComponent,
-              ),
+              import(
+                /* webpackChunkName: "admin-audit-system" */ './pages/admin/audit/views/system-audit-view.component'
+              ).then(c => c.SystemAuditViewComponent),
             children: [
               {
                 path: ':entryId',
                 loadComponent: () =>
-                  import('./pages/admin/audit/components/audit-detail-panel.component').then(
-                    c => c.AuditDetailPanelComponent,
-                  ),
+                  import(
+                    /* webpackChunkName: "admin-audit-detail" */ './pages/admin/audit/components/audit-detail-panel.component'
+                  ).then(c => c.AuditDetailPanelComponent),
                 data: { stream: 'system' },
               },
             ],
@@ -214,16 +214,16 @@ export const routes: Routes = [
           {
             path: 'threat-models',
             loadComponent: () =>
-              import('./pages/admin/audit/views/tm-audit-view.component').then(
-                c => c.TmAuditViewComponent,
-              ),
+              import(
+                /* webpackChunkName: "admin-audit-tm" */ './pages/admin/audit/views/tm-audit-view.component'
+              ).then(c => c.TmAuditViewComponent),
             children: [
               {
                 path: ':entryId',
                 loadComponent: () =>
-                  import('./pages/admin/audit/components/audit-detail-panel.component').then(
-                    c => c.AuditDetailPanelComponent,
-                  ),
+                  import(
+                    /* webpackChunkName: "admin-audit-detail" */ './pages/admin/audit/components/audit-detail-panel.component'
+                  ).then(c => c.AuditDetailPanelComponent),
                 data: { stream: 'tm' },
               },
             ],

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -186,6 +186,51 @@ export const routes: Routes = [
         canActivate: [adminGuard],
       },
       {
+        path: 'audit',
+        loadComponent: () =>
+          import('./pages/admin/audit/audit-logs-page.component').then(
+            c => c.AuditLogsPageComponent,
+          ),
+        canActivate: [adminGuard],
+        children: [
+          { path: '', pathMatch: 'full', redirectTo: 'system' },
+          {
+            path: 'system',
+            loadComponent: () =>
+              import('./pages/admin/audit/views/system-audit-view.component').then(
+                c => c.SystemAuditViewComponent,
+              ),
+            children: [
+              {
+                path: ':entryId',
+                loadComponent: () =>
+                  import('./pages/admin/audit/components/audit-detail-panel.component').then(
+                    c => c.AuditDetailPanelComponent,
+                  ),
+                data: { stream: 'system' },
+              },
+            ],
+          },
+          {
+            path: 'threat-models',
+            loadComponent: () =>
+              import('./pages/admin/audit/views/tm-audit-view.component').then(
+                c => c.TmAuditViewComponent,
+              ),
+            children: [
+              {
+                path: ':entryId',
+                loadComponent: () =>
+                  import('./pages/admin/audit/components/audit-detail-panel.component').then(
+                    c => c.AuditDetailPanelComponent,
+                  ),
+                data: { stream: 'tm' },
+              },
+            ],
+          },
+        ],
+      },
+      {
         path: 'surveys/new',
         loadComponent: () =>
           import(

--- a/src/app/core/services/api.service.ts
+++ b/src/app/core/services/api.service.ts
@@ -114,6 +114,26 @@ export class ApiService {
   }
 
   /**
+   * GET request that returns a Blob (for streamed file exports).
+   * @param endpoint The API endpoint (without the base URL)
+   * @param params Optional query parameters
+   */
+  getBlob(
+    endpoint: string,
+    params?: Record<string, string | number | boolean | ReadonlyArray<string | number | boolean>>,
+  ): Observable<Blob> {
+    const url = this.buildUrl(endpoint);
+
+    return this.http.get(url, { params, responseType: 'blob' }).pipe(
+      retry({
+        count: 1,
+        delay: (error: HttpErrorResponse) => this.getRetryDelay(error),
+      }),
+      catchError((error: HttpErrorResponse) => this.handleError(error, 'GET', endpoint)),
+    );
+  }
+
+  /**
    * Generic POST request
    * @param endpoint The API endpoint (without the base URL)
    * @param body The request body

--- a/src/app/generated/api-types.d.ts
+++ b/src/app/generated/api-types.d.ts
@@ -3671,7 +3671,17 @@ export interface paths {
     put?: never;
     /**
      * Send a message to Timmy
-     * @description Sends a user message to the Timmy AI assistant and returns an SSE stream of the assistant response
+     * @description Sends a user message to the Timmy AI assistant and returns an SSE stream of the assistant response.
+     *
+     *     **SSE event types emitted by this endpoint:**
+     *
+     *     - `status` (zero or more) — Phase-transition events fired BEFORE `message_start` so clients can show "Timmy is …" affordances during the often-multi-second pre-token latency. Payload: `{"phase": "<snake_case>", "entity_type": "<optional>", "entity_name": "<optional>", "detail": "<optional>"}`. `phase` is a stable identifier the client can map to localized strings; the server is free to add or rename phases as the pipeline evolves, so unknown phases should be treated as opaque labels. Current phases include `building_context`, `loading_history`, `querying_embeddings`, `waiting_for_llm`. Once tokens begin streaming, no further `status` events are emitted.
+     *     - `message_start` (exactly one, after any `status` events) — Signals that the server is about to (or has just begun) streaming tokens. Payload: `{"status": "processing"}`.
+     *     - `token` (zero or more) — Individual tokens streamed from the LLM. Payload: token text.
+     *     - `message_end` (exactly one, terminal) — The full persisted assistant message. Payload: `TimmyChatMessage` object.
+     *     - `error` (terminal in the failure case) — Emitted instead of `message_end` if the request fails after the SSE stream has begun.
+     *
+     *     **Auto-generated session title.** After the first user message in a fresh session is processed successfully, the server may asynchronously generate a short title (≤ 60 characters) from that message and persist it to the session's `title` field. This only happens when the existing title is empty or matches the client's default placeholder (e.g. `Chat — <date>, <time>`); a user-set title is never overwritten. Title generation runs out-of-band and never blocks or fails the message response — clients see the new title on the next `getTimmyChatSession` / `listTimmyChatSessions` call.
      */
     post: operations['createTimmyChatMessage'];
     delete?: never;
@@ -4049,6 +4059,206 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/oauth2/step_up': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Initiate fresh-prompt step-up re-authentication
+     * @description Forces a fresh interactive re-authentication at the user's bound IdP by adding prompt=login&max_age=0 (OAuth/OIDC) or ForceAuthn=true (SAML) to the upstream authorize URL. For providers that do not honor those parameters (e.g., GitHub), the endpoint short-circuits and rotates tokens in-place with a 'strength: weak' audit marker. See #397 and docs/superpowers/specs/2026-05-10-oauth2-step-up-design.md.
+     */
+    get: operations['stepUpAuthenticate'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/admin/audit/system': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List system audit entries
+     * @description Cursor-paginated, filterable list of system-level admin-write audit records. Admin role required; read-only (no step-up).
+     */
+    get: operations['listSystemAuditEntries'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/admin/audit/system/{entry_id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get a system audit entry
+     * @description Returns a single system-level audit entry by ID. Admin role required.
+     */
+    get: operations['getSystemAuditEntry'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/admin/audit/threat_models': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List threat-model audit entries across all threat models
+     * @description Cursor-paginated cross-threat-model admin view of the threat-model audit stream. Admin role required; read-only (no step-up).
+     */
+    get: operations['listAdminThreatModelAuditEntries'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/admin/audit/threat_models/{entry_id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get a threat-model audit entry by id (admin)
+     * @description Returns a single threat-model audit entry by ID, admin cross-TM view. Admin role required.
+     */
+    get: operations['getAdminThreatModelAuditEntry'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/me/identities/link/start': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Start an identity link flow
+     * @description Initiates the OAuth flow to link an additional identity provider to the current user account. Returns a link state token and authorization URL. The user must be redirected to the authorization URL to complete provider authentication.
+     */
+    post: operations['startIdentityLink'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/me/identities/link/confirm': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Confirm and complete an identity link
+     * @description Consumes a pending identity link token and permanently links the second identity to the current user account. The token is one-time-use and expires after 5 minutes. Returns the newly created linked identity.
+     */
+    post: operations['confirmIdentityLink'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/me/identities': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List current user identities
+     * @description Returns the primary identity and all linked identities for the authenticated user.
+     */
+    get: operations['listMyIdentities'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/me/identities/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+     * Unlink a linked identity
+     * @description Removes a linked identity from the current user account. The primary identity cannot be removed. Service accounts are not permitted.
+     */
+    delete: operations['deleteMyIdentity'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/me/identities/link/pending/{link_id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get pending identity link details
+     * @description Returns the details of a pending identity link, including both sides of the link for user confirmation. The token must belong to the authenticated user.
+     */
+    get: operations['getPendingIdentityLink'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -4250,7 +4460,13 @@ export interface components {
      *       "content_source": "http"
      *     }
      */
-    Document: components['schemas']['DocumentBase'] & {
+    Document: {
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
+    } & (components['schemas']['DocumentBase'] & {
       /**
        * Format: uuid
        * @description Unique identifier for the document
@@ -4301,7 +4517,12 @@ export interface components {
        * @description Server-assigned monotonically-increasing integer alias, unique within the parent threat model. Immutable after creation.
        */
       readonly alias?: number;
-    };
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
+    });
     /**
      * @description Base diagram object with common properties - used for API responses
      * @example {
@@ -4456,7 +4677,13 @@ export interface components {
      *       "timmy_enabled": true
      *     }
      */
-    DfdDiagram: Omit<components['schemas']['BaseDiagram'], 'type'> & {
+    DfdDiagram: {
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
+    } & (Omit<components['schemas']['BaseDiagram'], 'type'> & {
       /**
        * @description DFD diagram type with version
        * @enum {string}
@@ -4464,6 +4691,11 @@ export interface components {
       type?: 'DFD-1.0.0';
       /** @description List of diagram cells (nodes and edges) following X6 structure */
       cells: (components['schemas']['Node'] | components['schemas']['Edge'])[];
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
     } & {
       /**
        * @description discriminator enum property added by openapi-typescript
@@ -4476,7 +4708,7 @@ export interface components {
        * @enum {string}
        */
       type: 'DFD-1.0.0';
-    };
+    });
     /**
      * @description Input schema for creating or updating a Data Flow Diagram
      * @example {
@@ -4541,7 +4773,13 @@ export interface components {
      *       "cells": []
      *     }
      */
-    Diagram: components['schemas']['DfdDiagram'];
+    Diagram: {
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
+    } & components['schemas']['DfdDiagram'];
     /**
      * @description Base schema for all diagram cells (nodes and edges). Contains common properties shared by Node and Edge types.
      * @example {
@@ -4714,7 +4952,13 @@ export interface components {
      *       "modified_at": "2026-01-15T10:30:00Z"
      *     }
      */
-    ThreatModel: components['schemas']['ThreatModelBase'] & {
+    ThreatModel: {
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
+    } & (components['schemas']['ThreatModelBase'] & {
       /**
        * Format: uuid
        * @description Unique identifier for the threat model (UUID)
@@ -4756,7 +5000,12 @@ export interface components {
        * @description Deletion timestamp (RFC3339). Present only on soft-deleted entities within the tombstone retention period.
        */
       readonly deleted_at?: string | null;
-    };
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
+    });
     /**
      * @description A security threat identified during threat modeling, with severity, status, and mitigation details
      * @example {
@@ -4787,7 +5036,13 @@ export interface components {
      *       }
      *     }
      */
-    Threat: components['schemas']['ThreatBase'] & {
+    Threat: {
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
+    } & (components['schemas']['ThreatBase'] & {
       /**
        * Format: uuid
        * @description Unique identifier for the threat (UUID)
@@ -4820,7 +5075,12 @@ export interface components {
        * @description Server-assigned monotonically-increasing integer alias, unique within the parent threat model. Immutable after creation.
        */
       readonly alias?: number;
-    };
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
+    });
     /**
      * @description Authorization record granting a user access to a resource with a specific role
      * @example {
@@ -5876,7 +6136,13 @@ export interface components {
      *       "modified_at": "2026-01-14T14:00:00Z"
      *     }
      */
-    Asset: components['schemas']['AssetBase'] & {
+    Asset: {
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
+    } & (components['schemas']['AssetBase'] & {
       /**
        * Format: uuid
        * @description Unique identifier for the asset
@@ -5904,7 +6170,12 @@ export interface components {
        * @description Server-assigned monotonically-increasing integer alias, unique within the parent threat model. Immutable after creation.
        */
       readonly alias?: number;
-    };
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
+    });
     /** @description Asset with extended metadata for detailed security analysis */
     ExtendedAsset: components['schemas']['Asset'] & {
       /**
@@ -6376,6 +6647,8 @@ export interface components {
         | 'document.created'
         | 'document.updated'
         | 'document.deleted'
+        | 'document.extraction_completed'
+        | 'document.extraction_failed'
         | 'note.created'
         | 'note.updated'
         | 'note.deleted'
@@ -6390,7 +6663,8 @@ export interface components {
         | 'threat.deleted'
         | 'metadata.created'
         | 'metadata.updated'
-        | 'metadata.deleted';
+        | 'metadata.deleted'
+        | 'system_audit.admin_write';
     };
     /**
      * @description Response from a webhook test including delivery status
@@ -7034,6 +7308,8 @@ export interface components {
       | 'document.created'
       | 'document.updated'
       | 'document.deleted'
+      | 'document.extraction_completed'
+      | 'document.extraction_failed'
       | 'note.created'
       | 'note.updated'
       | 'note.deleted'
@@ -7055,7 +7331,8 @@ export interface components {
       | 'survey.deleted'
       | 'survey_response.created'
       | 'survey_response.updated'
-      | 'survey_response.deleted';
+      | 'survey_response.deleted'
+      | 'system_audit.admin_write';
     /**
      * @description Member of a group with role information
      * @example {
@@ -7681,7 +7958,8 @@ export interface components {
      *       },
      *       "operator": {
      *         "name": "TMI Project",
-     *         "contact": "https://github.com/ericfitz/tmi"
+     *         "contact": "https://github.com/ericfitz/tmi",
+     *         "jurisdiction": "Florida, United States of America"
      *       },
      *       "limits": {
      *         "max_file_upload_mb": 10,
@@ -7722,6 +8000,8 @@ export interface components {
         name?: string;
         /** @description Contact information for the operator */
         contact?: string;
+        /** @description Legal jurisdiction under which the service operates */
+        jurisdiction?: string;
       };
       /** @description System limits and quotas */
       limits?: {
@@ -8375,7 +8655,13 @@ export interface components {
       is_confidential: boolean;
     };
     /** @description A survey response containing answers to survey questions */
-    SurveyResponse: components['schemas']['SurveyResponseBase'] & {
+    SurveyResponse: {
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
+    } & (components['schemas']['SurveyResponseBase'] & {
       /**
        * Format: uuid
        * @description Unique identifier for the response (UUID)
@@ -8424,7 +8710,12 @@ export interface components {
       metadata?: components['schemas']['Metadata'][] | null;
       /** @description User who created the response */
       readonly created_by?: components['schemas']['User'] | null;
-    };
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
+    });
     /**
      * @description Summary of a survey response for list endpoints
      * @example {
@@ -9030,7 +9321,13 @@ export interface components {
       status?: (string & components['schemas']['TeamStatus']) | null;
     };
     /** @description A team representing an organizational unit */
-    Team: components['schemas']['TeamBase'] & {
+    Team: {
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
+    } & (components['schemas']['TeamBase'] & {
       /**
        * Format: uuid
        * @description Unique identifier for the team (UUID)
@@ -9061,7 +9358,12 @@ export interface components {
       metadata?: components['schemas']['Metadata'][] | null;
       /** @description List of notes associated with the team */
       readonly notes?: components['schemas']['TeamNoteListItem'][];
-    };
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
+    });
     /** @description Summary of a team for list views */
     TeamListItem: {
       /** Format: uuid */
@@ -9157,7 +9459,13 @@ export interface components {
       status?: (string & components['schemas']['ProjectStatus']) | null;
     };
     /** @description A project representing a product, service, or application */
-    Project: components['schemas']['ProjectBase'] & {
+    Project: {
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
+    } & (components['schemas']['ProjectBase'] & {
       /**
        * Format: uuid
        * @description Unique identifier for the project (UUID)
@@ -9190,7 +9498,12 @@ export interface components {
       metadata?: components['schemas']['Metadata'][] | null;
       /** @description List of notes associated with the project */
       readonly notes?: components['schemas']['ProjectNoteListItem'][];
-    };
+      /**
+       * Format: int32
+       * @description Server-managed monotonically-increasing optimistic-locking version. Returned on reads and bumped by every successful PUT/PATCH. Clients echo this back via the If-Match request header (preferred) or the body 'version' field on the next mutation. A mismatch returns 409 Conflict. See issue #385.
+       */
+      readonly version?: number;
+    });
     /** @description Summary of a project for list views */
     ProjectListItem: {
       /** Format: uuid */
@@ -10440,6 +10753,8 @@ export interface components {
         | 'needs_tuning';
       client_id: string;
       client_version?: string;
+      /** @description Optional viewport screenshot captured by the client at submission time. Data URL form (e.g. `data:image/jpeg;base64,...`). Used as support context. */
+      screenshot?: string;
     };
     ContentFeedback: components['schemas']['ContentFeedbackInput'] & {
       /** Format: uuid */
@@ -10475,6 +10790,8 @@ export interface components {
       };
       /** @description Viewport dimensions, e.g. '1280x1024' */
       viewport?: string;
+      /** @description Optional viewport screenshot captured by the client at submission time. Data URL form (e.g. `data:image/jpeg;base64,...`). Used as support context. */
+      screenshot?: string;
     };
     UsabilityFeedback: components['schemas']['UsabilityFeedbackInput'] & {
       /**
@@ -10519,6 +10836,128 @@ export interface components {
       picker_config?: {
         [key: string]: string;
       };
+    };
+    /** @description An immutable system-level audit record of a successful /admin/* write (T7 evidence). Old/new values are redacted at write time. */
+    SystemAuditEntry: {
+      /**
+       * Format: uuid
+       * @description Entry identifier.
+       */
+      id: string;
+      actor: components['schemas']['AuditActor'];
+      /** @description HTTP method of the audited request. */
+      http_method: string;
+      /** @description Request path of the audited request. */
+      http_path: string;
+      /** @description Dotted path of the changed field. */
+      field_path: string;
+      /** @description Previous value, redacted at write time. */
+      old_value_redacted?: string | null;
+      /** @description New value, redacted at write time. */
+      new_value_redacted?: string | null;
+      /** @description Human-readable change summary. */
+      change_summary?: string | null;
+      /**
+       * Format: date-time
+       * @description When the audited write completed.
+       */
+      created_at: string;
+    };
+    /** @description Cursor-paginated list of system audit entries. */
+    ListSystemAuditEntriesResponse: {
+      entries: components['schemas']['SystemAuditEntry'][];
+      /** @description Total entries matching the filter. */
+      total: number;
+      /** @description Page size used. */
+      limit: number;
+      /** @description Cursor for the next page; absent or null when exhausted. */
+      next_cursor?: string | null;
+      /** @description Cursor for the previous (newer) page; absent or null when at the newest end. */
+      prev_cursor?: string | null;
+    };
+    /** @description Cursor-paginated cross-threat-model list of audit entries. */
+    ListAdminAuditEntriesResponse: {
+      entries: components['schemas']['AuditEntry'][];
+      /** @description Total entries matching the filter. */
+      total: number;
+      /** @description Page size used. */
+      limit: number;
+      /** @description Cursor for the next page; absent or null when exhausted. */
+      next_cursor?: string | null;
+      /** @description Cursor for the previous (newer) page; absent or null when at the newest end. */
+      prev_cursor?: string | null;
+    };
+    LinkedIdentity: {
+      /**
+       * Format: uuid
+       * @description Linked identity unique identifier
+       */
+      id: string;
+      /** @description Identity provider ID */
+      provider: string;
+      /** @description User identifier at the provider (truncated for display) */
+      provider_user_id: string;
+      /**
+       * Format: email
+       * @description Cached email address from provider (display only)
+       */
+      email?: string;
+      /** @description Cached display name from provider */
+      name?: string;
+      /**
+       * Format: date-time
+       * @description When this identity was linked
+       */
+      linked_at: string;
+      /**
+       * Format: date-time
+       * @description When this identity was last used to sign in
+       */
+      last_used_at?: string | null;
+    };
+    IdentityLinkStartResponse: {
+      /** @description Opaque state identifier for the link flow */
+      link_state: string;
+      /**
+       * Format: uri
+       * @description URL to redirect the user to for identity provider authorization (prompt=select_account)
+       */
+      authorization_url: string;
+      /**
+       * Format: date-time
+       * @description When the link state expires (10 minutes from creation)
+       */
+      expires_at: string;
+    };
+    PendingIdentityLinkResponse: {
+      pending: {
+        /** @description Identity provider of the second identity */
+        provider: string;
+        /** @description User identifier at the provider (first 8 chars + ellipsis) */
+        provider_user_id: string;
+        /** @description Cached email from the second identity (display only) */
+        email?: string;
+        /** @description Cached display name from the second identity */
+        name?: string;
+      };
+      account: {
+        /** @description Primary identity provider of this TMI account */
+        provider: string;
+        /** @description Email address of this TMI account */
+        email: string;
+      };
+    };
+    MyIdentitiesResponse: {
+      primary: {
+        /** @description Primary identity provider ID */
+        provider: string;
+        /** @description Primary account email address */
+        email: string;
+        /** @description Primary account display name */
+        name?: string;
+      };
+      /** @description Additional linked identities */
+      linked?: components['schemas']['LinkedIdentity'][];
     };
   };
   responses: {
@@ -10736,6 +11175,47 @@ export interface components {
         'application/json': components['schemas']['Error'];
       };
     };
+    /** @description Conflict — the supplied version does not match the resource's current version. Refetch and retry. */
+    Conflict: {
+      headers: {
+        /** @description Maximum number of requests allowed in the current time window */
+        'X-RateLimit-Limit'?: number;
+        /** @description Number of requests remaining in the current time window */
+        'X-RateLimit-Remaining'?: number;
+        /** @description Unix epoch seconds when the rate limit window resets */
+        'X-RateLimit-Reset'?: number;
+        [name: string]: unknown;
+      };
+      content: {
+        'application/json': components['schemas']['Error'];
+      };
+    };
+    /** @description Precondition Required — the request did not include an If-Match header. This response is returned only when the server has flipped the RequireIfMatch config flag (planned for a future release). */
+    PreconditionRequired: {
+      headers: {
+        /** @description Maximum number of requests allowed in the current time window */
+        'X-RateLimit-Limit'?: number;
+        /** @description Number of requests remaining in the current time window */
+        'X-RateLimit-Remaining'?: number;
+        /** @description Unix epoch seconds when the rate limit window resets */
+        'X-RateLimit-Reset'?: number;
+        [name: string]: unknown;
+      };
+      content: {
+        'application/json': components['schemas']['Error'];
+      };
+    };
+    /** @description Recent re-authentication required for this admin operation. Per draft-ietf-oauth-step-up-authn-challenge: the client must re-authenticate the user (via the standard OAuth flow at /oauth2/authorize) and retry the request with a fresh JWT. */
+    StepUpRequired: {
+      headers: {
+        /** @description Bearer challenge with insufficient_user_authentication error and max_age (seconds) indicating the step-up window. Example: Bearer error="insufficient_user_authentication", error_description="re-authentication required", max_age=300 */
+        'WWW-Authenticate'?: string;
+        [name: string]: unknown;
+      };
+      content: {
+        'application/json': components['schemas']['Error'];
+      };
+    };
   };
   parameters: {
     /** @description Threat model identifier */
@@ -10874,9 +11354,9 @@ export interface components {
     UserIdPathParam: string;
     /** @description Filter by email (case-insensitive substring match) */
     EmailQueryParam: string;
-    /** @description Filter users created after this timestamp (RFC3339) */
+    /** @description Return only records created after this RFC 3339 timestamp. */
     CreatedAfterQueryParam: string;
-    /** @description Filter users created before this timestamp (RFC3339) */
+    /** @description Return only records created before this RFC 3339 timestamp. */
     CreatedBeforeQueryParam: string;
     /** @description Filter users who logged in after this timestamp (RFC3339) */
     LastLoginAfterQueryParam: string;
@@ -10949,6 +11429,26 @@ export interface components {
     SecurityReviewerQueryParam: string;
     /** @description Chat session identifier */
     SessionId: string;
+    /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+    IfMatchHeader: number;
+    /** @description Maximum number of entries to return per page. */
+    AuditPageLimit: number;
+    /** @description Opaque pagination cursor from the previous page next_cursor. Omit for the first page. */
+    AuditCursor: string;
+    /** @description Filter by the actor identity provider. */
+    AuditActorProvider: string;
+    /** @description Filter system audit entries by HTTP method. */
+    AuditHTTPMethod: 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+    /** @description Filter system audit entries whose request path starts with this prefix (matched literally). */
+    AuditPathPrefix: string;
+    /** @description Filter system audit entries by exact field path. */
+    AuditFieldPath: string;
+    /** @description Filter audit entries to a single threat model. */
+    AuditThreatModelId: string;
+    /** @description Return a page centered on this entry id (~half newer, ~half older, entry included). Mutually exclusive with cursor. */
+    AuditAround: string;
+    /** @description When set, stream the entire filtered set as an attachment instead of a JSON page. Honors all active filters; ignores cursor/limit/around. */
+    AuditExportFormat: 'csv' | 'ndjson';
   };
   requestBodies: never;
   headers: never;
@@ -12366,6 +12866,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -12468,7 +12970,10 @@ export interface operations {
   updateThreatModel: {
     parameters: {
       query?: never;
-      header?: never;
+      header?: {
+        /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+        'If-Match'?: components['parameters']['IfMatchHeader'];
+      };
       path: {
         /** @description Threat model identifier */
         threat_model_id: components['parameters']['ThreatModelId'];
@@ -12491,6 +12996,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -12558,6 +13065,8 @@ export interface operations {
       401: components['responses']['Error'];
       403: components['responses']['Error'];
       404: components['responses']['Error'];
+      409: components['responses']['Conflict'];
+      428: components['responses']['PreconditionRequired'];
       429: components['responses']['TooManyRequests'];
       500: components['responses']['Error'];
     };
@@ -12627,7 +13136,10 @@ export interface operations {
   patchThreatModel: {
     parameters: {
       query?: never;
-      header?: never;
+      header?: {
+        /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+        'If-Match'?: components['parameters']['IfMatchHeader'];
+      };
       path: {
         /** @description Threat model identifier */
         threat_model_id: components['parameters']['ThreatModelId'];
@@ -12664,6 +13176,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -12731,6 +13245,8 @@ export interface operations {
       401: components['responses']['Error'];
       403: components['responses']['Error'];
       404: components['responses']['Error'];
+      409: components['responses']['Conflict'];
+      428: components['responses']['PreconditionRequired'];
       429: components['responses']['TooManyRequests'];
       500: components['responses']['Error'];
     };
@@ -12924,6 +13440,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -12955,7 +13473,10 @@ export interface operations {
   updateThreatModelThreat: {
     parameters: {
       query?: never;
-      header?: never;
+      header?: {
+        /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+        'If-Match'?: components['parameters']['IfMatchHeader'];
+      };
       path: {
         /** @description Threat model identifier */
         threat_model_id: components['parameters']['ThreatModelId'];
@@ -12980,6 +13501,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -13004,6 +13527,8 @@ export interface operations {
       401: components['responses']['Error'];
       403: components['responses']['Error'];
       404: components['responses']['Error'];
+      409: components['responses']['Conflict'];
+      428: components['responses']['PreconditionRequired'];
       429: components['responses']['TooManyRequests'];
       500: components['responses']['Error'];
     };
@@ -13060,7 +13585,10 @@ export interface operations {
   patchThreatModelThreat: {
     parameters: {
       query?: never;
-      header?: never;
+      header?: {
+        /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+        'If-Match'?: components['parameters']['IfMatchHeader'];
+      };
       path: {
         /** @description Threat model identifier */
         threat_model_id: components['parameters']['ThreatModelId'];
@@ -13085,6 +13613,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -13109,6 +13639,8 @@ export interface operations {
       401: components['responses']['Error'];
       403: components['responses']['Error'];
       404: components['responses']['Error'];
+      409: components['responses']['Conflict'];
+      428: components['responses']['PreconditionRequired'];
       429: components['responses']['TooManyRequests'];
       500: components['responses']['Error'];
     };
@@ -13906,6 +14438,28 @@ export interface operations {
           'application/json': components['schemas']['Document'];
         };
       };
+      /** @description Document created and queued for asynchronous content extraction. Returned instead of 201 when async extraction is enabled (extraction.async_enabled) and the document URI is extractable. The extraction outcome is delivered later via the document access_status and the document.extraction_completed / document.extraction_failed webhook events. */
+      202: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            document: components['schemas']['Document'];
+            /**
+             * Format: uuid
+             * @description Identifier of the queued extraction job, for client correlation. The extraction result is surfaced via the document access_status and the document.extraction_* webhook events; there is no dedicated job-status endpoint.
+             */
+            job_id: string;
+          };
+        };
+      };
       /** @description Bad Request - Invalid parameters, malformed UUIDs, or validation failures */
       400: {
         headers: {
@@ -13951,6 +14505,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -13982,7 +14538,10 @@ export interface operations {
   updateThreatModelDocument: {
     parameters: {
       query?: never;
-      header?: never;
+      header?: {
+        /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+        'If-Match'?: components['parameters']['IfMatchHeader'];
+      };
       path: {
         /** @description Threat model identifier */
         threat_model_id: components['parameters']['ThreatModelId'];
@@ -14007,6 +14566,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -14031,6 +14592,8 @@ export interface operations {
       401: components['responses']['Error'];
       403: components['responses']['Error'];
       404: components['responses']['Error'];
+      409: components['responses']['Conflict'];
+      428: components['responses']['PreconditionRequired'];
       429: components['responses']['TooManyRequests'];
       500: components['responses']['Error'];
     };
@@ -14087,7 +14650,10 @@ export interface operations {
   patchThreatModelDocument: {
     parameters: {
       query?: never;
-      header?: never;
+      header?: {
+        /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+        'If-Match'?: components['parameters']['IfMatchHeader'];
+      };
       path: {
         /** @description Threat model identifier */
         threat_model_id: components['parameters']['ThreatModelId'];
@@ -14126,6 +14692,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -14150,6 +14718,8 @@ export interface operations {
       401: components['responses']['Error'];
       403: components['responses']['Error'];
       404: components['responses']['Error'];
+      409: components['responses']['Conflict'];
+      428: components['responses']['PreconditionRequired'];
       429: components['responses']['TooManyRequests'];
       500: components['responses']['InternalServerError'];
     };
@@ -16275,6 +16845,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -16306,7 +16878,10 @@ export interface operations {
   updateThreatModelDiagram: {
     parameters: {
       query?: never;
-      header?: never;
+      header?: {
+        /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+        'If-Match'?: components['parameters']['IfMatchHeader'];
+      };
       path: {
         /** @description Threat model identifier */
         threat_model_id: components['parameters']['ThreatModelId'];
@@ -16331,6 +16906,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -16370,6 +16947,7 @@ export interface operations {
           'application/json': components['schemas']['Error'];
         };
       };
+      428: components['responses']['PreconditionRequired'];
       429: components['responses']['TooManyRequests'];
       500: components['responses']['Error'];
     };
@@ -16441,7 +17019,10 @@ export interface operations {
   patchThreatModelDiagram: {
     parameters: {
       query?: never;
-      header?: never;
+      header?: {
+        /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+        'If-Match'?: components['parameters']['IfMatchHeader'];
+      };
       path: {
         /** @description Threat model identifier */
         threat_model_id: components['parameters']['ThreatModelId'];
@@ -16466,6 +17047,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -16506,6 +17089,7 @@ export interface operations {
         };
       };
       422: components['responses']['Error'];
+      428: components['responses']['PreconditionRequired'];
       429: components['responses']['TooManyRequests'];
       500: components['responses']['Error'];
     };
@@ -18466,6 +19050,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -18507,7 +19093,10 @@ export interface operations {
   updateThreatModelAsset: {
     parameters: {
       query?: never;
-      header?: never;
+      header?: {
+        /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+        'If-Match'?: components['parameters']['IfMatchHeader'];
+      };
       path: {
         /** @description Threat model identifier */
         threat_model_id: components['parameters']['ThreatModelId'];
@@ -18532,6 +19121,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -18566,6 +19157,8 @@ export interface operations {
       401: components['responses']['Error'];
       403: components['responses']['Error'];
       404: components['responses']['Error'];
+      409: components['responses']['Conflict'];
+      428: components['responses']['PreconditionRequired'];
       429: components['responses']['TooManyRequests'];
       500: components['responses']['Error'];
     };
@@ -18622,7 +19215,10 @@ export interface operations {
   patchThreatModelAsset: {
     parameters: {
       query?: never;
-      header?: never;
+      header?: {
+        /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+        'If-Match'?: components['parameters']['IfMatchHeader'];
+      };
       path: {
         /** @description Threat model identifier */
         threat_model_id: components['parameters']['ThreatModelId'];
@@ -18661,6 +19257,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -18695,6 +19293,8 @@ export interface operations {
       401: components['responses']['Error'];
       403: components['responses']['Error'];
       404: components['responses']['Error'];
+      409: components['responses']['Conflict'];
+      428: components['responses']['PreconditionRequired'];
       429: components['responses']['TooManyRequests'];
       500: components['responses']['InternalServerError'];
     };
@@ -20723,9 +21323,9 @@ export interface operations {
         email?: components['parameters']['EmailQueryParam'];
         /** @description Filter by name (case-insensitive substring match) */
         name?: components['parameters']['NameQueryParam'];
-        /** @description Filter users created after this timestamp (RFC3339) */
+        /** @description Return only records created after this RFC 3339 timestamp. */
         created_after?: components['parameters']['CreatedAfterQueryParam'];
-        /** @description Filter users created before this timestamp (RFC3339) */
+        /** @description Return only records created before this RFC 3339 timestamp. */
         created_before?: components['parameters']['CreatedBeforeQueryParam'];
         /** @description Filter users who logged in after this timestamp (RFC3339) */
         last_login_after?: components['parameters']['LastLoginAfterQueryParam'];
@@ -25244,6 +25844,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -25314,7 +25916,10 @@ export interface operations {
   updateIntakeSurveyResponse: {
     parameters: {
       query?: never;
-      header?: never;
+      header?: {
+        /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+        'If-Match'?: components['parameters']['IfMatchHeader'];
+      };
       path: {
         /** @description Unique identifier of the survey response */
         survey_response_id: components['parameters']['SurveyResponseId'];
@@ -25337,6 +25942,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -25415,6 +26022,7 @@ export interface operations {
           'application/json': components['schemas']['Error'];
         };
       };
+      428: components['responses']['PreconditionRequired'];
       429: components['responses']['TooManyRequests'];
       500: components['responses']['Error'];
     };
@@ -25469,7 +26077,10 @@ export interface operations {
   patchIntakeSurveyResponse: {
     parameters: {
       query?: never;
-      header?: never;
+      header?: {
+        /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+        'If-Match'?: components['parameters']['IfMatchHeader'];
+      };
       path: {
         /** @description Unique identifier of the survey response */
         survey_response_id: components['parameters']['SurveyResponseId'];
@@ -25506,6 +26117,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -25605,6 +26218,7 @@ export interface operations {
           'application/json': components['schemas']['Error'];
         };
       };
+      428: components['responses']['PreconditionRequired'];
       429: components['responses']['TooManyRequests'];
       500: components['responses']['Error'];
     };
@@ -27903,6 +28517,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -27986,7 +28602,10 @@ export interface operations {
   updateTeam: {
     parameters: {
       query?: never;
-      header?: never;
+      header?: {
+        /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+        'If-Match'?: components['parameters']['IfMatchHeader'];
+      };
       path: {
         /** @description Team UUID */
         team_id: string;
@@ -28015,6 +28634,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -28106,6 +28727,7 @@ export interface operations {
           'application/json': components['schemas']['Error'];
         };
       };
+      428: components['responses']['PreconditionRequired'];
       429: components['responses']['TooManyRequests'];
       500: components['responses']['Error'];
     };
@@ -28217,7 +28839,10 @@ export interface operations {
   patchTeam: {
     parameters: {
       query?: never;
-      header?: never;
+      header?: {
+        /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+        'If-Match'?: components['parameters']['IfMatchHeader'];
+      };
       path: {
         /** @description Team UUID */
         team_id: string;
@@ -28249,6 +28874,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -28340,6 +28967,7 @@ export interface operations {
           'application/json': components['schemas']['Error'];
         };
       };
+      428: components['responses']['PreconditionRequired'];
       429: components['responses']['TooManyRequests'];
       500: components['responses']['Error'];
     };
@@ -29158,6 +29786,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -29242,7 +29872,10 @@ export interface operations {
   updateProject: {
     parameters: {
       query?: never;
-      header?: never;
+      header?: {
+        /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+        'If-Match'?: components['parameters']['IfMatchHeader'];
+      };
       path: {
         /** @description Project UUID */
         project_id: string;
@@ -29272,6 +29905,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -29364,6 +29999,7 @@ export interface operations {
           'application/json': components['schemas']['Error'];
         };
       };
+      428: components['responses']['PreconditionRequired'];
       429: components['responses']['TooManyRequests'];
       500: components['responses']['Error'];
     };
@@ -29475,7 +30111,10 @@ export interface operations {
   patchProject: {
     parameters: {
       query?: never;
-      header?: never;
+      header?: {
+        /** @description Optimistic-locking precondition. Pass the integer version returned by the previous read (or as the body 'version' field on the previous write). On version mismatch the server returns 409 Conflict. In a future release this header will be required and missing values will return 428 Precondition Required. */
+        'If-Match'?: components['parameters']['IfMatchHeader'];
+      };
       path: {
         /** @description Project UUID */
         project_id: string;
@@ -29507,6 +30146,8 @@ export interface operations {
           'X-RateLimit-Remaining'?: number;
           /** @description Unix epoch seconds when the rate limit window resets */
           'X-RateLimit-Reset'?: number;
+          /** @description Current optimistic-locking version of the resource (RFC 7232). Echo this value back via If-Match on the next PUT/PATCH. */
+          ETag?: string;
           [name: string]: unknown;
         };
         content: {
@@ -29599,6 +30240,7 @@ export interface operations {
           'application/json': components['schemas']['Error'];
         };
       };
+      428: components['responses']['PreconditionRequired'];
       429: components['responses']['TooManyRequests'];
       500: components['responses']['Error'];
     };
@@ -34807,6 +35449,1205 @@ export interface operations {
       401: components['responses']['Unauthorized'];
       403: components['responses']['Forbidden'];
       404: components['responses']['NotFound'];
+    };
+  };
+  stepUpAuthenticate: {
+    parameters: {
+      query: {
+        /** @description Client callback URL where TMI should redirect after successful OAuth completion with tokens in URL fragment (#access_token=...). If not provided, tokens are returned as JSON response. Per OAuth 2.0 implicit flow spec, tokens are in fragments to prevent logging. */
+        client_callback?: components['parameters']['ClientCallbackQueryParam'];
+        /** @description CSRF protection state parameter. Recommended for security. Will be included in the callback response. */
+        state?: components['parameters']['StateQueryParam'];
+        /** @description PKCE code challenge (RFC 7636) - Base64url-encoded SHA256 hash of the code_verifier. Must be 43-128 characters using unreserved characters [A-Za-z0-9-._~]. The server associates this with the authorization code for later verification during token exchange. */
+        code_challenge: components['parameters']['CodeChallengeQueryParam'];
+        /** @description PKCE code challenge method (RFC 7636) - Specifies the transformation applied to the code_verifier. Only "S256" (SHA256) is supported for security. The "plain" method is not supported. */
+        code_challenge_method: components['parameters']['CodeChallengeMethodQueryParam'];
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Weak-provider short-circuit: tokens rotated in-place. Set-Cookie headers carry new HttpOnly access and refresh tokens. Returned only when the JWT-bound provider is classified as 'weak' (e.g., github). */
+      200: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+           * @example {
+           *       "result": "step_up_weak_complete",
+           *       "provider": "github",
+           *       "auth_time": 1715357321,
+           *       "message": "Provider does not support guaranteed fresh re-auth; tokens rotated and step-up window reset. Audit log records this as a weak step-up."
+           *     }
+           */
+          'application/json': {
+            /** @enum {string} */
+            result: 'step_up_weak_complete';
+            provider: string;
+            /** Format: int64 */
+            auth_time: number;
+            message: string;
+          };
+        };
+      };
+      /** @description Strong-provider path: redirect to upstream IdP with prompt=login&max_age=0 (OAuth/OIDC) or ForceAuthn=true (SAML). */
+      302: {
+        headers: {
+          /** @description Upstream IdP authorization URL with fresh-prompt parameters appended. */
+          Location?: string;
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation or pre-flight rejection (RFC 6749 §4.1.2.1-aligned error codes). */
+      400: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description JWT cookie/header missing, invalid, or expired. */
+      401: {
+        headers: {
+          /** @description Bearer error="invalid_token" */
+          'WWW-Authenticate'?: string;
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+           * @example {
+           *       "error": "invalid_token",
+           *       "error_description": "Missing or invalid access token"
+           *     }
+           */
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Reserved for future per-grant restrictions (unauthorized_client). */
+      403: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+           * @example {
+           *       "error": "unauthorized_client",
+           *       "error_description": "Step-up is not permitted for this grant"
+           *     }
+           */
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      429: components['responses']['TooManyRequests'];
+      /** @description Internal server error. */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+           * @example {
+           *       "error": "server_error",
+           *       "error_description": "Internal failure during step-up processing"
+           *     }
+           */
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Redis or downstream store temporarily unavailable. */
+      503: {
+        headers: {
+          /** @description Seconds to wait before retry */
+          'Retry-After'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+           * @example {
+           *       "error": "temporarily_unavailable",
+           *       "error_description": "State storage temporarily unavailable"
+           *     }
+           */
+          'application/json': components['schemas']['Error'];
+        };
+      };
+    };
+  };
+  listSystemAuditEntries: {
+    parameters: {
+      query?: {
+        /** @description Filter by actor email */
+        actor_email?: components['parameters']['AuditActorEmail'];
+        /** @description Filter by the actor identity provider. */
+        actor_provider?: components['parameters']['AuditActorProvider'];
+        /** @description Return only records created after this RFC 3339 timestamp. */
+        created_after?: components['parameters']['CreatedAfterQueryParam'];
+        /** @description Return only records created before this RFC 3339 timestamp. */
+        created_before?: components['parameters']['CreatedBeforeQueryParam'];
+        /** @description Filter system audit entries by HTTP method. */
+        http_method?: components['parameters']['AuditHTTPMethod'];
+        /** @description Filter system audit entries whose request path starts with this prefix (matched literally). */
+        path_prefix?: components['parameters']['AuditPathPrefix'];
+        /** @description Filter system audit entries by exact field path. */
+        field_path?: components['parameters']['AuditFieldPath'];
+        /** @description Maximum number of entries to return per page. */
+        limit?: components['parameters']['AuditPageLimit'];
+        /** @description Opaque pagination cursor from the previous page next_cursor. Omit for the first page. */
+        cursor?: components['parameters']['AuditCursor'];
+        /** @description Return a page centered on this entry id (~half newer, ~half older, entry included). Mutually exclusive with cursor. */
+        around?: components['parameters']['AuditAround'];
+        /** @description When set, stream the entire filtered set as an attachment instead of a JSON page. Honors all active filters; ignores cursor/limit/around. */
+        format?: components['parameters']['AuditExportFormat'];
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Paginated system audit entries */
+      200: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          /** @description Set to attachment with a filename when format=csv|ndjson. */
+          'Content-Disposition'?: string;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ListSystemAuditEntriesResponse'];
+          'text/csv': string;
+          'application/x-ndjson': string;
+        };
+      };
+      /** @description Bad Request - Invalid parameters, malformed UUIDs, or validation failures */
+      400: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Unauthorized - Invalid or missing authentication token */
+      401: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Forbidden - Insufficient permissions to access this resource */
+      403: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Not Found - the around entry id does not exist */
+      404: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Too many requests - rate limit exceeded */
+      429: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          /** @description Seconds until rate limit resets */
+          'Retry-After'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /**
+             * @description Error message
+             * @example rate_limit_exceeded
+             */
+            error: string;
+            /**
+             * @description Seconds until rate limit resets
+             * @example 60
+             */
+            retry_after?: number;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+    };
+  };
+  getSystemAuditEntry: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The system audit entry ID. */
+        entry_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description System audit entry */
+      200: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SystemAuditEntry'];
+        };
+      };
+      /** @description Bad Request - Invalid parameters, malformed UUIDs, or validation failures */
+      400: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Unauthorized - Invalid or missing authentication token */
+      401: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Forbidden - Insufficient permissions to access this resource */
+      403: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description System audit entry not found */
+      404: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Too many requests - rate limit exceeded */
+      429: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          /** @description Seconds until rate limit resets */
+          'Retry-After'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /**
+             * @description Error message
+             * @example rate_limit_exceeded
+             */
+            error: string;
+            /**
+             * @description Seconds until rate limit resets
+             * @example 60
+             */
+            retry_after?: number;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+    };
+  };
+  listAdminThreatModelAuditEntries: {
+    parameters: {
+      query?: {
+        /** @description Filter by actor email */
+        actor_email?: components['parameters']['AuditActorEmail'];
+        /** @description Filter by the actor identity provider. */
+        actor_provider?: components['parameters']['AuditActorProvider'];
+        /** @description Return only records created after this RFC 3339 timestamp. */
+        created_after?: components['parameters']['CreatedAfterQueryParam'];
+        /** @description Return only records created before this RFC 3339 timestamp. */
+        created_before?: components['parameters']['CreatedBeforeQueryParam'];
+        /** @description Filter by change type */
+        change_type?: components['parameters']['AuditChangeType'];
+        /** @description Filter by object type */
+        object_type?: components['parameters']['AuditObjectType'];
+        /** @description Filter audit entries to a single threat model. */
+        threat_model_id?: components['parameters']['AuditThreatModelId'];
+        /** @description Maximum number of entries to return per page. */
+        limit?: components['parameters']['AuditPageLimit'];
+        /** @description Opaque pagination cursor from the previous page next_cursor. Omit for the first page. */
+        cursor?: components['parameters']['AuditCursor'];
+        /** @description Return a page centered on this entry id (~half newer, ~half older, entry included). Mutually exclusive with cursor. */
+        around?: components['parameters']['AuditAround'];
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Paginated audit entries */
+      200: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ListAdminAuditEntriesResponse'];
+        };
+      };
+      /** @description Bad Request - Invalid parameters, malformed UUIDs, or validation failures */
+      400: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Unauthorized - Invalid or missing authentication token */
+      401: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Forbidden - Insufficient permissions to access this resource */
+      403: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Not Found - the around entry id does not exist */
+      404: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Too many requests - rate limit exceeded */
+      429: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          /** @description Seconds until rate limit resets */
+          'Retry-After'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /**
+             * @description Error message
+             * @example rate_limit_exceeded
+             */
+            error: string;
+            /**
+             * @description Seconds until rate limit resets
+             * @example 60
+             */
+            retry_after?: number;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+    };
+  };
+  getAdminThreatModelAuditEntry: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The audit entry ID. */
+        entry_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Audit entry */
+      200: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['AuditEntry'];
+        };
+      };
+      /** @description Bad Request - Invalid parameters, malformed UUIDs, or validation failures */
+      400: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Unauthorized - Invalid or missing authentication token */
+      401: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Forbidden - Insufficient permissions to access this resource */
+      403: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Audit entry not found */
+      404: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Too many requests - rate limit exceeded */
+      429: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          /** @description Seconds until rate limit resets */
+          'Retry-After'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /**
+             * @description Error message
+             * @example rate_limit_exceeded
+             */
+            error: string;
+            /**
+             * @description Seconds until rate limit resets
+             * @example 60
+             */
+            retry_after?: number;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+    };
+  };
+  startIdentityLink: {
+    parameters: {
+      query: {
+        /** @description The identity provider ID to link */
+        idp: string;
+        /** @description The URL to redirect to after the provider returns. Must be in the allowlist. */
+        client_callback: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Identity link flow started successfully */
+      200: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['IdentityLinkStartResponse'];
+        };
+      };
+      /** @description Invalid request parameters */
+      400: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Unauthorized - missing or invalid JWT token */
+      401: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Forbidden - service accounts cannot link identities */
+      403: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Identity provider not found */
+      404: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Too many requests - rate limit exceeded */
+      429: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          /** @description Seconds until rate limit resets */
+          'Retry-After'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            /**
+             * @description Error message
+             * @example rate_limit_exceeded
+             */
+            error: string;
+            /**
+             * @description Seconds until rate limit resets
+             * @example 60
+             */
+            retry_after?: number;
+          };
+        };
+      };
+      500: components['responses']['InternalServerError'];
+      503: components['responses']['ServiceUnavailable'];
+    };
+  };
+  confirmIdentityLink: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          /** @description Pending identity link token from the callback redirect */
+          token: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Identity linked successfully */
+      201: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LinkedIdentity'];
+        };
+      };
+      /** @description Invalid request body or token format */
+      400: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Unauthorized - missing or invalid JWT token */
+      401: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Forbidden - service accounts cannot link identities */
+      403: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Pending identity link token not found or expired */
+      404: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Conflict - the identity is already bound to a TMI account (error_code: identity_already_bound) */
+      409: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Too many requests - rate limit exceeded */
+      429: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          /** @description Seconds until rate limit resets */
+          'Retry-After'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            error: string;
+            retry_after?: number;
+          };
+        };
+      };
+      500: components['responses']['InternalServerError'];
+      503: components['responses']['ServiceUnavailable'];
+    };
+  };
+  listMyIdentities: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description User identities */
+      200: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['MyIdentitiesResponse'];
+        };
+      };
+      /** @description Unauthorized - missing or invalid JWT token */
+      401: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Forbidden - service accounts cannot list identities */
+      403: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Too many requests - rate limit exceeded */
+      429: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          /** @description Seconds until rate limit resets */
+          'Retry-After'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            error: string;
+            retry_after?: number;
+          };
+        };
+      };
+      500: components['responses']['InternalServerError'];
+    };
+  };
+  deleteMyIdentity: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Linked identity UUID */
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Identity unlinked successfully */
+      204: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Unauthorized - missing or invalid JWT token */
+      401: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Forbidden - service accounts cannot unlink identities */
+      403: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Linked identity not found or not owned by current user */
+      404: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Too many requests - rate limit exceeded */
+      429: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          /** @description Seconds until rate limit resets */
+          'Retry-After'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            error: string;
+            retry_after?: number;
+          };
+        };
+      };
+      500: components['responses']['InternalServerError'];
+      503: components['responses']['ServiceUnavailable'];
+    };
+  };
+  getPendingIdentityLink: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Pending identity link identifier returned by the OAuth callback */
+        link_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Pending identity link details */
+      200: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PendingIdentityLinkResponse'];
+        };
+      };
+      /** @description Unauthorized - missing or invalid JWT token */
+      401: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Pending identity link not found or does not belong to authenticated user */
+      404: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['Error'];
+        };
+      };
+      /** @description Too many requests - rate limit exceeded */
+      429: {
+        headers: {
+          /** @description Maximum number of requests allowed in the current time window */
+          'X-RateLimit-Limit'?: number;
+          /** @description Number of requests remaining in the current time window */
+          'X-RateLimit-Remaining'?: number;
+          /** @description Unix epoch seconds when the rate limit window resets */
+          'X-RateLimit-Reset'?: number;
+          /** @description Seconds until rate limit resets */
+          'Retry-After'?: number;
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            error: string;
+            retry_after?: number;
+          };
+        };
+      };
+      500: components['responses']['InternalServerError'];
     };
   };
 }

--- a/src/app/pages/admin/admin.component.ts
+++ b/src/app/pages/admin/admin.component.ts
@@ -77,6 +77,12 @@ export class AdminComponent {
       icon: 'assignment',
       action: 'surveys',
     },
+    {
+      title: 'admin.sections.audit.title',
+      description: 'admin.sections.audit.description',
+      icon: 'history',
+      action: 'audit',
+    },
   ];
 
   onSectionClick(action: string): void {

--- a/src/app/pages/admin/audit/admin-audit.service.spec.ts
+++ b/src/app/pages/admin/audit/admin-audit.service.spec.ts
@@ -1,0 +1,78 @@
+import '@angular/compiler';
+import { vi, expect, describe, it, beforeEach } from 'vitest';
+import { of, throwError, lastValueFrom } from 'rxjs';
+import { AdminAuditService } from './admin-audit.service';
+
+describe('AdminAuditService', () => {
+  let service: AdminAuditService;
+  let api: { get: ReturnType<typeof vi.fn>; getBlob: ReturnType<typeof vi.fn> };
+  let logger: {
+    debug: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    api = { get: vi.fn(), getBlob: vi.fn() };
+    logger = { debug: vi.fn(), info: vi.fn(), error: vi.fn() };
+    service = new AdminAuditService(api as never, logger as never);
+  });
+
+  it('lists system entries, passing filter + page params, dropping empties', async () => {
+    api.get.mockReturnValue(of({ entries: [], total: 0, limit: 50, next_cursor: null }));
+    await lastValueFrom(
+      service.listSystem(
+        { actor_email: 'a@b.c', http_method: 'PUT', path_prefix: '' },
+        { limit: 50, cursor: 'X' },
+      ),
+    );
+    expect(api.get).toHaveBeenCalledWith('admin/audit/system', {
+      actor_email: 'a@b.c',
+      http_method: 'PUT',
+      limit: 50,
+      cursor: 'X',
+    });
+  });
+
+  it('lists system entries in around mode', async () => {
+    api.get.mockReturnValue(of({ entries: [], total: 0, limit: 50 }));
+    await lastValueFrom(service.listSystem({}, { limit: 50, around: 'uuid-1' }));
+    expect(api.get).toHaveBeenCalledWith('admin/audit/system', { limit: 50, around: 'uuid-1' });
+  });
+
+  it('gets a single system entry by id', async () => {
+    api.get.mockReturnValue(of({ id: 'e1' }));
+    await lastValueFrom(service.getSystemEntry('e1'));
+    expect(api.get).toHaveBeenCalledWith('admin/audit/system/e1');
+  });
+
+  it('lists TM entries against the threat_models endpoint', async () => {
+    api.get.mockReturnValue(of({ entries: [], total: 0, limit: 50 }));
+    await lastValueFrom(service.listTm({ object_type: 'threat' }, { limit: 50 }));
+    expect(api.get).toHaveBeenCalledWith('admin/audit/threat_models', {
+      object_type: 'threat',
+      limit: 50,
+    });
+  });
+
+  it('gets a single TM entry by id', async () => {
+    api.get.mockReturnValue(of({ id: 't1' }));
+    await lastValueFrom(service.getTmEntry('t1'));
+    expect(api.get).toHaveBeenCalledWith('admin/audit/threat_models/t1');
+  });
+
+  it('exports system audit as a blob with format param', async () => {
+    api.getBlob.mockReturnValue(of(new Blob(['x'])));
+    await lastValueFrom(service.exportSystem({ actor_email: 'a@b.c' }, 'ndjson'));
+    expect(api.getBlob).toHaveBeenCalledWith('admin/audit/system', {
+      actor_email: 'a@b.c',
+      format: 'ndjson',
+    });
+  });
+
+  it('logs and rethrows on list error', async () => {
+    api.get.mockReturnValue(throwError(() => new Error('boom')));
+    await expect(lastValueFrom(service.listSystem({}, {}))).rejects.toThrow('boom');
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/src/app/pages/admin/audit/admin-audit.service.ts
+++ b/src/app/pages/admin/audit/admin-audit.service.ts
@@ -1,0 +1,129 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
+
+import { ApiService } from '@app/core/services/api.service';
+import { LoggerService } from '@app/core/services/logger.service';
+import { buildHttpParams } from '@app/shared/utils/http-params.util';
+import {
+  AuditEntry,
+  AuditExportFormat,
+  AuditPageRequest,
+  ListSystemAuditResponse,
+  ListTmAuditResponse,
+  SystemAuditEntry,
+  SystemAuditFilter,
+  TmAuditFilter,
+} from './models/admin-audit.model';
+
+const SYSTEM_PATH = 'admin/audit/system';
+const TM_PATH = 'admin/audit/threat_models';
+
+/** Strip undefined, null, and empty-string values so blank filters don't become query params. */
+function clean<T extends object>(obj: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined && v !== null && v !== ''),
+  ) as Partial<T>;
+}
+
+/**
+ * Service for accessing the admin audit-log API endpoints.
+ * Provides list, get, and export operations for both the system audit log
+ * and the threat-model audit log.
+ */
+@Injectable({ providedIn: 'root' })
+export class AdminAuditService {
+  constructor(
+    private apiService: ApiService,
+    private logger: LoggerService,
+  ) {}
+
+  /**
+   * List system audit entries with optional filters and cursor pagination.
+   * @param filter Active filter values (empty strings are dropped)
+   * @param page Pagination params (limit, cursor, or around)
+   * @returns Observable of the paginated system audit response
+   */
+  listSystem(
+    filter: SystemAuditFilter,
+    page: AuditPageRequest,
+  ): Observable<ListSystemAuditResponse> {
+    const params = buildHttpParams(clean({ ...filter, ...page }));
+    return this.apiService.get<ListSystemAuditResponse>(SYSTEM_PATH, params).pipe(
+      tap(r =>
+        this.logger.debug('System audit entries loaded', {
+          count: r.entries.length,
+          total: r.total,
+        }),
+      ),
+      catchError(error => {
+        this.logger.error('Failed to list system audit entries', error);
+        throw error;
+      }),
+    );
+  }
+
+  /**
+   * Fetch a single system audit entry by id.
+   * @param entryId The audit entry UUID
+   * @returns Observable of the system audit entry
+   */
+  getSystemEntry(entryId: string): Observable<SystemAuditEntry> {
+    return this.apiService.get<SystemAuditEntry>(`${SYSTEM_PATH}/${entryId}`).pipe(
+      catchError(error => {
+        this.logger.error('Failed to get system audit entry', error);
+        throw error;
+      }),
+    );
+  }
+
+  /**
+   * List threat-model audit entries with optional filters and cursor pagination.
+   * @param filter Active filter values (empty strings are dropped)
+   * @param page Pagination params (limit, cursor, or around)
+   * @returns Observable of the paginated TM audit response
+   */
+  listTm(filter: TmAuditFilter, page: AuditPageRequest): Observable<ListTmAuditResponse> {
+    const params = buildHttpParams(clean({ ...filter, ...page }));
+    return this.apiService.get<ListTmAuditResponse>(TM_PATH, params).pipe(
+      tap(r =>
+        this.logger.debug('TM audit entries loaded', { count: r.entries.length, total: r.total }),
+      ),
+      catchError(error => {
+        this.logger.error('Failed to list threat-model audit entries', error);
+        throw error;
+      }),
+    );
+  }
+
+  /**
+   * Fetch a single threat-model audit entry by id.
+   * @param entryId The audit entry UUID
+   * @returns Observable of the TM audit entry
+   */
+  getTmEntry(entryId: string): Observable<AuditEntry> {
+    return this.apiService.get<AuditEntry>(`${TM_PATH}/${entryId}`).pipe(
+      catchError(error => {
+        this.logger.error('Failed to get threat-model audit entry', error);
+        throw error;
+      }),
+    );
+  }
+
+  /**
+   * Export system audit entries as a downloadable blob (CSV or NDJSON).
+   * @param filter Active filter values (empty strings are dropped)
+   * @param format Export format: 'csv' or 'ndjson'
+   * @returns Observable of the response Blob
+   */
+  exportSystem(filter: SystemAuditFilter, format: AuditExportFormat): Observable<Blob> {
+    const params = buildHttpParams(clean({ ...filter, format }));
+    return this.apiService.getBlob(SYSTEM_PATH, params).pipe(
+      tap(() => this.logger.info('System audit export downloaded', { format })),
+      catchError(error => {
+        this.logger.error('Failed to export system audit', error);
+        throw error;
+      }),
+    );
+  }
+}

--- a/src/app/pages/admin/audit/audit-logs-page.component.html
+++ b/src/app/pages/admin/audit/audit-logs-page.component.html
@@ -1,0 +1,26 @@
+<h1>{{ 'admin.audit.title' | transloco }}</h1>
+
+<nav mat-tab-nav-bar [tabPanel]="tabPanel">
+  <a
+    mat-tab-link
+    routerLink="system"
+    routerLinkActive
+    #s1="routerLinkActive"
+    [active]="s1.isActive"
+    data-testid="audit-tab-system"
+    >{{ 'admin.audit.tabs.system' | transloco }}</a
+  >
+  <a
+    mat-tab-link
+    routerLink="threat-models"
+    routerLinkActive
+    #s2="routerLinkActive"
+    [active]="s2.isActive"
+    data-testid="audit-tab-tm"
+    >{{ 'admin.audit.tabs.threatModels' | transloco }}</a
+  >
+</nav>
+
+<mat-tab-nav-panel #tabPanel>
+  <router-outlet></router-outlet>
+</mat-tab-nav-panel>

--- a/src/app/pages/admin/audit/audit-logs-page.component.scss
+++ b/src/app/pages/admin/audit/audit-logs-page.component.scss
@@ -1,0 +1,8 @@
+:host {
+  display: block;
+  padding: 16px;
+}
+
+h1 {
+  margin-bottom: 16px;
+}

--- a/src/app/pages/admin/audit/audit-logs-page.component.spec.ts
+++ b/src/app/pages/admin/audit/audit-logs-page.component.spec.ts
@@ -1,0 +1,76 @@
+import '@angular/compiler';
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
+import { provideRouter } from '@angular/router';
+import { TranslocoTestingModule } from '@jsverse/transloco';
+
+import { AuditLogsPageComponent } from './audit-logs-page.component';
+
+beforeAll(() => {
+  TestBed.initTestEnvironment(BrowserTestingModule, platformBrowserTesting());
+});
+
+afterEach(() => {
+  TestBed.resetTestingModule();
+});
+
+function buildFixture(): ComponentFixture<AuditLogsPageComponent> {
+  const translocoTesting = TranslocoTestingModule.forRoot({
+    langs: { en: {} },
+    translocoConfig: { availableLangs: ['en'], defaultLang: 'en' },
+    preloadLangs: true,
+  });
+
+  void TestBed.configureTestingModule({
+    imports: [AuditLogsPageComponent, translocoTesting],
+    providers: [provideRouter([])],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(AuditLogsPageComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('AuditLogsPageComponent', () => {
+  let fixture: ComponentFixture<AuditLogsPageComponent>;
+
+  beforeEach(() => {
+    fixture = buildFixture();
+  });
+
+  it('should create the component', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should render the system tab link', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector('[data-testid="audit-tab-system"]');
+    expect(link).toBeTruthy();
+  });
+
+  it('should render the threat-models tab link', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector('[data-testid="audit-tab-tm"]');
+    expect(link).toBeTruthy();
+  });
+
+  it('should have both audit tab links', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const links = el.querySelectorAll('[data-testid^="audit-tab"]');
+    expect(links.length).toBe(2);
+  });
+
+  it('system tab link should have routerLink pointing to system', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector<HTMLAnchorElement>('[data-testid="audit-tab-system"]');
+    expect(link?.getAttribute('href')).toContain('system');
+  });
+
+  it('threat-models tab link should have routerLink pointing to threat-models', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    const link = el.querySelector<HTMLAnchorElement>('[data-testid="audit-tab-tm"]');
+    expect(link?.getAttribute('href')).toContain('threat-models');
+  });
+});

--- a/src/app/pages/admin/audit/audit-logs-page.component.ts
+++ b/src/app/pages/admin/audit/audit-logs-page.component.ts
@@ -1,0 +1,30 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { MatTabsModule } from '@angular/material/tabs';
+import { TranslocoModule } from '@jsverse/transloco';
+import { COMMON_IMPORTS, CORE_MATERIAL_IMPORTS } from '@app/shared/imports';
+
+/**
+ * Audit Logs Page Component
+ *
+ * Shell component for the audit log feature. Renders a tab nav bar with
+ * links to the system-audit and threat-model-audit views, with a router
+ * outlet below for rendering the active tab content.
+ */
+@Component({
+  selector: 'app-audit-logs-page',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ...COMMON_IMPORTS,
+    ...CORE_MATERIAL_IMPORTS,
+    MatTabsModule,
+    TranslocoModule,
+    RouterLink,
+    RouterLinkActive,
+    RouterOutlet,
+  ],
+  templateUrl: './audit-logs-page.component.html',
+  styleUrl: './audit-logs-page.component.scss',
+})
+export class AuditLogsPageComponent {}

--- a/src/app/pages/admin/audit/components/audit-detail-panel.component.html
+++ b/src/app/pages/admin/audit/components/audit-detail-panel.component.html
@@ -1,0 +1,148 @@
+<div class="detail-panel">
+  <div class="detail-panel__header">
+    <h2>{{ 'admin.audit.detail.title' | transloco }}</h2>
+    <div class="detail-panel__actions">
+      @if (entry && !loading) {
+        <button
+          mat-icon-button
+          data-testid="audit-detail-copy"
+          [matTooltip]="
+            (copied ? 'admin.audit.detail.copied' : 'admin.audit.detail.copyPermalink') | transloco
+          "
+          (click)="copyPermalink()"
+        >
+          <mat-icon>{{ copied ? 'check' : 'link' }}</mat-icon>
+        </button>
+        <button
+          mat-icon-button
+          data-testid="audit-detail-context"
+          [matTooltip]="'admin.audit.detail.viewInContext' | transloco"
+          (click)="viewInContext()"
+        >
+          <mat-icon>open_in_new</mat-icon>
+        </button>
+      }
+      <button
+        mat-icon-button
+        data-testid="audit-detail-close"
+        [matTooltip]="'admin.audit.detail.close' | transloco"
+        (click)="close()"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    </div>
+  </div>
+
+  <div class="detail-panel__body">
+    @if (loading) {
+      <div class="detail-panel__spinner">
+        <mat-spinner diameter="40"></mat-spinner>
+      </div>
+    } @else if (notFound) {
+      <div class="detail-panel__not-found">
+        <p>{{ 'admin.audit.detail.notFound' | transloco }}</p>
+        <button mat-button data-testid="audit-detail-close" (click)="close()">
+          {{ 'admin.audit.detail.close' | transloco }}
+        </button>
+      </div>
+    } @else if (entry) {
+      <div class="detail-panel__field">
+        <label>{{ 'admin.audit.detail.timestamp' | transloco }}</label>
+        <span class="value">{{ entry.created_at }}</span>
+      </div>
+
+      <div class="detail-panel__field">
+        <label>{{ 'admin.audit.detail.actor' | transloco }}</label>
+        <span class="value">{{ entry.actor.display_name }}</span>
+      </div>
+
+      <div class="detail-panel__field">
+        <label>{{ 'admin.audit.detail.email' | transloco }}</label>
+        <span class="value">{{ entry.actor.email }}</span>
+      </div>
+
+      <div class="detail-panel__field">
+        <label>{{ 'admin.audit.detail.provider' | transloco }}</label>
+        <span class="value">{{ entry.actor.provider }}</span>
+      </div>
+
+      <div class="detail-panel__field">
+        <label>{{ 'admin.audit.detail.providerId' | transloco }}</label>
+        <span class="value">{{ entry.actor.provider_id }}</span>
+      </div>
+
+      @switch (stream) {
+        @case ('system') {
+          @if (systemEntry) {
+            <div class="detail-panel__field">
+              <label>{{ 'admin.audit.detail.method' | transloco }}</label>
+              <span class="value">{{ systemEntry.http_method }}</span>
+            </div>
+
+            <div class="detail-panel__field">
+              <label>{{ 'admin.audit.detail.path' | transloco }}</label>
+              <span class="value">{{ systemEntry.http_path }}</span>
+            </div>
+
+            <div class="detail-panel__field">
+              <label>{{ 'admin.audit.detail.fieldPath' | transloco }}</label>
+              <span class="value">{{ systemEntry.field_path }}</span>
+            </div>
+
+            <div class="detail-panel__field">
+              <label>{{ 'admin.audit.detail.oldValue' | transloco }}</label>
+              <span class="value">{{ systemEntry.old_value_redacted }}</span>
+            </div>
+
+            <div class="detail-panel__field">
+              <label>{{ 'admin.audit.detail.newValue' | transloco }}</label>
+              <span class="value">{{ systemEntry.new_value_redacted }}</span>
+            </div>
+
+            @if (systemEntry.change_summary) {
+              <div class="detail-panel__field">
+                <label>{{ 'admin.audit.detail.changeSummary' | transloco }}</label>
+                <span class="value">{{ systemEntry.change_summary }}</span>
+              </div>
+            }
+          }
+        }
+        @case ('tm') {
+          @if (tmEntry) {
+            <div class="detail-panel__field">
+              <label>{{ 'admin.audit.detail.threatModel' | transloco }}</label>
+              <span class="value">{{ tmEntry.threat_model_id }}</span>
+            </div>
+
+            <div class="detail-panel__field">
+              <label>{{ 'admin.audit.detail.objectType' | transloco }}</label>
+              <span class="value">{{ tmEntry.object_type }}</span>
+            </div>
+
+            <div class="detail-panel__field">
+              <label>{{ 'admin.audit.detail.objectId' | transloco }}</label>
+              <span class="value">{{ tmEntry.object_id }}</span>
+            </div>
+
+            <div class="detail-panel__field">
+              <label>{{ 'admin.audit.detail.changeType' | transloco }}</label>
+              <span class="value">{{ tmEntry.change_type }}</span>
+            </div>
+
+            <div class="detail-panel__field">
+              <label>{{ 'admin.audit.detail.version' | transloco }}</label>
+              <span class="value">{{ tmEntry.version }}</span>
+            </div>
+
+            @if (tmEntry.change_summary) {
+              <div class="detail-panel__field">
+                <label>{{ 'admin.audit.detail.changeSummary' | transloco }}</label>
+                <span class="value">{{ tmEntry.change_summary }}</span>
+              </div>
+            }
+          }
+        }
+      }
+    }
+  </div>
+</div>

--- a/src/app/pages/admin/audit/components/audit-detail-panel.component.html
+++ b/src/app/pages/admin/audit/components/audit-detail-panel.component.html
@@ -9,6 +9,9 @@
           [matTooltip]="
             (copied ? 'admin.audit.detail.copied' : 'admin.audit.detail.copyPermalink') | transloco
           "
+          [attr.aria-label]="
+            (copied ? 'admin.audit.detail.copied' : 'admin.audit.detail.copyPermalink') | transloco
+          "
           (click)="copyPermalink()"
         >
           <mat-icon>{{ copied ? 'check' : 'link' }}</mat-icon>
@@ -17,6 +20,7 @@
           mat-icon-button
           data-testid="audit-detail-context"
           [matTooltip]="'admin.audit.detail.viewInContext' | transloco"
+          [attr.aria-label]="'admin.audit.detail.viewInContext' | transloco"
           (click)="viewInContext()"
         >
           <mat-icon>open_in_new</mat-icon>
@@ -26,6 +30,7 @@
         mat-icon-button
         data-testid="audit-detail-close"
         [matTooltip]="'admin.audit.detail.close' | transloco"
+        [attr.aria-label]="'admin.audit.detail.close' | transloco"
         (click)="close()"
       >
         <mat-icon>close</mat-icon>
@@ -41,7 +46,7 @@
     } @else if (notFound) {
       <div class="detail-panel__not-found">
         <p>{{ 'admin.audit.detail.notFound' | transloco }}</p>
-        <button mat-button data-testid="audit-detail-close" (click)="close()">
+        <button mat-button data-testid="audit-detail-close-notfound" (click)="close()">
           {{ 'admin.audit.detail.close' | transloco }}
         </button>
       </div>

--- a/src/app/pages/admin/audit/components/audit-detail-panel.component.scss
+++ b/src/app/pages/admin/audit/components/audit-detail-panel.component.scss
@@ -1,0 +1,64 @@
+:host {
+  display: block;
+}
+
+.detail-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 16px;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+
+    h2 {
+      margin: 0;
+      font-size: 1.25rem;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    gap: 8px;
+  }
+
+  &__body {
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  &__field {
+    margin-bottom: 12px;
+
+    label {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--mat-sys-on-surface-variant);
+      margin-bottom: 2px;
+    }
+
+    .value {
+      font-size: 0.875rem;
+      word-break: break-all;
+    }
+  }
+
+  &__spinner {
+    display: flex;
+    justify-content: center;
+    padding: 32px;
+  }
+
+  &__not-found {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 32px;
+    gap: 16px;
+    text-align: center;
+  }
+}

--- a/src/app/pages/admin/audit/components/audit-detail-panel.component.spec.ts
+++ b/src/app/pages/admin/audit/components/audit-detail-panel.component.spec.ts
@@ -1,0 +1,311 @@
+import '@angular/compiler';
+
+import { vi, expect, afterEach, beforeEach, describe, it } from 'vitest';
+import { ChangeDetectorRef, DestroyRef, Injector, runInInjectionContext } from '@angular/core';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
+import { BehaviorSubject, of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+
+import { AuditDetailPanelComponent } from './audit-detail-panel.component';
+import { createTypedMockLoggerService, createTypedMockRouter } from '@testing/mocks';
+import type { MockLoggerService, MockRouter } from '@testing/mocks';
+import { LoggerService } from '@app/core/services/logger.service';
+import { AdminAuditService } from '@app/pages/admin/audit/admin-audit.service';
+import type { AuditEntry, SystemAuditEntry } from '@app/pages/admin/audit/models/admin-audit.model';
+
+// ── Fixture data ──────────────────────────────────────────────────────────────
+
+const SYSTEM_ENTRY: SystemAuditEntry = {
+  id: 'sys-1',
+  actor: {
+    email: 'admin@example.com',
+    provider: 'google',
+    provider_id: 'goog-123',
+    display_name: 'Admin User',
+  },
+  http_method: 'PATCH',
+  http_path: '/admin/users/42',
+  field_path: 'role',
+  old_value_redacted: 'viewer',
+  new_value_redacted: 'admin',
+  change_summary: 'Role changed',
+  created_at: '2026-01-01T12:00:00Z',
+};
+
+const TM_ENTRY: AuditEntry = {
+  id: 'tm-1',
+  threat_model_id: 'tm-uuid-999',
+  object_type: 'diagram',
+  object_id: 'diag-5',
+  version: 3,
+  change_type: 'updated',
+  actor: {
+    email: 'user@example.com',
+    provider: 'local',
+    provider_id: 'local-7',
+    display_name: 'Regular User',
+  },
+  change_summary: 'Updated diagram',
+  created_at: '2026-02-15T08:30:00Z',
+};
+
+// ── Shared mock setup helpers ─────────────────────────────────────────────────
+
+function buildMocks(
+  options: {
+    stream?: 'system' | 'tm';
+    entryId?: string;
+    systemEntry?: SystemAuditEntry | null;
+    tmEntry?: AuditEntry | null;
+    systemError?: unknown;
+    tmError?: unknown;
+  } = {},
+): {
+  injector: Injector;
+  paramMapSubject: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+  mockRoute: {
+    snapshot: { data: Record<string, unknown> };
+    paramMap: ReturnType<typeof BehaviorSubject.prototype.asObservable>;
+  };
+  mockRouter: MockRouter;
+  mockAuditService: Partial<AdminAuditService>;
+  mockLogger: MockLoggerService;
+} {
+  const stream = options.stream ?? 'system';
+  const entryId = options.entryId ?? 'sys-1';
+
+  const paramMapSubject = new BehaviorSubject(convertToParamMap({ entryId }));
+
+  const mockRoute = {
+    snapshot: { data: { stream } },
+    paramMap: paramMapSubject.asObservable(),
+  };
+
+  const mockRouter = createTypedMockRouter('/admin/audit/system/sys-1') as MockRouter;
+  const mockLogger = createTypedMockLoggerService();
+
+  const mockAuditService: Partial<AdminAuditService> = {
+    getSystemEntry: options.systemError
+      ? vi.fn().mockReturnValue(throwError(() => options.systemError))
+      : vi.fn().mockReturnValue(of(options.systemEntry ?? SYSTEM_ENTRY)),
+    getTmEntry: options.tmError
+      ? vi.fn().mockReturnValue(throwError(() => options.tmError))
+      : vi.fn().mockReturnValue(of(options.tmEntry ?? TM_ENTRY)),
+  };
+
+  const mockDestroyRef = { onDestroy: vi.fn() };
+  const mockCdr = { markForCheck: vi.fn(), detectChanges: vi.fn() };
+
+  const injector = Injector.create({
+    providers: [
+      { provide: DestroyRef, useValue: mockDestroyRef },
+      { provide: ChangeDetectorRef, useValue: mockCdr },
+      { provide: ActivatedRoute, useValue: mockRoute },
+      { provide: Router, useValue: mockRouter },
+      { provide: AdminAuditService, useValue: mockAuditService },
+      { provide: LoggerService, useValue: mockLogger },
+    ],
+  });
+
+  return { injector, paramMapSubject, mockRoute, mockRouter, mockAuditService, mockLogger };
+}
+
+function createComponent(injector: Injector): AuditDetailPanelComponent {
+  const comp = runInInjectionContext(injector, () => new AuditDetailPanelComponent());
+  comp.ngOnInit();
+  return comp;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('AuditDetailPanelComponent', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  describe('(a) stream=system calls getSystemEntry and exposes the entry', () => {
+    let comp: AuditDetailPanelComponent;
+    let mocks: ReturnType<typeof buildMocks>;
+
+    beforeEach(() => {
+      mocks = buildMocks({ stream: 'system', entryId: 'sys-1' });
+      comp = createComponent(mocks.injector);
+    });
+
+    it('should create the component', () => {
+      expect(comp).toBeTruthy();
+    });
+
+    it('should call getSystemEntry with the entryId from paramMap', () => {
+      expect(mocks.mockAuditService.getSystemEntry).toHaveBeenCalledWith('sys-1');
+    });
+
+    it('should NOT call getTmEntry for system stream', () => {
+      expect(mocks.mockAuditService.getTmEntry).not.toHaveBeenCalled();
+    });
+
+    it('should set entry to the resolved SystemAuditEntry', () => {
+      expect(comp.entry).toEqual(SYSTEM_ENTRY);
+    });
+
+    it('should set loading to false after the entry is loaded', () => {
+      expect(comp.loading).toBe(false);
+    });
+
+    it('should expose stream as system', () => {
+      expect(comp.stream).toBe('system');
+    });
+
+    it('should expose systemEntry getter returning the typed entry', () => {
+      expect(comp.systemEntry).toEqual(SYSTEM_ENTRY);
+    });
+
+    it('should have notFound=false when entry loads successfully', () => {
+      expect(comp.notFound).toBe(false);
+    });
+  });
+
+  describe('(b) stream=tm calls getTmEntry and exposes the entry', () => {
+    let comp: AuditDetailPanelComponent;
+    let mocks: ReturnType<typeof buildMocks>;
+
+    beforeEach(() => {
+      mocks = buildMocks({ stream: 'tm', entryId: 'tm-1' });
+      comp = createComponent(mocks.injector);
+    });
+
+    it('should call getTmEntry with the entryId from paramMap', () => {
+      expect(mocks.mockAuditService.getTmEntry).toHaveBeenCalledWith('tm-1');
+    });
+
+    it('should NOT call getSystemEntry for tm stream', () => {
+      expect(mocks.mockAuditService.getSystemEntry).not.toHaveBeenCalled();
+    });
+
+    it('should set entry to the resolved AuditEntry', () => {
+      expect(comp.entry).toEqual(TM_ENTRY);
+    });
+
+    it('should expose tmEntry getter returning the typed entry', () => {
+      expect(comp.tmEntry).toEqual(TM_ENTRY);
+    });
+  });
+
+  describe('(c) re-fetches when paramMap emits a new entryId', () => {
+    it('should re-fetch when paramMap emits a second entryId', () => {
+      const SECOND_ENTRY: SystemAuditEntry = { ...SYSTEM_ENTRY, id: 'sys-2' };
+      const mocks = buildMocks({ stream: 'system', entryId: 'sys-1' });
+
+      // Override the mock to return different entries per call
+      let callCount = 0;
+      (mocks.mockAuditService.getSystemEntry as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        callCount++;
+        return of(callCount === 1 ? SYSTEM_ENTRY : SECOND_ENTRY);
+      });
+
+      const comp = createComponent(mocks.injector);
+
+      // First fetch
+      expect(comp.entry).toEqual(SYSTEM_ENTRY);
+
+      // Emit a new paramMap with a different entryId
+      mocks.paramMapSubject.next(convertToParamMap({ entryId: 'sys-2' }));
+
+      expect(mocks.mockAuditService.getSystemEntry).toHaveBeenCalledWith('sys-2');
+      expect(comp.entry).toEqual(SECOND_ENTRY);
+    });
+  });
+
+  describe('(d) copyPermalink() writes to clipboard', () => {
+    it('should call navigator.clipboard.writeText with the permalink URL', () => {
+      const writeTextMock = vi.fn().mockResolvedValue(undefined);
+      vi.stubGlobal('navigator', { clipboard: { writeText: writeTextMock } });
+      vi.stubGlobal('window', {
+        location: { origin: 'https://app.example.com' },
+      });
+
+      const mocks = buildMocks({ stream: 'system', entryId: 'sys-1' });
+      // router.url is set to '/admin/audit/system/sys-1' from createTypedMockRouter
+      const comp = createComponent(mocks.injector);
+
+      comp.copyPermalink();
+
+      expect(writeTextMock).toHaveBeenCalledWith(
+        'https://app.example.com/admin/audit/system/sys-1',
+      );
+    });
+
+    it('should set copied=true after calling copyPermalink()', () => {
+      vi.stubGlobal('navigator', {
+        clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+      });
+      vi.stubGlobal('window', { location: { origin: 'https://app.example.com' } });
+
+      const mocks = buildMocks({ stream: 'system', entryId: 'sys-1' });
+      const comp = createComponent(mocks.injector);
+
+      comp.copyPermalink();
+      expect(comp.copied).toBe(true);
+    });
+  });
+
+  describe('(e) viewInContext() navigates with around queryParam', () => {
+    it('should call router.navigate with around=entryId', () => {
+      const mocks = buildMocks({ stream: 'system', entryId: 'sys-1' });
+      const comp = createComponent(mocks.injector);
+
+      comp.viewInContext();
+
+      expect(mocks.mockRouter.navigate).toHaveBeenCalledWith(['../'], {
+        relativeTo: mocks.mockRoute,
+        queryParams: { around: 'sys-1' },
+      });
+    });
+  });
+
+  describe('close()', () => {
+    it('should call router.navigate to parent without queryParams', () => {
+      const mocks = buildMocks({ stream: 'system', entryId: 'sys-1' });
+      const comp = createComponent(mocks.injector);
+
+      comp.close();
+
+      expect(mocks.mockRouter.navigate).toHaveBeenCalledWith(['../'], {
+        relativeTo: mocks.mockRoute,
+      });
+    });
+  });
+
+  describe('(f) 404 error sets notFound=true', () => {
+    it('should set notFound=true when getSystemEntry throws a 404 HttpErrorResponse', () => {
+      const notFoundError = new HttpErrorResponse({ status: 404 });
+      const mocks = buildMocks({ stream: 'system', systemError: notFoundError });
+
+      const comp = createComponent(mocks.injector);
+
+      expect(comp.notFound).toBe(true);
+      expect(comp.entry).toBeNull();
+    });
+
+    it('should set notFound=true when getTmEntry throws a 404 HttpErrorResponse', () => {
+      const notFoundError = new HttpErrorResponse({ status: 404 });
+      const mocks = buildMocks({ stream: 'tm', tmError: notFoundError });
+
+      const comp = createComponent(mocks.injector);
+
+      expect(comp.notFound).toBe(true);
+      expect(comp.entry).toBeNull();
+    });
+
+    it('should set notFound=true and log for non-404 errors', () => {
+      const serverError = new HttpErrorResponse({ status: 500 });
+      const mocks = buildMocks({ stream: 'system', systemError: serverError });
+
+      const comp = createComponent(mocks.injector);
+
+      expect(comp.notFound).toBe(true);
+      expect(mocks.mockLogger.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/pages/admin/audit/components/audit-detail-panel.component.ts
+++ b/src/app/pages/admin/audit/components/audit-detail-panel.component.ts
@@ -1,0 +1,159 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  inject,
+  OnInit,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { TranslocoModule } from '@jsverse/transloco';
+import { switchMap } from 'rxjs/operators';
+
+import { LoggerService } from '@app/core/services/logger.service';
+import {
+  COMMON_IMPORTS,
+  CORE_MATERIAL_IMPORTS,
+  FEEDBACK_MATERIAL_IMPORTS,
+} from '@app/shared/imports';
+import { AdminAuditService } from '@app/pages/admin/audit/admin-audit.service';
+import {
+  AuditEntry,
+  AuditStream,
+  SystemAuditEntry,
+} from '@app/pages/admin/audit/models/admin-audit.model';
+
+/**
+ * Route-driven side panel showing one audit entry (system OR threat-model).
+ * Rendered inside a parent view's `<router-outlet>` via a child route `:entryId`.
+ * The route supplies `data.stream` to indicate which audit stream to use.
+ */
+@Component({
+  selector: 'app-audit-detail-panel',
+  standalone: true,
+  imports: [
+    ...COMMON_IMPORTS,
+    ...CORE_MATERIAL_IMPORTS,
+    ...FEEDBACK_MATERIAL_IMPORTS,
+    TranslocoModule,
+  ],
+  templateUrl: './audit-detail-panel.component.html',
+  styleUrl: './audit-detail-panel.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AuditDetailPanelComponent implements OnInit {
+  private readonly route: ActivatedRoute;
+  private readonly router: Router;
+  private readonly auditService: AdminAuditService;
+  private readonly logger: LoggerService;
+  private readonly destroyRef: DestroyRef;
+  private readonly cdr: ChangeDetectorRef;
+
+  /** Which audit stream this panel is showing — read from route data. */
+  readonly stream: AuditStream;
+
+  /** The resolved audit entry, or null when not yet loaded or on error. */
+  entry: SystemAuditEntry | AuditEntry | null = null;
+
+  /** True while the entry is being fetched. */
+  loading = false;
+
+  /** True when the entry was not found (404) or any fetch error occurred. */
+  notFound = false;
+
+  /** True briefly after the user copies the permalink URL. */
+  copied = false;
+
+  /** The current entryId from the route. */
+  private _currentEntryId: string | null = null;
+
+  constructor() {
+    this.route = inject(ActivatedRoute);
+    this.router = inject(Router);
+    this.auditService = inject(AdminAuditService);
+    this.logger = inject(LoggerService);
+    this.destroyRef = inject(DestroyRef);
+    this.cdr = inject(ChangeDetectorRef);
+    this.stream = (this.route.snapshot.data['stream'] as AuditStream) ?? 'system';
+  }
+
+  /** Type-safe accessor for system audit entries. */
+  get systemEntry(): SystemAuditEntry | null {
+    if (this.stream !== 'system') return null;
+    return this.entry as SystemAuditEntry | null;
+  }
+
+  /** Type-safe accessor for threat-model audit entries. */
+  get tmEntry(): AuditEntry | null {
+    if (this.stream !== 'tm') return null;
+    return this.entry as AuditEntry | null;
+  }
+
+  ngOnInit(): void {
+    this.route.paramMap
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        switchMap(params => {
+          const entryId = params.get('entryId') ?? '';
+          this._currentEntryId = entryId;
+          this.loading = true;
+          this.notFound = false;
+          this.entry = null;
+          this.cdr.markForCheck();
+
+          return this.stream === 'system'
+            ? this.auditService.getSystemEntry(entryId)
+            : this.auditService.getTmEntry(entryId);
+        }),
+      )
+      .subscribe({
+        next: entry => {
+          this.entry = entry;
+          this.loading = false;
+          this.cdr.markForCheck();
+        },
+        error: (err: unknown) => {
+          this.loading = false;
+          this.entry = null;
+          this.notFound = true;
+
+          if (err instanceof HttpErrorResponse && err.status === 404) {
+            // Silently set not-found; no log noise for expected 404s
+          } else {
+            this.logger.error('Failed to load audit entry', err);
+          }
+
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  /**
+   * Copies the absolute permalink URL of this entry to the clipboard.
+   * URL = window.location.origin + router.url (the current route is already the permalink).
+   */
+  copyPermalink(): void {
+    const url = `${window.location.origin}${this.router.url}`;
+    void navigator.clipboard.writeText(url);
+    this.copied = true;
+    this.cdr.markForCheck();
+  }
+
+  /**
+   * Navigates to the parent list with this entry as the around-anchor,
+   * allowing the user to see this entry in context.
+   */
+  viewInContext(): void {
+    void this.router.navigate(['../'], {
+      relativeTo: this.route,
+      queryParams: { around: this._currentEntryId },
+    });
+  }
+
+  /** Closes the detail panel by navigating back to the parent list. */
+  close(): void {
+    void this.router.navigate(['../'], { relativeTo: this.route });
+  }
+}

--- a/src/app/pages/admin/audit/components/audit-detail-panel.component.ts
+++ b/src/app/pages/admin/audit/components/audit-detail-panel.component.ts
@@ -101,6 +101,7 @@ export class AuditDetailPanelComponent implements OnInit {
           this.loading = true;
           this.notFound = false;
           this.entry = null;
+          this.copied = false;
           this.cdr.markForCheck();
 
           return this.stream === 'system'

--- a/src/app/pages/admin/audit/components/audit-filter-bar.component.html
+++ b/src/app/pages/admin/audit/components/audit-filter-bar.component.html
@@ -1,0 +1,169 @@
+<div class="audit-filter-bar">
+  <!-- Actor autocomplete (shared) -->
+  <mat-form-field appearance="outline" class="filter-field actor-field">
+    <mat-label>{{ 'admin.audit.filters.actor' | transloco }}</mat-label>
+    <input
+      matInput
+      [value]="actorInput"
+      [matAutocomplete]="actorAuto"
+      [placeholder]="'admin.audit.filters.actorPlaceholder' | transloco"
+      (input)="onActorInput($any($event.target).value)"
+      data-testid="audit-filter-actor"
+    />
+    <mat-autocomplete
+      #actorAuto="matAutocomplete"
+      [displayWith]="displayActor"
+      (optionSelected)="onActorSelected($event)"
+    >
+      @for (user of actorSuggestions$ | async; track user.internal_uuid) {
+        <mat-option [value]="user">{{ user.email }}</mat-option>
+      }
+    </mat-autocomplete>
+  </mat-form-field>
+
+  <!-- Created After date picker (shared) -->
+  <mat-form-field appearance="outline" class="filter-field date-field">
+    <mat-label>{{ 'admin.audit.filters.createdAfter' | transloco }}</mat-label>
+    <input
+      matInput
+      [matDatepicker]="createdAfterPicker"
+      [value]="createdAfter"
+      (dateChange)="onCreatedAfterChange($event.value?.toISOString() ?? null)"
+    />
+    <mat-datepicker-toggle matSuffix [for]="createdAfterPicker"></mat-datepicker-toggle>
+    <mat-datepicker #createdAfterPicker></mat-datepicker>
+  </mat-form-field>
+
+  <!-- Created Before date picker (shared) -->
+  <mat-form-field appearance="outline" class="filter-field date-field">
+    <mat-label>{{ 'admin.audit.filters.createdBefore' | transloco }}</mat-label>
+    <input
+      matInput
+      [matDatepicker]="createdBeforePicker"
+      [value]="createdBefore"
+      (dateChange)="onCreatedBeforeChange($event.value?.toISOString() ?? null)"
+    />
+    <mat-datepicker-toggle matSuffix [for]="createdBeforePicker"></mat-datepicker-toggle>
+    <mat-datepicker #createdBeforePicker></mat-datepicker>
+  </mat-form-field>
+
+  <!-- ── System-only filters ─────────────────────────────────────── -->
+  @if (isSystemStream) {
+    <!-- HTTP Method select -->
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>{{ 'admin.audit.filters.httpMethod' | transloco }}</mat-label>
+      <mat-select
+        [value]="httpMethod"
+        (selectionChange)="onHttpMethodChange($event.value)"
+        data-testid="audit-filter-http-method"
+      >
+        <mat-option [value]="null">&mdash;</mat-option>
+        @for (method of httpMethods; track method) {
+          <mat-option [value]="method">
+            {{ 'admin.audit.enums.httpMethod.' + method | transloco }}
+          </mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    <!-- Path Prefix text -->
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>{{ 'admin.audit.filters.pathPrefix' | transloco }}</mat-label>
+      <input
+        matInput
+        [value]="pathPrefix"
+        (input)="onPathPrefixInput($any($event.target).value)"
+        data-testid="audit-filter-path-prefix"
+      />
+    </mat-form-field>
+
+    <!-- Field Path text -->
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>{{ 'admin.audit.filters.fieldPath' | transloco }}</mat-label>
+      <input
+        matInput
+        [value]="fieldPath"
+        (input)="onFieldPathInput($any($event.target).value)"
+        data-testid="audit-filter-field-path"
+      />
+    </mat-form-field>
+  }
+
+  <!-- ── TM-only filters ────────────────────────────────────────── -->
+  @if (!isSystemStream) {
+    <!-- Change Type select -->
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>{{ 'admin.audit.filters.changeType' | transloco }}</mat-label>
+      <mat-select
+        [value]="changeType"
+        (selectionChange)="onChangeTypeChange($event.value)"
+        data-testid="audit-filter-change-type"
+      >
+        <mat-option [value]="null">&mdash;</mat-option>
+        @for (ct of changeTypes; track ct) {
+          <mat-option [value]="ct">
+            {{ 'admin.audit.enums.changeType.' + ct | transloco }}
+          </mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    <!-- Object Type select -->
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>{{ 'admin.audit.filters.objectType' | transloco }}</mat-label>
+      <mat-select
+        [value]="objectType"
+        (selectionChange)="onObjectTypeChange($event.value)"
+        data-testid="audit-filter-object-type"
+      >
+        <mat-option [value]="null">&mdash;</mat-option>
+        @for (ot of objectTypes; track ot) {
+          <mat-option [value]="ot">
+            {{ 'admin.audit.enums.objectType.' + ot | transloco }}
+          </mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    <!-- Threat Model ID text -->
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>{{ 'admin.audit.filters.threatModelId' | transloco }}</mat-label>
+      <input
+        matInput
+        [value]="threatModelId"
+        (input)="onThreatModelIdInput($any($event.target).value)"
+        data-testid="audit-filter-threat-model-id"
+      />
+    </mat-form-field>
+  }
+
+  <!-- ── Action buttons ─────────────────────────────────────────── -->
+  <div class="filter-actions">
+    <!-- Clear filters -->
+    <button
+      mat-button
+      (click)="clearFilters()"
+      class="clear-filters-button"
+      data-testid="audit-filter-clear"
+    >
+      <mat-icon>filter_list_off</mat-icon>
+      {{ 'admin.audit.filters.clear' | transloco }}
+    </button>
+
+    <!-- Export menu (system stream only) -->
+    @if (isSystemStream) {
+      <button mat-button [matMenuTriggerFor]="exportMenu" data-testid="audit-filter-export-menu">
+        <mat-icon>download</mat-icon>
+        {{ 'admin.audit.export.menu' | transloco }}
+      </button>
+      <mat-menu #exportMenu="matMenu">
+        <button mat-menu-item (click)="onExportCsv()" data-testid="audit-filter-export-csv">
+          {{ 'admin.audit.export.csv' | transloco }}
+        </button>
+        <button mat-menu-item (click)="onExportNdjson()" data-testid="audit-filter-export-ndjson">
+          {{ 'admin.audit.export.ndjson' | transloco }}
+        </button>
+      </mat-menu>
+    }
+  </div>
+</div>

--- a/src/app/pages/admin/audit/components/audit-filter-bar.component.html
+++ b/src/app/pages/admin/audit/components/audit-filter-bar.component.html
@@ -60,7 +60,7 @@
         <mat-option [value]="null">&mdash;</mat-option>
         @for (method of httpMethods; track method) {
           <mat-option [value]="method">
-            {{ 'admin.audit.enums.httpMethod.' + method | transloco }}
+            {{ method }}
           </mat-option>
         }
       </mat-select>

--- a/src/app/pages/admin/audit/components/audit-filter-bar.component.scss
+++ b/src/app/pages/admin/audit/components/audit-filter-bar.component.scss
@@ -1,0 +1,30 @@
+.audit-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 0;
+}
+
+.filter-field {
+  min-width: 160px;
+  flex: 1 1 160px;
+}
+
+.actor-field {
+  min-width: 220px;
+  flex: 2 1 220px;
+}
+
+.date-field {
+  min-width: 160px;
+  flex: 1 1 160px;
+}
+
+.filter-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding-top: 4px;
+  flex-shrink: 0;
+}

--- a/src/app/pages/admin/audit/components/audit-filter-bar.component.spec.ts
+++ b/src/app/pages/admin/audit/components/audit-filter-bar.component.spec.ts
@@ -1,0 +1,376 @@
+import '@angular/compiler';
+
+import { vi, expect, afterEach, beforeEach, describe, it } from 'vitest';
+import { DestroyRef, Injector, runInInjectionContext } from '@angular/core';
+import { of } from 'rxjs';
+
+import { AuditFilterBarComponent } from './audit-filter-bar.component';
+import { createTypedMockLoggerService, type MockLoggerService } from '@testing/mocks';
+
+interface MockUserAdminService {
+  list: ReturnType<typeof vi.fn>;
+}
+
+describe('AuditFilterBarComponent', () => {
+  let component: AuditFilterBarComponent;
+  let mockUserAdminService: MockUserAdminService;
+  let mockLogger: MockLoggerService;
+  let mockDestroyRef: { onDestroy: ReturnType<typeof vi.fn> };
+  let injector: Injector;
+
+  function createComponent(
+    overrides?: Partial<{ stream: 'system' | 'tm' }>,
+  ): AuditFilterBarComponent {
+    const comp = runInInjectionContext(injector, () => {
+      return new AuditFilterBarComponent(mockUserAdminService as never, mockLogger as never);
+    });
+    comp.stream = overrides?.stream ?? 'system';
+    comp.initialFilter = {};
+    return comp;
+  }
+
+  beforeEach(() => {
+    mockUserAdminService = {
+      list: vi.fn().mockReturnValue(of({ users: [], total: 0 })),
+    };
+
+    mockLogger = createTypedMockLoggerService();
+    mockDestroyRef = { onDestroy: vi.fn() };
+
+    injector = Injector.create({
+      providers: [{ provide: DestroyRef, useValue: mockDestroyRef }],
+    });
+
+    component = createComponent();
+    component.ngOnInit();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  describe('initialization', () => {
+    it('should create the component', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should emit filterChange with empty object on init when initialFilter is empty', () => {
+      const emitted: unknown[] = [];
+      component.filterChange.subscribe(v => emitted.push(v));
+
+      // Re-init with empty filter
+      component.initialFilter = {};
+      component.ngOnInit();
+
+      // No emission expected on init; emissions occur on user interaction
+      expect(emitted).toHaveLength(0);
+    });
+
+    it('should initialize actor input from initialFilter', () => {
+      const comp = createComponent();
+      comp.initialFilter = { actor_email: 'test@example.com' };
+      comp.ngOnInit();
+
+      expect(comp.actorInput).toBe('test@example.com');
+    });
+
+    it('should initialize http_method from initialFilter for system stream', () => {
+      const comp = createComponent({ stream: 'system' });
+      comp.initialFilter = { http_method: 'POST' };
+      comp.ngOnInit();
+
+      expect(comp.httpMethod).toBe('POST');
+    });
+
+    it('should initialize change_type from initialFilter for tm stream', () => {
+      const comp = createComponent({ stream: 'tm' });
+      comp.initialFilter = { change_type: 'created' };
+      comp.ngOnInit();
+
+      expect(comp.changeType).toBe('created');
+    });
+  });
+
+  describe('select filters emit immediately', () => {
+    it('should emit filterChange with http_method when select changes (system stream)', () => {
+      const emitted: unknown[] = [];
+      component.filterChange.subscribe(v => emitted.push(v));
+
+      component.onHttpMethodChange('PUT');
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toEqual({ http_method: 'PUT' });
+    });
+
+    it('should emit filterChange with change_type when select changes (tm stream)', () => {
+      const tmComp = createComponent({ stream: 'tm' });
+      tmComp.ngOnInit();
+      const emitted: unknown[] = [];
+      tmComp.filterChange.subscribe(v => emitted.push(v));
+
+      tmComp.onChangeTypeChange('updated');
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toEqual({ change_type: 'updated' });
+    });
+
+    it('should emit filterChange with object_type when select changes (tm stream)', () => {
+      const tmComp = createComponent({ stream: 'tm' });
+      tmComp.ngOnInit();
+      const emitted: unknown[] = [];
+      tmComp.filterChange.subscribe(v => emitted.push(v));
+
+      tmComp.onObjectTypeChange('diagram');
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toEqual({ object_type: 'diagram' });
+    });
+
+    it('should omit undefined and empty-string values from emitted filter', () => {
+      const emitted: unknown[] = [];
+      component.filterChange.subscribe(v => emitted.push(v));
+
+      // http_method is undefined initially, only set path_prefix to ''
+      component.pathPrefix = '';
+      component.onHttpMethodChange('DELETE');
+
+      expect(emitted[0]).toEqual({ http_method: 'DELETE' });
+      expect(Object.keys(emitted[0] as object)).not.toContain('path_prefix');
+    });
+  });
+
+  describe('date filter changes emit immediately', () => {
+    it('should emit filterChange with created_after date', () => {
+      const emitted: unknown[] = [];
+      component.filterChange.subscribe(v => emitted.push(v));
+
+      component.onCreatedAfterChange('2026-01-01T00:00:00.000Z');
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toEqual({ created_after: '2026-01-01T00:00:00.000Z' });
+    });
+
+    it('should emit filterChange with created_before date', () => {
+      const emitted: unknown[] = [];
+      component.filterChange.subscribe(v => emitted.push(v));
+
+      component.onCreatedBeforeChange('2026-12-31T23:59:59.000Z');
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toEqual({ created_before: '2026-12-31T23:59:59.000Z' });
+    });
+
+    it('should omit null date values from emitted filter', () => {
+      const emitted: unknown[] = [];
+      component.filterChange.subscribe(v => emitted.push(v));
+
+      component.onHttpMethodChange('POST');
+      component.onCreatedAfterChange(null);
+
+      // Second emission should not contain created_after
+      expect(Object.keys(emitted[1] as object)).not.toContain('created_after');
+    });
+  });
+
+  describe('text inputs are debounced by 300ms', () => {
+    it('should debounce actor input and emit after 300ms', () => {
+      vi.useFakeTimers();
+      const emitted: unknown[] = [];
+      component.filterChange.subscribe(v => emitted.push(v));
+
+      // Push to the actor subject
+      component.onActorInput('alice@example.com');
+
+      // Not emitted before 300ms
+      expect(emitted).toHaveLength(0);
+
+      vi.advanceTimersByTime(300);
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toEqual({ actor_email: 'alice@example.com' });
+    });
+
+    it('should debounce path_prefix input and emit after 300ms', () => {
+      vi.useFakeTimers();
+      const emitted: unknown[] = [];
+      component.filterChange.subscribe(v => emitted.push(v));
+
+      component.onPathPrefixInput('/admin');
+
+      expect(emitted).toHaveLength(0);
+
+      vi.advanceTimersByTime(300);
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toEqual({ path_prefix: '/admin' });
+    });
+
+    it('should debounce field_path input and emit after 300ms', () => {
+      vi.useFakeTimers();
+      const emitted: unknown[] = [];
+      component.filterChange.subscribe(v => emitted.push(v));
+
+      component.onFieldPathInput('users.email');
+
+      expect(emitted).toHaveLength(0);
+
+      vi.advanceTimersByTime(300);
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toEqual({ field_path: 'users.email' });
+    });
+
+    it('should debounce threat_model_id input and emit after 300ms', () => {
+      vi.useFakeTimers();
+      const tmComp = createComponent({ stream: 'tm' });
+      tmComp.ngOnInit();
+      const emitted: unknown[] = [];
+      tmComp.filterChange.subscribe(v => emitted.push(v));
+
+      tmComp.onThreatModelIdInput('tm-123');
+
+      expect(emitted).toHaveLength(0);
+
+      vi.advanceTimersByTime(300);
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toEqual({ threat_model_id: 'tm-123' });
+    });
+
+    it('should only emit the latest value within debounce window', () => {
+      vi.useFakeTimers();
+      const emitted: unknown[] = [];
+      component.filterChange.subscribe(v => emitted.push(v));
+
+      component.onActorInput('a');
+      vi.advanceTimersByTime(100);
+      component.onActorInput('al');
+      vi.advanceTimersByTime(100);
+      component.onActorInput('alice@example.com');
+      vi.advanceTimersByTime(300);
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toEqual({ actor_email: 'alice@example.com' });
+    });
+  });
+
+  describe('actor autocomplete triggers user search after debounce', () => {
+    it('should call userAdminService.list with email filter after 300ms', () => {
+      vi.useFakeTimers();
+      // Activate the cold suggestions pipeline (template subscribes via the async pipe).
+      component.actorSuggestions$.subscribe();
+
+      component.onActorInput('bob@example.com');
+      expect(mockUserAdminService.list).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(300);
+
+      expect(mockUserAdminService.list).toHaveBeenCalledWith(
+        expect.objectContaining({ email: 'bob@example.com' }),
+      );
+    });
+
+    it('should not call userAdminService.list with empty actor input', () => {
+      vi.useFakeTimers();
+
+      component.onActorInput('');
+      vi.advanceTimersByTime(300);
+
+      expect(mockUserAdminService.list).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clearFilters', () => {
+    it('should reset all controls and emit empty object', () => {
+      const emitted: unknown[] = [];
+      component.filterChange.subscribe(v => emitted.push(v));
+
+      // Set some values first
+      component.actorInput = 'someone@example.com';
+      component.httpMethod = 'POST';
+      component.pathPrefix = '/admin';
+      component.fieldPath = 'users.name';
+      component.createdAfter = '2026-01-01T00:00:00.000Z';
+      component.createdBefore = '2026-12-31T23:59:59.000Z';
+
+      component.clearFilters();
+
+      expect(component.actorInput).toBe('');
+      expect(component.httpMethod).toBeNull();
+      expect(component.pathPrefix).toBe('');
+      expect(component.fieldPath).toBe('');
+      expect(component.createdAfter).toBeNull();
+      expect(component.createdBefore).toBeNull();
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toEqual({});
+    });
+
+    it('should reset TM-only fields when stream is tm', () => {
+      const tmComp = createComponent({ stream: 'tm' });
+      tmComp.ngOnInit();
+      tmComp.changeType = 'created';
+      tmComp.objectType = 'diagram';
+      tmComp.threatModelId = 'tm-abc';
+      const emitted: unknown[] = [];
+      tmComp.filterChange.subscribe(v => emitted.push(v));
+
+      tmComp.clearFilters();
+
+      expect(tmComp.changeType).toBeNull();
+      expect(tmComp.objectType).toBeNull();
+      expect(tmComp.threatModelId).toBe('');
+      expect(emitted[0]).toEqual({});
+    });
+  });
+
+  describe('export menu (system stream only)', () => {
+    it('should expose isSystemStream=true when stream is "system"', () => {
+      expect(component.isSystemStream).toBe(true);
+    });
+
+    it('should expose isSystemStream=false when stream is "tm"', () => {
+      const tmComp = createComponent({ stream: 'tm' });
+      tmComp.ngOnInit();
+      expect(tmComp.isSystemStream).toBe(false);
+    });
+
+    it('should emit exportRequested with "csv" when onExportCsv is called', () => {
+      const emitted: unknown[] = [];
+      component.exportRequested.subscribe(v => emitted.push(v));
+
+      component.onExportCsv();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toBe('csv');
+    });
+
+    it('should emit exportRequested with "ndjson" when onExportNdjson is called', () => {
+      const emitted: unknown[] = [];
+      component.exportRequested.subscribe(v => emitted.push(v));
+
+      component.onExportNdjson();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toBe('ndjson');
+    });
+  });
+
+  describe('combined filter state', () => {
+    it('should combine multiple filter values in a single emission', () => {
+      const emitted: unknown[] = [];
+      component.filterChange.subscribe(v => emitted.push(v));
+
+      // Set http_method (immediate)
+      component.onHttpMethodChange('PATCH');
+      // Set date (immediate)
+      component.onCreatedAfterChange('2026-06-01T00:00:00.000Z');
+
+      // The second emission should include both active filters
+      expect(emitted[1]).toEqual({
+        http_method: 'PATCH',
+        created_after: '2026-06-01T00:00:00.000Z',
+      });
+    });
+  });
+});

--- a/src/app/pages/admin/audit/components/audit-filter-bar.component.ts
+++ b/src/app/pages/admin/audit/components/audit-filter-bar.component.ts
@@ -1,0 +1,328 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  EventEmitter,
+  inject,
+  Input,
+  OnInit,
+  Output,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  MatAutocompleteModule,
+  MatAutocompleteSelectedEvent,
+} from '@angular/material/autocomplete';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { Observable, of, Subject } from 'rxjs';
+import { debounceTime, switchMap } from 'rxjs/operators';
+import { TranslocoModule } from '@jsverse/transloco';
+import {
+  COMMON_IMPORTS,
+  CORE_MATERIAL_IMPORTS,
+  DATA_MATERIAL_IMPORTS,
+  FEEDBACK_MATERIAL_IMPORTS,
+  FORM_MATERIAL_IMPORTS,
+} from '@app/shared/imports';
+import { UserAdminService } from '@app/core/services/user-admin.service';
+import { LoggerService } from '@app/core/services/logger.service';
+import { AdminUser } from '@app/types/user.types';
+import {
+  AuditChangeType,
+  AuditExportFormat,
+  AuditFilter,
+  AuditHttpMethod,
+  AuditObjectType,
+  AuditStream,
+  SystemAuditFilter,
+  TmAuditFilter,
+} from '../models/admin-audit.model';
+
+/** Minimum number of chars before the actor autocomplete fires a search. */
+const ACTOR_MIN_LENGTH = 1;
+
+/**
+ * Config-driven filter bar shared by both audit views (system + threat-model).
+ * Which fields are rendered is determined by the `stream` input.
+ */
+@Component({
+  selector: 'app-audit-filter-bar',
+  standalone: true,
+  imports: [
+    ...COMMON_IMPORTS,
+    ...CORE_MATERIAL_IMPORTS,
+    ...FORM_MATERIAL_IMPORTS,
+    ...DATA_MATERIAL_IMPORTS,
+    ...FEEDBACK_MATERIAL_IMPORTS,
+    MatAutocompleteModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    TranslocoModule,
+  ],
+  templateUrl: './audit-filter-bar.component.html',
+  styleUrl: './audit-filter-bar.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AuditFilterBarComponent implements OnInit {
+  private destroyRef = inject(DestroyRef);
+
+  /** Which audit stream this bar serves — drives which fields are shown. */
+  @Input({ required: true }) stream!: AuditStream;
+
+  /** Initial filter values (e.g. restored from query params). */
+  @Input() initialFilter: AuditFilter = {};
+
+  /** Emitted whenever any filter value changes. Only non-empty values are included. */
+  @Output() filterChange = new EventEmitter<AuditFilter>();
+
+  /** Emitted when the user chooses an export format. */
+  @Output() exportRequested = new EventEmitter<AuditExportFormat>();
+
+  // ── Shared filter state ──────────────────────────────────────────────────
+
+  /** Bound to the actor autocomplete text input. */
+  actorInput = '';
+
+  /** ISO string for the created_after date picker. */
+  createdAfter: string | null = null;
+
+  /** ISO string for the created_before date picker. */
+  createdBefore: string | null = null;
+
+  /** Actor autocomplete suggestions. */
+  actorSuggestions$: Observable<AdminUser[]> = of([]);
+
+  // ── System-only filter state ─────────────────────────────────────────────
+
+  httpMethod: AuditHttpMethod | null = null;
+  pathPrefix = '';
+  fieldPath = '';
+
+  // ── TM-only filter state ─────────────────────────────────────────────────
+
+  changeType: AuditChangeType | null = null;
+  objectType: AuditObjectType | null = null;
+  threatModelId = '';
+
+  // ── Enum option lists ────────────────────────────────────────────────────
+
+  readonly httpMethods: AuditHttpMethod[] = ['POST', 'PUT', 'PATCH', 'DELETE'];
+  readonly changeTypes: AuditChangeType[] = [
+    'created',
+    'updated',
+    'patched',
+    'deleted',
+    'rolled_back',
+    'restored',
+  ];
+  readonly objectTypes: AuditObjectType[] = [
+    'threat_model',
+    'diagram',
+    'threat',
+    'asset',
+    'document',
+    'note',
+    'repository',
+  ];
+
+  // ── Internal subjects for debounced text inputs ──────────────────────────
+
+  private actorSubject$ = new Subject<string>();
+  private pathPrefixSubject$ = new Subject<string>();
+  private fieldPathSubject$ = new Subject<string>();
+  private threatModelIdSubject$ = new Subject<string>();
+
+  constructor(
+    private userAdminService: UserAdminService,
+    private logger: LoggerService,
+  ) {}
+
+  /** True when the component is operating in the system-audit stream. */
+  get isSystemStream(): boolean {
+    return this.stream === 'system';
+  }
+
+  ngOnInit(): void {
+    this._initFromFilter();
+    this._wireTextDebounce();
+    this._wireActorAutocomplete();
+  }
+
+  // ── Template event handlers ──────────────────────────────────────────────
+
+  /** Called by the actor `<input>` on every keystroke. */
+  onActorInput(value: string): void {
+    this.actorInput = value;
+    this.actorSubject$.next(value);
+  }
+
+  /** Called when the user picks a suggestion from the actor autocomplete. */
+  onActorSelected(event: MatAutocompleteSelectedEvent): void {
+    const user = event.option.value as AdminUser;
+    this.actorInput = user.email ?? '';
+    this._emit();
+  }
+
+  /** Display function for the actor autocomplete panel. */
+  displayActor = (user: AdminUser | string | null): string => {
+    if (!user) return '';
+    if (typeof user === 'string') return user;
+    return user.email ?? '';
+  };
+
+  /** Called by the http_method `<mat-select>`. */
+  onHttpMethodChange(value: AuditHttpMethod | null): void {
+    this.httpMethod = value;
+    this._emit();
+  }
+
+  /** Called by the path_prefix text input. */
+  onPathPrefixInput(value: string): void {
+    this.pathPrefix = value;
+    this.pathPrefixSubject$.next(value);
+  }
+
+  /** Called by the field_path text input. */
+  onFieldPathInput(value: string): void {
+    this.fieldPath = value;
+    this.fieldPathSubject$.next(value);
+  }
+
+  /** Called by the change_type `<mat-select>`. */
+  onChangeTypeChange(value: AuditChangeType | null): void {
+    this.changeType = value;
+    this._emit();
+  }
+
+  /** Called by the object_type `<mat-select>`. */
+  onObjectTypeChange(value: AuditObjectType | null): void {
+    this.objectType = value;
+    this._emit();
+  }
+
+  /** Called by the threat_model_id text input. */
+  onThreatModelIdInput(value: string): void {
+    this.threatModelId = value;
+    this.threatModelIdSubject$.next(value);
+  }
+
+  /** Called by the created_after date picker. */
+  onCreatedAfterChange(isoString: string | null): void {
+    this.createdAfter = isoString ?? null;
+    this._emit();
+  }
+
+  /** Called by the created_before date picker. */
+  onCreatedBeforeChange(isoString: string | null): void {
+    this.createdBefore = isoString ?? null;
+    this._emit();
+  }
+
+  /** Resets every control and emits an empty filter. */
+  clearFilters(): void {
+    this.actorInput = '';
+    this.createdAfter = null;
+    this.createdBefore = null;
+    this.httpMethod = null;
+    this.pathPrefix = '';
+    this.fieldPath = '';
+    this.changeType = null;
+    this.objectType = null;
+    this.threatModelId = '';
+    this.filterChange.emit({});
+  }
+
+  /** Emits the CSV export request. */
+  onExportCsv(): void {
+    this.exportRequested.emit('csv');
+  }
+
+  /** Emits the NDJSON export request. */
+  onExportNdjson(): void {
+    this.exportRequested.emit('ndjson');
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────────
+
+  /** Populates controls from `initialFilter` so query-param restoration works upstream. */
+  private _initFromFilter(): void {
+    const f = this.initialFilter as SystemAuditFilter & TmAuditFilter;
+    this.actorInput = f.actor_email ?? '';
+    this.createdAfter = f.created_after ?? null;
+    this.createdBefore = f.created_before ?? null;
+
+    if (this.stream === 'system') {
+      const sf = f as SystemAuditFilter;
+      this.httpMethod = sf.http_method ?? null;
+      this.pathPrefix = sf.path_prefix ?? '';
+      this.fieldPath = sf.field_path ?? '';
+    } else {
+      const tf = f as TmAuditFilter;
+      this.changeType = tf.change_type ?? null;
+      this.objectType = tf.object_type ?? null;
+      this.threatModelId = tf.threat_model_id ?? '';
+    }
+  }
+
+  /** Sets up debounced subjects for text inputs; each debounce calls `_emit()`. */
+  private _wireTextDebounce(): void {
+    this.actorSubject$
+      .pipe(debounceTime(300), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this._emit());
+
+    this.pathPrefixSubject$
+      .pipe(debounceTime(300), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this._emit());
+
+    this.fieldPathSubject$
+      .pipe(debounceTime(300), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this._emit());
+
+    this.threatModelIdSubject$
+      .pipe(debounceTime(300), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this._emit());
+  }
+
+  /** Wires the actor autocomplete search against UserAdminService. */
+  private _wireActorAutocomplete(): void {
+    this.actorSuggestions$ = this.actorSubject$.pipe(
+      debounceTime(300),
+      switchMap(term =>
+        term.length >= ACTOR_MIN_LENGTH
+          ? this.userAdminService
+              .list({ email: term, limit: 10 })
+              .pipe(switchMap(response => of(response.users)))
+          : of([]),
+      ),
+    );
+  }
+
+  /**
+   * Builds and emits the current filter, omitting any undefined/null/'' keys
+   * so that blank fields don't pollute query params.
+   */
+  private _emit(): void {
+    const raw: Record<string, string | undefined | null> = {
+      actor_email: this.actorInput || undefined,
+      created_after: this.createdAfter || undefined,
+      created_before: this.createdBefore || undefined,
+    };
+
+    if (this.stream === 'system') {
+      raw['http_method'] = this.httpMethod ?? undefined;
+      raw['path_prefix'] = this.pathPrefix || undefined;
+      raw['field_path'] = this.fieldPath || undefined;
+    } else {
+      raw['change_type'] = this.changeType ?? undefined;
+      raw['object_type'] = this.objectType ?? undefined;
+      raw['threat_model_id'] = this.threatModelId || undefined;
+    }
+
+    const filter = Object.fromEntries(
+      Object.entries(raw).filter(([, v]) => v !== undefined && v !== null && v !== ''),
+    ) as AuditFilter;
+
+    this.filterChange.emit(filter);
+  }
+}

--- a/src/app/pages/admin/audit/components/audit-table.component.html
+++ b/src/app/pages/admin/audit/components/audit-table.component.html
@@ -18,7 +18,7 @@
     @for (col of columns; track col.key) {
       <ng-container [matColumnDef]="col.key">
         <th mat-header-cell *matHeaderCellDef>{{ col.headerKey | transloco }}</th>
-        <td mat-cell *matCellDef="let row">{{ col.cell(row) }}</td>
+        <td mat-cell *matCellDef="let row">{{ cellValue(col, row) }}</td>
       </ng-container>
     }
 
@@ -27,7 +27,7 @@
       mat-row
       data-testid="audit-row"
       *matRowDef="let row; columns: displayedColumns"
-      [class.anchor-row]="row['id'] === anchorId"
+      [class.anchor-row]="rowId(row) === anchorId"
       (click)="onRowClick(row)"
     ></tr>
   </table>

--- a/src/app/pages/admin/audit/components/audit-table.component.html
+++ b/src/app/pages/admin/audit/components/audit-table.component.html
@@ -1,0 +1,43 @@
+@if (hasError) {
+  <div class="audit-error-banner">
+    <span>{{ 'admin.audit.error' | transloco }}</span>
+    <button mat-button data-testid="audit-retry" (click)="onRetryClick()">
+      {{ 'admin.audit.retry' | transloco }}
+    </button>
+  </div>
+} @else if (loading) {
+  <div class="audit-loading">
+    <mat-spinner diameter="40"></mat-spinner>
+  </div>
+} @else if (rows.length === 0) {
+  <div class="audit-empty">
+    {{ 'admin.audit.empty' | transloco }}
+  </div>
+} @else {
+  <table mat-table data-testid="audit-table" [dataSource]="rows">
+    @for (col of columns; track col.key) {
+      <ng-container [matColumnDef]="col.key">
+        <th mat-header-cell *matHeaderCellDef>{{ col.headerKey | transloco }}</th>
+        <td mat-cell *matCellDef="let row">{{ col.cell(row) }}</td>
+      </ng-container>
+    }
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr
+      mat-row
+      data-testid="audit-row"
+      *matRowDef="let row; columns: displayedColumns"
+      [class.anchor-row]="row['id'] === anchorId"
+      (click)="onRowClick(row)"
+    ></tr>
+  </table>
+
+  <div class="audit-pagination">
+    <button mat-button data-testid="audit-newer" [disabled]="!prevCursor" (click)="onNewerClick()">
+      {{ 'admin.audit.pagination.newer' | transloco }}
+    </button>
+    <button mat-button data-testid="audit-older" [disabled]="!nextCursor" (click)="onOlderClick()">
+      {{ 'admin.audit.pagination.older' | transloco }}
+    </button>
+  </div>
+}

--- a/src/app/pages/admin/audit/components/audit-table.component.scss
+++ b/src/app/pages/admin/audit/components/audit-table.component.scss
@@ -1,0 +1,39 @@
+.audit-error-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background-color: var(--mat-sys-error-container, #fde8e8);
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+
+.audit-loading {
+  display: flex;
+  justify-content: center;
+  padding: 32px;
+}
+
+.audit-empty {
+  padding: 32px;
+  text-align: center;
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.audit-pagination {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 0;
+}
+
+table {
+  width: 100%;
+}
+
+tr.anchor-row {
+  background-color: var(--mat-sys-secondary-container, #e8f0fe);
+}
+
+tr[data-testid='audit-row'] {
+  cursor: pointer;
+}

--- a/src/app/pages/admin/audit/components/audit-table.component.spec.ts
+++ b/src/app/pages/admin/audit/components/audit-table.component.spec.ts
@@ -1,0 +1,236 @@
+import '@angular/compiler';
+
+import { describe, it, expect, beforeEach, beforeAll, afterEach } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
+import { TranslocoTestingModule } from '@jsverse/transloco';
+
+import { AuditTableComponent } from './audit-table.component';
+import { AuditColumnDef } from '@app/pages/admin/audit/models/admin-audit.model';
+
+/** Two-column, two-row fixture data. */
+const TWO_COLUMNS: AuditColumnDef[] = [
+  { key: 'id', headerKey: 'admin.audit.col.id', cell: row => String(row['id']) },
+  { key: 'action', headerKey: 'admin.audit.col.action', cell: row => String(row['action']) },
+];
+
+const TWO_ROWS: Record<string, unknown>[] = [
+  { id: 'row-1', action: 'create' },
+  { id: 'row-2', action: 'delete' },
+];
+
+function buildFixture(
+  overrides: Partial<{
+    columns: AuditColumnDef[];
+    rows: Record<string, unknown>[];
+    loading: boolean;
+    nextCursor: string | null;
+    prevCursor: string | null;
+    anchorId: string | null;
+    hasError: boolean;
+  }> = {},
+): ComponentFixture<AuditTableComponent> {
+  /** Minimal i18n stub: transloco returns the key as-is. */
+  const translocoTesting = TranslocoTestingModule.forRoot({
+    langs: { en: {} },
+    translocoConfig: { availableLangs: ['en'], defaultLang: 'en' },
+    preloadLangs: true,
+  });
+
+  void TestBed.configureTestingModule({
+    imports: [AuditTableComponent, translocoTesting],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(AuditTableComponent);
+  const comp = fixture.componentInstance;
+  comp.columns = overrides.columns ?? TWO_COLUMNS;
+  comp.rows = overrides.rows ?? TWO_ROWS;
+  comp.loading = overrides.loading ?? false;
+  comp.nextCursor = overrides.nextCursor !== undefined ? overrides.nextCursor : null;
+  comp.prevCursor = overrides.prevCursor !== undefined ? overrides.prevCursor : null;
+  comp.anchorId = overrides.anchorId ?? null;
+  comp.hasError = overrides.hasError ?? false;
+  fixture.detectChanges();
+  return fixture;
+}
+
+function query<E extends Element = HTMLElement>(
+  fixture: ComponentFixture<AuditTableComponent>,
+  selector: string,
+): E {
+  return fixture.nativeElement.querySelector(selector) as E;
+}
+
+function queryAll<E extends Element = HTMLElement>(
+  fixture: ComponentFixture<AuditTableComponent>,
+  selector: string,
+): E[] {
+  return Array.from(fixture.nativeElement.querySelectorAll<E>(selector));
+}
+
+beforeAll(() => {
+  TestBed.initTestEnvironment(BrowserTestingModule, platformBrowserTesting());
+});
+
+afterEach(() => {
+  TestBed.resetTestingModule();
+});
+
+describe('AuditTableComponent', () => {
+  describe('(a) renders one row per data record', () => {
+    let fixture: ComponentFixture<AuditTableComponent>;
+
+    beforeEach(() => {
+      fixture = buildFixture();
+    });
+
+    it('should render exactly 2 audit rows', () => {
+      const rows = queryAll(fixture, '[data-testid="audit-row"]');
+      expect(rows).toHaveLength(2);
+    });
+
+    it('should render the mat-table', () => {
+      const table = query(fixture, '[data-testid="audit-table"]');
+      expect(table).not.toBeNull();
+    });
+  });
+
+  describe('(b) Newer button', () => {
+    it('is disabled when prevCursor is null', () => {
+      const fixture = buildFixture({ prevCursor: null });
+      const btn = query<HTMLButtonElement>(fixture, '[data-testid="audit-newer"]');
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('is disabled when prevCursor is undefined', () => {
+      const fixture = buildFixture({ prevCursor: undefined });
+      const btn = query<HTMLButtonElement>(fixture, '[data-testid="audit-newer"]');
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('is enabled when prevCursor is set', () => {
+      const fixture = buildFixture({ prevCursor: 'cursor-abc' });
+      const btn = query<HTMLButtonElement>(fixture, '[data-testid="audit-newer"]');
+      expect(btn.disabled).toBe(false);
+    });
+
+    it('emits newer when the handler is invoked', () => {
+      // mat-button DOM clicks don't dispatch Angular events in JSDOM; test the handler wire-up
+      const fixture = buildFixture({ prevCursor: 'cursor-abc' });
+      let count = 0;
+      fixture.componentInstance.newer.subscribe(() => count++);
+      fixture.componentInstance.onNewerClick();
+      expect(count).toBe(1);
+    });
+  });
+
+  describe('(c) Older button', () => {
+    it('is disabled when nextCursor is null', () => {
+      const fixture = buildFixture({ nextCursor: null });
+      const btn = query<HTMLButtonElement>(fixture, '[data-testid="audit-older"]');
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('is disabled when nextCursor is undefined', () => {
+      const fixture = buildFixture({ nextCursor: undefined });
+      const btn = query<HTMLButtonElement>(fixture, '[data-testid="audit-older"]');
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('is enabled when nextCursor is set', () => {
+      const fixture = buildFixture({ nextCursor: 'cursor-xyz' });
+      const btn = query<HTMLButtonElement>(fixture, '[data-testid="audit-older"]');
+      expect(btn.disabled).toBe(false);
+    });
+
+    it('emits older when the handler is invoked', () => {
+      // mat-button DOM clicks don't dispatch Angular events in JSDOM; test the handler wire-up
+      const fixture = buildFixture({ nextCursor: 'cursor-xyz' });
+      let count = 0;
+      fixture.componentInstance.older.subscribe(() => count++);
+      fixture.componentInstance.onOlderClick();
+      expect(count).toBe(1);
+    });
+  });
+
+  describe('(d) row click emits rowClick with id', () => {
+    it('emits { id } when a row is clicked', () => {
+      const fixture = buildFixture();
+      const emitted: { id: string }[] = [];
+      fixture.componentInstance.rowClick.subscribe((v: { id: string }) => emitted.push(v));
+
+      const rows = queryAll<HTMLTableRowElement>(fixture, '[data-testid="audit-row"]');
+      rows[0].click();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toEqual({ id: 'row-1' });
+    });
+
+    it('emits the correct id for the second row', () => {
+      const fixture = buildFixture();
+      const emitted: { id: string }[] = [];
+      fixture.componentInstance.rowClick.subscribe((v: { id: string }) => emitted.push(v));
+
+      const rows = queryAll<HTMLTableRowElement>(fixture, '[data-testid="audit-row"]');
+      rows[1].click();
+
+      expect(emitted[0]).toEqual({ id: 'row-2' });
+    });
+  });
+
+  describe('(e) error and empty states', () => {
+    it('shows retry button when hasError=true', () => {
+      const fixture = buildFixture({ hasError: true });
+      const retryBtn = query(fixture, '[data-testid="audit-retry"]');
+      expect(retryBtn).not.toBeNull();
+    });
+
+    it('retry button emits retry when the handler is invoked', () => {
+      // mat-button DOM clicks don't dispatch Angular events in JSDOM; test the handler wire-up
+      const fixture = buildFixture({ hasError: true });
+      let count = 0;
+      fixture.componentInstance.retry.subscribe(() => count++);
+      fixture.componentInstance.onRetryClick();
+      expect(count).toBe(1);
+    });
+
+    it('does not show the table when hasError=true', () => {
+      const fixture = buildFixture({ hasError: true });
+      const table = query(fixture, '[data-testid="audit-table"]');
+      expect(table).toBeNull();
+    });
+
+    it('shows empty message when rows=[] and no error and not loading', () => {
+      const fixture = buildFixture({ rows: [] });
+      const el = fixture.nativeElement as HTMLElement;
+      expect(el.textContent).toContain('admin.audit.empty');
+    });
+
+    it('does not show the table when rows are empty', () => {
+      const fixture = buildFixture({ rows: [] });
+      const table = query(fixture, '[data-testid="audit-table"]');
+      expect(table).toBeNull();
+    });
+
+    it('does not show retry button when no error', () => {
+      const fixture = buildFixture({ hasError: false, rows: TWO_ROWS });
+      const retryBtn = query(fixture, '[data-testid="audit-retry"]');
+      expect(retryBtn).toBeNull();
+    });
+  });
+
+  describe('(f) anchor-row class', () => {
+    it('adds anchor-row class to the row whose id matches anchorId', () => {
+      const fixture = buildFixture({ anchorId: 'row-2' });
+      const rows = queryAll<HTMLElement>(fixture, '[data-testid="audit-row"]');
+      expect(rows[0].classList.contains('anchor-row')).toBe(false);
+      expect(rows[1].classList.contains('anchor-row')).toBe(true);
+    });
+
+    it('does not add anchor-row class when anchorId is null', () => {
+      const fixture = buildFixture({ anchorId: null });
+      const rows = queryAll<HTMLElement>(fixture, '[data-testid="audit-row"]');
+      rows.forEach(row => expect(row.classList.contains('anchor-row')).toBe(false));
+    });
+  });
+});

--- a/src/app/pages/admin/audit/components/audit-table.component.ts
+++ b/src/app/pages/admin/audit/components/audit-table.component.ts
@@ -25,7 +25,7 @@ import { AuditColumnDef } from '@app/pages/admin/audit/models/admin-audit.model'
 })
 export class AuditTableComponent {
   @Input() columns: AuditColumnDef[] = [];
-  @Input() rows: Record<string, unknown>[] = [];
+  @Input() rows: readonly unknown[] = [];
   @Input() loading = false;
   @Input() nextCursor: string | null | undefined = undefined;
   @Input() prevCursor: string | null | undefined = undefined;
@@ -42,8 +42,18 @@ export class AuditTableComponent {
     return this.columns.map(c => c.key);
   }
 
-  onRowClick(row: Record<string, unknown>): void {
-    this.rowClick.emit({ id: row['id'] as string });
+  /** Renders a column's cell text for a row (widens the row to an indexable record). */
+  cellValue(col: AuditColumnDef, row: unknown): string {
+    return col.cell(row as Record<string, unknown>);
+  }
+
+  /** Extracts a row's id for anchor highlighting and click events. */
+  rowId(row: unknown): string {
+    return String((row as Record<string, unknown>)['id'] ?? '');
+  }
+
+  onRowClick(row: unknown): void {
+    this.rowClick.emit({ id: this.rowId(row) });
   }
 
   onOlderClick(): void {

--- a/src/app/pages/admin/audit/components/audit-table.component.ts
+++ b/src/app/pages/admin/audit/components/audit-table.component.ts
@@ -1,0 +1,60 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+
+import {
+  COMMON_IMPORTS,
+  CORE_MATERIAL_IMPORTS,
+  DATA_MATERIAL_IMPORTS,
+  FEEDBACK_MATERIAL_IMPORTS,
+} from '@app/shared/imports';
+import { AuditColumnDef } from '@app/pages/admin/audit/models/admin-audit.model';
+
+@Component({
+  selector: 'app-audit-table',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ...COMMON_IMPORTS,
+    ...CORE_MATERIAL_IMPORTS,
+    ...DATA_MATERIAL_IMPORTS,
+    ...FEEDBACK_MATERIAL_IMPORTS,
+    TranslocoModule,
+  ],
+  templateUrl: './audit-table.component.html',
+  styleUrl: './audit-table.component.scss',
+})
+export class AuditTableComponent {
+  @Input() columns: AuditColumnDef[] = [];
+  @Input() rows: Record<string, unknown>[] = [];
+  @Input() loading = false;
+  @Input() nextCursor: string | null | undefined = undefined;
+  @Input() prevCursor: string | null | undefined = undefined;
+  @Input() anchorId: string | null = null;
+  @Input() hasError = false;
+
+  @Output() older = new EventEmitter<void>();
+  @Output() newer = new EventEmitter<void>();
+  @Output() rowClick = new EventEmitter<{ id: string }>();
+  @Output() retry = new EventEmitter<void>();
+
+  /** Returns column keys for mat-table's displayedColumns. */
+  get displayedColumns(): string[] {
+    return this.columns.map(c => c.key);
+  }
+
+  onRowClick(row: Record<string, unknown>): void {
+    this.rowClick.emit({ id: row['id'] as string });
+  }
+
+  onOlderClick(): void {
+    this.older.emit();
+  }
+
+  onNewerClick(): void {
+    this.newer.emit();
+  }
+
+  onRetryClick(): void {
+    this.retry.emit();
+  }
+}

--- a/src/app/pages/admin/audit/components/audit-table.component.ts
+++ b/src/app/pages/admin/audit/components/audit-table.component.ts
@@ -49,7 +49,7 @@ export class AuditTableComponent {
 
   /** Extracts a row's id for anchor highlighting and click events. */
   rowId(row: unknown): string {
-    return String((row as Record<string, unknown>)['id'] ?? '');
+    return (row as { id?: string }).id ?? '';
   }
 
   onRowClick(row: unknown): void {

--- a/src/app/pages/admin/audit/models/admin-audit.model.ts
+++ b/src/app/pages/admin/audit/models/admin-audit.model.ts
@@ -77,3 +77,13 @@ export type AuditExportFormat = 'csv' | 'ndjson';
 
 /** Which audit stream a shared component is operating on. */
 export type AuditStream = 'system' | 'tm';
+
+/** A column definition for the audit table: how to render one column. */
+export interface AuditColumnDef {
+  /** Unique column key (used for matColumnDef + displayedColumns). */
+  key: string;
+  /** i18n key for the column header. */
+  headerKey: string;
+  /** Renders the cell text for a given row. */
+  cell: (row: Record<string, unknown>) => string;
+}

--- a/src/app/pages/admin/audit/models/admin-audit.model.ts
+++ b/src/app/pages/admin/audit/models/admin-audit.model.ts
@@ -3,14 +3,14 @@
  * published on tmi dev/1.4.0 (tmi#398 + tmi#464). Hand-written because the
  * generated api-types.d.ts is built from tmi main, which lacks these schemas.
  */
-import {
+import type {
   AuditActor,
   AuditChangeType,
   AuditEntry,
   AuditObjectType,
 } from '@app/pages/tm/models/audit-trail.model';
 
-export { AuditActor, AuditChangeType, AuditEntry, AuditObjectType };
+export type { AuditActor, AuditChangeType, AuditEntry, AuditObjectType };
 
 /** HTTP methods recorded by the system audit log. */
 export type AuditHttpMethod = 'POST' | 'PUT' | 'PATCH' | 'DELETE';

--- a/src/app/pages/admin/audit/models/admin-audit.model.ts
+++ b/src/app/pages/admin/audit/models/admin-audit.model.ts
@@ -1,0 +1,79 @@
+/**
+ * Types for the admin audit-log UI (tmi-ux#679), matching the server contract
+ * published on tmi dev/1.4.0 (tmi#398 + tmi#464). Hand-written because the
+ * generated api-types.d.ts is built from tmi main, which lacks these schemas.
+ */
+import {
+  AuditActor,
+  AuditChangeType,
+  AuditEntry,
+  AuditObjectType,
+} from '@app/pages/tm/models/audit-trail.model';
+
+export { AuditActor, AuditChangeType, AuditEntry, AuditObjectType };
+
+/** HTTP methods recorded by the system audit log. */
+export type AuditHttpMethod = 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+/** A system audit entry: an immutable record of a successful /admin/* write. */
+export interface SystemAuditEntry {
+  id: string;
+  actor: AuditActor;
+  http_method: string;
+  http_path: string;
+  field_path: string;
+  old_value_redacted: string | null;
+  new_value_redacted: string | null;
+  change_summary: string | null;
+  created_at: string;
+}
+
+/** Common cursor-paginated list envelope returned by both audit list endpoints. */
+export interface AuditListResponse<T> {
+  entries: T[];
+  total: number;
+  limit: number;
+  /** Cursor for the next (older) page; null/absent when exhausted. */
+  next_cursor?: string | null;
+  /** Cursor for the previous (newer) page; null/absent at the newest end. */
+  prev_cursor?: string | null;
+}
+
+export type ListSystemAuditResponse = AuditListResponse<SystemAuditEntry>;
+export type ListTmAuditResponse = AuditListResponse<AuditEntry>;
+
+/** Active filters for the system audit list. All optional. */
+export interface SystemAuditFilter {
+  actor_email?: string;
+  actor_provider?: string;
+  created_after?: string;
+  created_before?: string;
+  http_method?: AuditHttpMethod;
+  path_prefix?: string;
+  field_path?: string;
+}
+
+/** Active filters for the threat-model audit list. All optional. */
+export interface TmAuditFilter {
+  actor_email?: string;
+  actor_provider?: string;
+  created_after?: string;
+  created_before?: string;
+  change_type?: AuditChangeType;
+  object_type?: AuditObjectType;
+  threat_model_id?: string;
+}
+
+export type AuditFilter = SystemAuditFilter | TmAuditFilter;
+
+/** Pagination request: forward/back cursor traversal OR around-anchor. Mutually exclusive cursor/around. */
+export interface AuditPageRequest {
+  limit?: number;
+  cursor?: string;
+  around?: string;
+}
+
+export type AuditExportFormat = 'csv' | 'ndjson';
+
+/** Which audit stream a shared component is operating on. */
+export type AuditStream = 'system' | 'tm';

--- a/src/app/pages/admin/audit/views/system-audit-view.component.html
+++ b/src/app/pages/admin/audit/views/system-audit-view.component.html
@@ -1,0 +1,24 @@
+<div class="system-audit-view">
+  <app-audit-filter-bar
+    [stream]="stream"
+    [initialFilter]="filter"
+    (filterChange)="onFilterChange($event)"
+    (exportRequested)="onExport($event)"
+  ></app-audit-filter-bar>
+
+  <app-audit-table
+    [columns]="columns"
+    [rows]="rows"
+    [loading]="loading"
+    [nextCursor]="nextCursor"
+    [prevCursor]="prevCursor"
+    [anchorId]="anchorId"
+    [hasError]="hasError"
+    (older)="onOlder()"
+    (newer)="onNewer()"
+    (rowClick)="onRowClick($event)"
+    (retry)="onRetry()"
+  ></app-audit-table>
+
+  <router-outlet></router-outlet>
+</div>

--- a/src/app/pages/admin/audit/views/system-audit-view.component.scss
+++ b/src/app/pages/admin/audit/views/system-audit-view.component.scss
@@ -1,0 +1,6 @@
+.system-audit-view {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+}

--- a/src/app/pages/admin/audit/views/system-audit-view.component.spec.ts
+++ b/src/app/pages/admin/audit/views/system-audit-view.component.spec.ts
@@ -1,0 +1,389 @@
+import '@angular/compiler';
+
+import { vi, expect, afterEach, beforeEach, describe, it } from 'vitest';
+import { ChangeDetectorRef, DestroyRef, Injector, runInInjectionContext } from '@angular/core';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
+import { BehaviorSubject, of, throwError } from 'rxjs';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { TranslocoService } from '@jsverse/transloco';
+
+import { SystemAuditViewComponent } from './system-audit-view.component';
+import { createTypedMockLoggerService, createTypedMockRouter } from '@testing/mocks';
+import type { MockLoggerService, MockRouter } from '@testing/mocks';
+import { LoggerService } from '@app/core/services/logger.service';
+import { AdminAuditService } from '@app/pages/admin/audit/admin-audit.service';
+import type { SystemAuditEntry } from '@app/pages/admin/audit/models/admin-audit.model';
+
+// ── vi.mock for downloadBlob ──────────────────────────────────────────────────
+
+vi.mock('@app/shared/utils/blob-download.util', () => ({
+  downloadBlob: vi.fn(),
+}));
+
+// Import after mock so we get the mocked version
+import { downloadBlob } from '@app/shared/utils/blob-download.util';
+
+// ── Fixture data ──────────────────────────────────────────────────────────────
+
+const ENTRY_1: SystemAuditEntry = {
+  id: 'sys-1',
+  actor: {
+    email: 'admin@example.com',
+    provider: 'google',
+    provider_id: 'g1',
+    display_name: 'Admin',
+  },
+  http_method: 'PATCH',
+  http_path: '/admin/users/1',
+  field_path: 'role',
+  old_value_redacted: 'viewer',
+  new_value_redacted: 'admin',
+  change_summary: 'Role changed',
+  created_at: '2026-01-01T12:00:00Z',
+};
+
+const ENTRY_2: SystemAuditEntry = {
+  id: 'sys-2',
+  actor: { email: 'user@example.com', provider: 'local', provider_id: 'l1', display_name: 'User' },
+  http_method: 'DELETE',
+  http_path: '/admin/users/2',
+  field_path: '',
+  old_value_redacted: null,
+  new_value_redacted: null,
+  change_summary: 'User deleted',
+  created_at: '2026-01-02T08:00:00Z',
+};
+
+function makeListResponse(
+  entries: SystemAuditEntry[] = [ENTRY_1],
+  opts: { total?: number; next_cursor?: string | null; prev_cursor?: string | null } = {},
+): {
+  entries: SystemAuditEntry[];
+  total: number;
+  limit: number;
+  next_cursor: string | null;
+  prev_cursor: string | null;
+} {
+  return {
+    entries,
+    total: opts.total ?? entries.length,
+    limit: 50,
+    next_cursor: opts.next_cursor ?? null,
+    prev_cursor: opts.prev_cursor ?? null,
+  };
+}
+
+// ── Build mocks / injector helper ─────────────────────────────────────────────
+
+function buildMocks(
+  options: {
+    queryParams?: Record<string, string>;
+    listResponse?: ReturnType<typeof makeListResponse>;
+    listError?: unknown;
+    exportResponse?: Blob;
+    exportError?: unknown;
+  } = {},
+): {
+  injector: Injector;
+  queryParamMapSubject: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+  mockRoute: {
+    snapshot: { queryParams: Record<string, string> };
+    queryParamMap: ReturnType<typeof BehaviorSubject.prototype.asObservable>;
+  };
+  mockRouter: MockRouter;
+  mockAuditService: Partial<AdminAuditService>;
+  mockLogger: MockLoggerService;
+  mockSnackBar: { open: ReturnType<typeof vi.fn> };
+  mockCdr: { markForCheck: ReturnType<typeof vi.fn> };
+} {
+  const queryParams = options.queryParams ?? {};
+  const queryParamMapSubject = new BehaviorSubject(convertToParamMap(queryParams));
+
+  const mockRoute = {
+    snapshot: { queryParams },
+    queryParamMap: queryParamMapSubject.asObservable(),
+  };
+
+  const mockRouter = createTypedMockRouter('/admin/audit/system') as MockRouter;
+  const mockLogger = createTypedMockLoggerService();
+
+  const listResponse = options.listResponse ?? makeListResponse();
+  const mockAuditService: Partial<AdminAuditService> = {
+    listSystem: options.listError
+      ? vi.fn().mockReturnValue(throwError(() => options.listError))
+      : vi.fn().mockReturnValue(of(listResponse)),
+    exportSystem: options.exportError
+      ? vi.fn().mockReturnValue(throwError(() => options.exportError))
+      : vi
+          .fn()
+          .mockReturnValue(of(options.exportResponse ?? new Blob(['data'], { type: 'text/csv' }))),
+  };
+
+  const mockDestroyRef = { onDestroy: vi.fn() };
+  const mockCdr = { markForCheck: vi.fn() };
+  const mockSnackBar = { open: vi.fn() };
+  const mockTransloco = { translate: vi.fn((key: string) => key) };
+
+  const injector = Injector.create({
+    providers: [
+      { provide: DestroyRef, useValue: mockDestroyRef },
+      { provide: ChangeDetectorRef, useValue: mockCdr },
+      { provide: ActivatedRoute, useValue: mockRoute },
+      { provide: Router, useValue: mockRouter },
+      { provide: AdminAuditService, useValue: mockAuditService },
+      { provide: LoggerService, useValue: mockLogger },
+      { provide: MatSnackBar, useValue: mockSnackBar },
+      { provide: TranslocoService, useValue: mockTransloco },
+    ],
+  });
+
+  return {
+    injector,
+    queryParamMapSubject,
+    mockRoute,
+    mockRouter,
+    mockAuditService,
+    mockLogger,
+    mockSnackBar,
+    mockCdr,
+  };
+}
+
+function createComponent(injector: Injector): SystemAuditViewComponent {
+  const comp = runInInjectionContext(injector, () => new SystemAuditViewComponent());
+  comp.ngOnInit();
+  return comp;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('SystemAuditViewComponent', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('(a) loads system entries on init (no around) and sets rows/total/cursors', () => {
+    let comp: SystemAuditViewComponent;
+    let mocks: ReturnType<typeof buildMocks>;
+
+    beforeEach(() => {
+      mocks = buildMocks({
+        listResponse: makeListResponse([ENTRY_1, ENTRY_2], {
+          total: 2,
+          next_cursor: 'cursor-next',
+          prev_cursor: 'cursor-prev',
+        }),
+      });
+      comp = createComponent(mocks.injector);
+    });
+
+    it('should create the component', () => {
+      expect(comp).toBeTruthy();
+    });
+
+    it('should call listSystem with empty filter and limit on init', () => {
+      expect(mocks.mockAuditService.listSystem).toHaveBeenCalledWith({}, { limit: 50 });
+    });
+
+    it('should set rows from service response', () => {
+      expect(comp.rows).toEqual([ENTRY_1, ENTRY_2]);
+    });
+
+    it('should set total from service response', () => {
+      expect(comp.total).toBe(2);
+    });
+
+    it('should set nextCursor from service response', () => {
+      expect(comp.nextCursor).toBe('cursor-next');
+    });
+
+    it('should set prevCursor from service response', () => {
+      expect(comp.prevCursor).toBe('cursor-prev');
+    });
+
+    it('should set loading=false after load completes', () => {
+      expect(comp.loading).toBe(false);
+    });
+
+    it('should set hasError=false on successful load', () => {
+      expect(comp.hasError).toBe(false);
+    });
+
+    it('should not set anchorId when there is no around param', () => {
+      expect(comp.anchorId).toBeNull();
+    });
+
+    it('should expose the stream as system', () => {
+      expect(comp.stream).toBe('system');
+    });
+  });
+
+  describe('(b) onFilterChange sets filter, resets anchorId, reloads and mirrors URL', () => {
+    let comp: SystemAuditViewComponent;
+    let mocks: ReturnType<typeof buildMocks>;
+
+    beforeEach(() => {
+      mocks = buildMocks();
+      comp = createComponent(mocks.injector);
+      vi.clearAllMocks();
+    });
+
+    it('should set the new filter', () => {
+      comp.onFilterChange({ actor_email: 'test@example.com' });
+      expect(comp.filter).toEqual({ actor_email: 'test@example.com' });
+    });
+
+    it('should reset anchorId to null', () => {
+      comp.anchorId = 'some-anchor';
+      comp.onFilterChange({ actor_email: 'test@example.com' });
+      expect(comp.anchorId).toBeNull();
+    });
+
+    it('should call listSystem with the new filter and limit', () => {
+      comp.onFilterChange({ actor_email: 'test@example.com' });
+      expect(mocks.mockAuditService.listSystem).toHaveBeenCalledWith(
+        { actor_email: 'test@example.com' },
+        { limit: 50 },
+      );
+    });
+
+    it('should call router.navigate with [] for URL mirroring', () => {
+      comp.onFilterChange({ actor_email: 'test@example.com' });
+      expect(mocks.mockRouter.navigate).toHaveBeenCalledWith(
+        [],
+        expect.objectContaining({
+          relativeTo: mocks.mockRoute,
+          replaceUrl: true,
+        }),
+      );
+    });
+  });
+
+  describe('(c) onOlder and onNewer pass the correct cursor', () => {
+    let comp: SystemAuditViewComponent;
+    let mocks: ReturnType<typeof buildMocks>;
+
+    beforeEach(() => {
+      mocks = buildMocks({
+        listResponse: makeListResponse([ENTRY_1], {
+          next_cursor: 'next-42',
+          prev_cursor: 'prev-42',
+        }),
+      });
+      comp = createComponent(mocks.injector);
+      vi.clearAllMocks();
+    });
+
+    it('onOlder() calls listSystem with cursor = nextCursor', () => {
+      comp.onOlder();
+      expect(mocks.mockAuditService.listSystem).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ cursor: 'next-42' }),
+      );
+    });
+
+    it('onNewer() calls listSystem with cursor = prevCursor', () => {
+      comp.onNewer();
+      expect(mocks.mockAuditService.listSystem).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ cursor: 'prev-42' }),
+      );
+    });
+  });
+
+  describe('(d) around query param on init triggers listSystem with { around } and sets anchorId', () => {
+    it('should set anchorId from the around param', () => {
+      const mocks = buildMocks({ queryParams: { around: 'sys-anchor-1' } });
+      const comp = createComponent(mocks.injector);
+      expect(comp.anchorId).toBe('sys-anchor-1');
+    });
+
+    it('should call listSystem with around in page request', () => {
+      const mocks = buildMocks({ queryParams: { around: 'sys-anchor-1' } });
+      createComponent(mocks.injector);
+      expect(mocks.mockAuditService.listSystem).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ around: 'sys-anchor-1', limit: 50 }),
+      );
+    });
+
+    it('should also restore filter keys from query params', () => {
+      const mocks = buildMocks({
+        queryParams: { actor_email: 'a@b.com', http_method: 'PATCH' },
+      });
+      const comp = createComponent(mocks.injector);
+      expect(comp.filter).toEqual({ actor_email: 'a@b.com', http_method: 'PATCH' });
+    });
+  });
+
+  describe('(e) onExport calls exportSystem and downloadBlob', () => {
+    it('should call exportSystem with the current filter and format', () => {
+      const mocks = buildMocks();
+      const comp = createComponent(mocks.injector);
+      comp.onExport('csv');
+      expect(mocks.mockAuditService.exportSystem).toHaveBeenCalledWith({}, 'csv');
+    });
+
+    it('should call downloadBlob with a .csv filename for csv format', () => {
+      const mocks = buildMocks();
+      const comp = createComponent(mocks.injector);
+      comp.onExport('csv');
+      expect(downloadBlob).toHaveBeenCalledWith(
+        expect.any(Blob),
+        expect.stringMatching(/^system-audit-.*\.csv$/),
+      );
+    });
+
+    it('should call downloadBlob with a .ndjson filename for ndjson format', () => {
+      const mocks = buildMocks({
+        exportResponse: new Blob(['{}'], { type: 'application/x-ndjson' }),
+      });
+      const comp = createComponent(mocks.injector);
+      comp.onExport('ndjson');
+      expect(downloadBlob).toHaveBeenCalledWith(
+        expect.any(Blob),
+        expect.stringMatching(/^system-audit-.*\.ndjson$/),
+      );
+    });
+
+    it('should log and open snackBar on export error', () => {
+      const exportErr = new Error('export failed');
+      const mocks = buildMocks({ exportError: exportErr });
+      const comp = createComponent(mocks.injector);
+      comp.onExport('csv');
+      expect(mocks.mockLogger.error).toHaveBeenCalled();
+      expect(mocks.mockSnackBar.open).toHaveBeenCalled();
+    });
+  });
+
+  describe('(f) onRowClick navigates to [id] relative to route', () => {
+    it('should call router.navigate with [id] relativeTo route', () => {
+      const mocks = buildMocks();
+      const comp = createComponent(mocks.injector);
+      comp.onRowClick({ id: 'sys-99' });
+      expect(mocks.mockRouter.navigate).toHaveBeenCalledWith(['sys-99'], {
+        relativeTo: mocks.mockRoute,
+      });
+    });
+  });
+
+  describe('(g) service error sets hasError=true', () => {
+    it('should set hasError=true when listSystem throws', () => {
+      const mocks = buildMocks({ listError: new Error('server error') });
+      const comp = createComponent(mocks.injector);
+      expect(comp.hasError).toBe(true);
+    });
+
+    it('should set loading=false on error', () => {
+      const mocks = buildMocks({ listError: new Error('server error') });
+      const comp = createComponent(mocks.injector);
+      expect(comp.loading).toBe(false);
+    });
+
+    it('should log the error', () => {
+      const mocks = buildMocks({ listError: new Error('server error') });
+      createComponent(mocks.injector);
+      expect(mocks.mockLogger.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/pages/admin/audit/views/system-audit-view.component.ts
+++ b/src/app/pages/admin/audit/views/system-audit-view.component.ts
@@ -83,6 +83,9 @@ export class SystemAuditViewComponent implements OnInit {
   hasError = false;
   anchorId: string | null = null;
 
+  /** The most recent page request, replayed by retry. */
+  private lastPage: AuditPageRequest = {};
+
   readonly limit = 50;
   readonly stream = 'system' as const;
 
@@ -175,14 +178,18 @@ export class SystemAuditViewComponent implements OnInit {
     this.updateUrl();
   }
 
-  /** Navigate to an older (earlier) page using the next cursor. */
+  /** Navigate to an older (earlier) page using the next cursor. Leaves around mode. */
   onOlder(): void {
+    this.anchorId = null;
     this.load({ cursor: this.nextCursor ?? undefined });
+    this.updateUrl();
   }
 
-  /** Navigate to a newer (later) page using the prev cursor. */
+  /** Navigate to a newer (later) page using the prev cursor. Leaves around mode. */
   onNewer(): void {
+    this.anchorId = null;
     this.load({ cursor: this.prevCursor ?? undefined });
+    this.updateUrl();
   }
 
   /** Navigate into the detail panel for the clicked row. */
@@ -190,9 +197,9 @@ export class SystemAuditViewComponent implements OnInit {
     void this.router.navigate([e.id], { relativeTo: this.route });
   }
 
-  /** Retry the most recent load (simplest: reload the newest page). */
+  /** Retry the most recent load, preserving the current page position. */
   onRetry(): void {
-    this.load({ limit: this.limit });
+    this.load(this.lastPage);
   }
 
   /** Export the current filtered view in the chosen format. */
@@ -201,25 +208,29 @@ export class SystemAuditViewComponent implements OnInit {
     const ext = format === 'csv' ? 'csv' : 'ndjson';
     const filename = `system-audit-${timestamp}.${ext}`;
 
-    this.auditService.exportSystem(this.filter, format).subscribe({
-      next: (blob: Blob) => {
-        downloadBlob(blob, filename);
-      },
-      error: (e: unknown) => {
-        this.logger.error('Failed to export system audit', e);
-        this.snackBar.open(
-          this.transloco.translate('admin.audit.export.error'),
-          this.transloco.translate('common.dismiss'),
-          { duration: 5000 },
-        );
-      },
-    });
+    this.auditService
+      .exportSystem(this.filter, format)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (blob: Blob) => {
+          downloadBlob(blob, filename);
+        },
+        error: (e: unknown) => {
+          this.logger.error('Failed to export system audit', e);
+          this.snackBar.open(
+            this.transloco.translate('admin.audit.export.error'),
+            this.transloco.translate('common.dismiss'),
+            { duration: 5000 },
+          );
+        },
+      });
   }
 
   // ── Private helpers ──────────────────────────────────────────────────────
 
   /** Load a page of entries; sets loading/error state and triggers change detection. */
   private load(page: AuditPageRequest): void {
+    this.lastPage = page;
     this.loading = true;
     this.hasError = false;
     this.cdr.markForCheck();

--- a/src/app/pages/admin/audit/views/system-audit-view.component.ts
+++ b/src/app/pages/admin/audit/views/system-audit-view.component.ts
@@ -1,0 +1,277 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  inject,
+  OnInit,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router, RouterOutlet } from '@angular/router';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
+
+import {
+  COMMON_IMPORTS,
+  CORE_MATERIAL_IMPORTS,
+  FEEDBACK_MATERIAL_IMPORTS,
+} from '@app/shared/imports';
+import { LoggerService } from '@app/core/services/logger.service';
+import { AdminAuditService } from '@app/pages/admin/audit/admin-audit.service';
+import {
+  AuditColumnDef,
+  AuditExportFormat,
+  AuditPageRequest,
+  SystemAuditEntry,
+  SystemAuditFilter,
+} from '@app/pages/admin/audit/models/admin-audit.model';
+import { AuditFilterBarComponent } from '@app/pages/admin/audit/components/audit-filter-bar.component';
+import { AuditTableComponent } from '@app/pages/admin/audit/components/audit-table.component';
+import { downloadBlob } from '@app/shared/utils/blob-download.util';
+
+/** System filter query-param keys recognised from the URL. */
+const SYSTEM_FILTER_KEYS: (keyof SystemAuditFilter)[] = [
+  'actor_email',
+  'actor_provider',
+  'created_after',
+  'created_before',
+  'http_method',
+  'path_prefix',
+  'field_path',
+];
+
+/**
+ * System audit view: owns state, composes the filter bar, audit table,
+ * and a router-outlet for the detail panel child route.
+ * Query params are mirrored to/from the URL for bookmarkability.
+ */
+@Component({
+  selector: 'app-system-audit-view',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ...COMMON_IMPORTS,
+    ...CORE_MATERIAL_IMPORTS,
+    ...FEEDBACK_MATERIAL_IMPORTS,
+    MatSnackBarModule,
+    TranslocoModule,
+    RouterOutlet,
+    AuditFilterBarComponent,
+    AuditTableComponent,
+  ],
+  templateUrl: './system-audit-view.component.html',
+  styleUrl: './system-audit-view.component.scss',
+})
+export class SystemAuditViewComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private auditService = inject(AdminAuditService);
+  private logger = inject(LoggerService);
+  private snackBar = inject(MatSnackBar);
+  private cdr = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
+  private transloco = inject(TranslocoService);
+
+  // ── Public state (used by template and tests) ────────────────────────────
+
+  filter: SystemAuditFilter = {};
+  rows: SystemAuditEntry[] = [];
+  total = 0;
+  nextCursor: string | null = null;
+  prevCursor: string | null = null;
+  loading = false;
+  hasError = false;
+  anchorId: string | null = null;
+
+  readonly limit = 50;
+  readonly stream = 'system' as const;
+
+  readonly columns: AuditColumnDef[] = [
+    {
+      key: 'created_at',
+      headerKey: 'admin.audit.columns.timestamp',
+      cell: (r: Record<string, unknown>) => (r['created_at'] as string | null | undefined) ?? '',
+    },
+    {
+      key: 'actor',
+      headerKey: 'admin.audit.columns.actor',
+      cell: (r: Record<string, unknown>) => {
+        const a = r['actor'] as { display_name?: string; email?: string } | undefined;
+        return a?.display_name || a?.email || '';
+      },
+    },
+    {
+      key: 'request',
+      headerKey: 'admin.audit.columns.request',
+      cell: (r: Record<string, unknown>) => {
+        const method = (r['http_method'] as string | null | undefined) ?? '';
+        const path = (r['http_path'] as string | null | undefined) ?? '';
+        return `${method} ${path}`.trim();
+      },
+    },
+    {
+      key: 'field_path',
+      headerKey: 'admin.audit.columns.fieldPath',
+      cell: (r: Record<string, unknown>) => (r['field_path'] as string | null | undefined) ?? '',
+    },
+    {
+      key: 'change_summary',
+      headerKey: 'admin.audit.columns.changeSummary',
+      cell: (r: Record<string, unknown>) =>
+        (r['change_summary'] as string | null | undefined) ?? '',
+    },
+  ];
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────
+
+  ngOnInit(): void {
+    // Read initial state from a snapshot so we don't create a reload loop.
+    // Then subscribe to queryParamMap for subsequent navigation changes
+    // (e.g. the detail panel's "view in context" sets `around`).
+    const snapshot = this.route.snapshot.queryParams as Record<string, string>;
+    this._applyQueryParams(snapshot);
+
+    const around = snapshot['around'];
+    if (around) {
+      this.anchorId = around;
+      this.load({ around, limit: this.limit });
+    } else {
+      this.load({ limit: this.limit });
+    }
+
+    // Subscribe for subsequent param changes (detail panel sets `around`).
+    this.route.queryParamMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(paramMap => {
+      const newAround = paramMap.get('around');
+      // Rebuild filter from current params
+      const params: Record<string, string> = {};
+      paramMap.keys.forEach(k => {
+        const v = paramMap.get(k);
+        if (v !== null) params[k] = v;
+      });
+      const newFilter = this._buildFilter(params);
+      const filterChanged =
+        JSON.stringify(newFilter) !== JSON.stringify(this.filter) || newAround !== this.anchorId;
+
+      if (!filterChanged) return; // guard against the initial emit
+
+      this.filter = newFilter;
+      if (newAround) {
+        this.anchorId = newAround;
+        this.load({ around: newAround, limit: this.limit });
+      } else {
+        this.anchorId = null;
+        this.load({ limit: this.limit });
+      }
+    });
+  }
+
+  // ── Event handlers ───────────────────────────────────────────────────────
+
+  /** Called by the filter bar when any filter value changes. */
+  onFilterChange(f: SystemAuditFilter): void {
+    this.filter = f;
+    this.anchorId = null;
+    this.load({ limit: this.limit });
+    this.updateUrl();
+  }
+
+  /** Navigate to an older (earlier) page using the next cursor. */
+  onOlder(): void {
+    this.load({ cursor: this.nextCursor ?? undefined });
+  }
+
+  /** Navigate to a newer (later) page using the prev cursor. */
+  onNewer(): void {
+    this.load({ cursor: this.prevCursor ?? undefined });
+  }
+
+  /** Navigate into the detail panel for the clicked row. */
+  onRowClick(e: { id: string }): void {
+    void this.router.navigate([e.id], { relativeTo: this.route });
+  }
+
+  /** Retry the most recent load (simplest: reload the newest page). */
+  onRetry(): void {
+    this.load({ limit: this.limit });
+  }
+
+  /** Export the current filtered view in the chosen format. */
+  onExport(format: AuditExportFormat): void {
+    const timestamp = new Date().toISOString();
+    const ext = format === 'csv' ? 'csv' : 'ndjson';
+    const filename = `system-audit-${timestamp}.${ext}`;
+
+    this.auditService.exportSystem(this.filter, format).subscribe({
+      next: (blob: Blob) => {
+        downloadBlob(blob, filename);
+      },
+      error: (e: unknown) => {
+        this.logger.error('Failed to export system audit', e);
+        this.snackBar.open(
+          this.transloco.translate('admin.audit.export.error'),
+          this.transloco.translate('common.dismiss'),
+          { duration: 5000 },
+        );
+      },
+    });
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────────
+
+  /** Load a page of entries; sets loading/error state and triggers change detection. */
+  private load(page: AuditPageRequest): void {
+    this.loading = true;
+    this.hasError = false;
+    this.cdr.markForCheck();
+
+    this.auditService
+      .listSystem(this.filter, { ...page, limit: this.limit })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: resp => {
+          this.rows = resp.entries;
+          this.total = resp.total;
+          this.nextCursor = resp.next_cursor ?? null;
+          this.prevCursor = resp.prev_cursor ?? null;
+          this.loading = false;
+          this.cdr.markForCheck();
+        },
+        error: (e: unknown) => {
+          this.hasError = true;
+          this.loading = false;
+          this.logger.error('Failed to load system audit entries', e);
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  /** Mirror the current filter (without cursor/around) to the URL. */
+  private updateUrl(): void {
+    const queryParams: Record<string, string | undefined> = {};
+    for (const key of SYSTEM_FILTER_KEYS) {
+      queryParams[key] = this.filter[key];
+    }
+
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams,
+      queryParamsHandling: '',
+      replaceUrl: true,
+    });
+  }
+
+  /** Extract filter values from a raw query-params map. */
+  private _buildFilter(params: Record<string, string>): SystemAuditFilter {
+    const f: SystemAuditFilter = {};
+    for (const key of SYSTEM_FILTER_KEYS) {
+      const v = params[key];
+      if (v) (f as Record<string, string>)[key] = v;
+    }
+    return f;
+  }
+
+  /** Apply snapshot query params to `this.filter` (without triggering a reload). */
+  private _applyQueryParams(params: Record<string, string>): void {
+    this.filter = this._buildFilter(params);
+  }
+}

--- a/src/app/pages/admin/audit/views/tm-audit-view.component.html
+++ b/src/app/pages/admin/audit/views/tm-audit-view.component.html
@@ -1,0 +1,23 @@
+<div class="tm-audit-view">
+  <app-audit-filter-bar
+    [stream]="stream"
+    [initialFilter]="filter"
+    (filterChange)="onFilterChange($event)"
+  ></app-audit-filter-bar>
+
+  <app-audit-table
+    [columns]="columns"
+    [rows]="rows"
+    [loading]="loading"
+    [nextCursor]="nextCursor"
+    [prevCursor]="prevCursor"
+    [anchorId]="anchorId"
+    [hasError]="hasError"
+    (older)="onOlder()"
+    (newer)="onNewer()"
+    (rowClick)="onRowClick($event)"
+    (retry)="onRetry()"
+  ></app-audit-table>
+
+  <router-outlet></router-outlet>
+</div>

--- a/src/app/pages/admin/audit/views/tm-audit-view.component.scss
+++ b/src/app/pages/admin/audit/views/tm-audit-view.component.scss
@@ -1,0 +1,6 @@
+.tm-audit-view {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+}

--- a/src/app/pages/admin/audit/views/tm-audit-view.component.spec.ts
+++ b/src/app/pages/admin/audit/views/tm-audit-view.component.spec.ts
@@ -1,0 +1,330 @@
+import '@angular/compiler';
+
+import { vi, expect, afterEach, beforeEach, describe, it } from 'vitest';
+import { ChangeDetectorRef, DestroyRef, Injector, runInInjectionContext } from '@angular/core';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
+import { BehaviorSubject, of, throwError } from 'rxjs';
+
+import { TmAuditViewComponent } from './tm-audit-view.component';
+import { createTypedMockLoggerService, createTypedMockRouter } from '@testing/mocks';
+import type { MockLoggerService, MockRouter } from '@testing/mocks';
+import { LoggerService } from '@app/core/services/logger.service';
+import { AdminAuditService } from '@app/pages/admin/audit/admin-audit.service';
+import type { AuditEntry } from '@app/pages/admin/audit/models/admin-audit.model';
+
+// ── Fixture data ──────────────────────────────────────────────────────────────
+
+const ENTRY_1: AuditEntry = {
+  id: 'tm-1',
+  threat_model_id: 'tm-model-1',
+  object_type: 'threat_model',
+  object_id: 'obj-1',
+  version: 1,
+  change_type: 'created',
+  actor: {
+    email: 'admin@example.com',
+    provider: 'google',
+    provider_id: 'g1',
+    display_name: 'Admin',
+  },
+  change_summary: 'Threat model created',
+  created_at: '2026-01-01T12:00:00Z',
+};
+
+const ENTRY_2: AuditEntry = {
+  id: 'tm-2',
+  threat_model_id: 'tm-model-1',
+  object_type: 'diagram',
+  object_id: 'obj-2',
+  version: 2,
+  change_type: 'updated',
+  actor: {
+    email: 'user@example.com',
+    provider: 'local',
+    provider_id: 'l1',
+    display_name: 'User',
+  },
+  change_summary: 'Diagram updated',
+  created_at: '2026-01-02T08:00:00Z',
+};
+
+function makeListResponse(
+  entries: AuditEntry[] = [ENTRY_1],
+  opts: { total?: number; next_cursor?: string | null; prev_cursor?: string | null } = {},
+): {
+  entries: AuditEntry[];
+  total: number;
+  limit: number;
+  next_cursor: string | null;
+  prev_cursor: string | null;
+} {
+  return {
+    entries,
+    total: opts.total ?? entries.length,
+    limit: 50,
+    next_cursor: opts.next_cursor ?? null,
+    prev_cursor: opts.prev_cursor ?? null,
+  };
+}
+
+// ── Build mocks / injector helper ─────────────────────────────────────────────
+
+function buildMocks(
+  options: {
+    queryParams?: Record<string, string>;
+    listResponse?: ReturnType<typeof makeListResponse>;
+    listError?: unknown;
+  } = {},
+): {
+  injector: Injector;
+  queryParamMapSubject: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+  mockRoute: {
+    snapshot: { queryParams: Record<string, string> };
+    queryParamMap: ReturnType<typeof BehaviorSubject.prototype.asObservable>;
+  };
+  mockRouter: MockRouter;
+  mockAuditService: Partial<AdminAuditService>;
+  mockLogger: MockLoggerService;
+  mockCdr: { markForCheck: ReturnType<typeof vi.fn> };
+} {
+  const queryParams = options.queryParams ?? {};
+  const queryParamMapSubject = new BehaviorSubject(convertToParamMap(queryParams));
+
+  const mockRoute = {
+    snapshot: { queryParams },
+    queryParamMap: queryParamMapSubject.asObservable(),
+  };
+
+  const mockRouter = createTypedMockRouter('/admin/audit/tm') as MockRouter;
+  const mockLogger = createTypedMockLoggerService();
+
+  const listResponse = options.listResponse ?? makeListResponse();
+  const mockAuditService: Partial<AdminAuditService> = {
+    listTm: options.listError
+      ? vi.fn().mockReturnValue(throwError(() => options.listError))
+      : vi.fn().mockReturnValue(of(listResponse)),
+  };
+
+  const mockDestroyRef = { onDestroy: vi.fn() };
+  const mockCdr = { markForCheck: vi.fn() };
+
+  const injector = Injector.create({
+    providers: [
+      { provide: DestroyRef, useValue: mockDestroyRef },
+      { provide: ChangeDetectorRef, useValue: mockCdr },
+      { provide: ActivatedRoute, useValue: mockRoute },
+      { provide: Router, useValue: mockRouter },
+      { provide: AdminAuditService, useValue: mockAuditService },
+      { provide: LoggerService, useValue: mockLogger },
+    ],
+  });
+
+  return {
+    injector,
+    queryParamMapSubject,
+    mockRoute,
+    mockRouter,
+    mockAuditService,
+    mockLogger,
+    mockCdr,
+  };
+}
+
+function createComponent(injector: Injector): TmAuditViewComponent {
+  const comp = runInInjectionContext(injector, () => new TmAuditViewComponent());
+  comp.ngOnInit();
+  return comp;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('TmAuditViewComponent', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('(a) loads TM entries on init (no around) and sets rows/total/cursors', () => {
+    let comp: TmAuditViewComponent;
+    let mocks: ReturnType<typeof buildMocks>;
+
+    beforeEach(() => {
+      mocks = buildMocks({
+        listResponse: makeListResponse([ENTRY_1, ENTRY_2], {
+          total: 2,
+          next_cursor: 'cursor-next',
+          prev_cursor: 'cursor-prev',
+        }),
+      });
+      comp = createComponent(mocks.injector);
+    });
+
+    it('should create the component', () => {
+      expect(comp).toBeTruthy();
+    });
+
+    it('should call listTm with empty filter and limit on init', () => {
+      expect(mocks.mockAuditService.listTm).toHaveBeenCalledWith({}, { limit: 50 });
+    });
+
+    it('should set rows from service response', () => {
+      expect(comp.rows).toEqual([ENTRY_1, ENTRY_2]);
+    });
+
+    it('should set total from service response', () => {
+      expect(comp.total).toBe(2);
+    });
+
+    it('should set nextCursor from service response', () => {
+      expect(comp.nextCursor).toBe('cursor-next');
+    });
+
+    it('should set prevCursor from service response', () => {
+      expect(comp.prevCursor).toBe('cursor-prev');
+    });
+
+    it('should set loading=false after load completes', () => {
+      expect(comp.loading).toBe(false);
+    });
+
+    it('should set hasError=false on successful load', () => {
+      expect(comp.hasError).toBe(false);
+    });
+
+    it('should not set anchorId when there is no around param', () => {
+      expect(comp.anchorId).toBeNull();
+    });
+
+    it('should expose the stream as tm', () => {
+      expect(comp.stream).toBe('tm');
+    });
+  });
+
+  describe('(b) onFilterChange sets filter, resets anchorId, reloads and mirrors URL', () => {
+    let comp: TmAuditViewComponent;
+    let mocks: ReturnType<typeof buildMocks>;
+
+    beforeEach(() => {
+      mocks = buildMocks();
+      comp = createComponent(mocks.injector);
+      vi.clearAllMocks();
+    });
+
+    it('should set the new filter', () => {
+      comp.onFilterChange({ actor_email: 'test@example.com' });
+      expect(comp.filter).toEqual({ actor_email: 'test@example.com' });
+    });
+
+    it('should reset anchorId to null', () => {
+      comp.anchorId = 'some-anchor';
+      comp.onFilterChange({ actor_email: 'test@example.com' });
+      expect(comp.anchorId).toBeNull();
+    });
+
+    it('should call listTm with the new filter and limit', () => {
+      comp.onFilterChange({ actor_email: 'test@example.com' });
+      expect(mocks.mockAuditService.listTm).toHaveBeenCalledWith(
+        { actor_email: 'test@example.com' },
+        { limit: 50 },
+      );
+    });
+
+    it('should call router.navigate with [] for URL mirroring', () => {
+      comp.onFilterChange({ actor_email: 'test@example.com' });
+      expect(mocks.mockRouter.navigate).toHaveBeenCalledWith(
+        [],
+        expect.objectContaining({
+          relativeTo: mocks.mockRoute,
+          replaceUrl: true,
+        }),
+      );
+    });
+  });
+
+  describe('(c) onOlder and onNewer pass the correct cursor', () => {
+    let comp: TmAuditViewComponent;
+    let mocks: ReturnType<typeof buildMocks>;
+
+    beforeEach(() => {
+      mocks = buildMocks({
+        listResponse: makeListResponse([ENTRY_1], {
+          next_cursor: 'next-42',
+          prev_cursor: 'prev-42',
+        }),
+      });
+      comp = createComponent(mocks.injector);
+      vi.clearAllMocks();
+    });
+
+    it('onOlder() calls listTm with cursor = nextCursor', () => {
+      comp.onOlder();
+      expect(mocks.mockAuditService.listTm).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ cursor: 'next-42' }),
+      );
+    });
+
+    it('onNewer() calls listTm with cursor = prevCursor', () => {
+      comp.onNewer();
+      expect(mocks.mockAuditService.listTm).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ cursor: 'prev-42' }),
+      );
+    });
+  });
+
+  describe('(d) around query param on init triggers listTm with { around } and sets anchorId', () => {
+    it('should set anchorId from the around param', () => {
+      const mocks = buildMocks({ queryParams: { around: 'tm-anchor-1' } });
+      const comp = createComponent(mocks.injector);
+      expect(comp.anchorId).toBe('tm-anchor-1');
+    });
+
+    it('should call listTm with around in page request', () => {
+      const mocks = buildMocks({ queryParams: { around: 'tm-anchor-1' } });
+      createComponent(mocks.injector);
+      expect(mocks.mockAuditService.listTm).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ around: 'tm-anchor-1', limit: 50 }),
+      );
+    });
+
+    it('should also restore filter keys from query params', () => {
+      const mocks = buildMocks({
+        queryParams: { actor_email: 'a@b.com', threat_model_id: 'tm-xyz' },
+      });
+      const comp = createComponent(mocks.injector);
+      expect(comp.filter).toEqual({ actor_email: 'a@b.com', threat_model_id: 'tm-xyz' });
+    });
+  });
+
+  describe('(e) onRowClick navigates to [id] relative to route', () => {
+    it('should call router.navigate with [id] relativeTo route', () => {
+      const mocks = buildMocks();
+      const comp = createComponent(mocks.injector);
+      comp.onRowClick({ id: 'tm-99' });
+      expect(mocks.mockRouter.navigate).toHaveBeenCalledWith(['tm-99'], {
+        relativeTo: mocks.mockRoute,
+      });
+    });
+  });
+
+  describe('(f) service error sets hasError=true', () => {
+    it('should set hasError=true when listTm throws', () => {
+      const mocks = buildMocks({ listError: new Error('server error') });
+      const comp = createComponent(mocks.injector);
+      expect(comp.hasError).toBe(true);
+    });
+
+    it('should set loading=false on error', () => {
+      const mocks = buildMocks({ listError: new Error('server error') });
+      const comp = createComponent(mocks.injector);
+      expect(comp.loading).toBe(false);
+    });
+
+    it('should log the error', () => {
+      const mocks = buildMocks({ listError: new Error('server error') });
+      createComponent(mocks.injector);
+      expect(mocks.mockLogger.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/pages/admin/audit/views/tm-audit-view.component.ts
+++ b/src/app/pages/admin/audit/views/tm-audit-view.component.ts
@@ -1,0 +1,250 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  inject,
+  OnInit,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router, RouterOutlet } from '@angular/router';
+import { TranslocoModule } from '@jsverse/transloco';
+
+import { COMMON_IMPORTS, CORE_MATERIAL_IMPORTS } from '@app/shared/imports';
+import { LoggerService } from '@app/core/services/logger.service';
+import { AdminAuditService } from '@app/pages/admin/audit/admin-audit.service';
+import {
+  AuditColumnDef,
+  AuditEntry,
+  AuditPageRequest,
+  TmAuditFilter,
+} from '@app/pages/admin/audit/models/admin-audit.model';
+import { AuditFilterBarComponent } from '@app/pages/admin/audit/components/audit-filter-bar.component';
+import { AuditTableComponent } from '@app/pages/admin/audit/components/audit-table.component';
+
+/** TM filter query-param keys recognised from the URL. */
+const TM_FILTER_KEYS: (keyof TmAuditFilter)[] = [
+  'actor_email',
+  'actor_provider',
+  'created_after',
+  'created_before',
+  'change_type',
+  'object_type',
+  'threat_model_id',
+];
+
+/**
+ * Threat-model audit view: owns state, composes the filter bar, audit table,
+ * and a router-outlet for the detail panel child route.
+ * Query params are mirrored to/from the URL for bookmarkability.
+ * No export capability (unlike the system audit view).
+ */
+@Component({
+  selector: 'app-tm-audit-view',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ...COMMON_IMPORTS,
+    ...CORE_MATERIAL_IMPORTS,
+    TranslocoModule,
+    RouterOutlet,
+    AuditFilterBarComponent,
+    AuditTableComponent,
+  ],
+  templateUrl: './tm-audit-view.component.html',
+  styleUrl: './tm-audit-view.component.scss',
+})
+export class TmAuditViewComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private auditService = inject(AdminAuditService);
+  private logger = inject(LoggerService);
+  private cdr = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
+
+  // ── Public state (used by template and tests) ────────────────────────────
+
+  filter: TmAuditFilter = {};
+  rows: AuditEntry[] = [];
+  total = 0;
+  nextCursor: string | null = null;
+  prevCursor: string | null = null;
+  loading = false;
+  hasError = false;
+  anchorId: string | null = null;
+
+  readonly limit = 50;
+  readonly stream = 'tm' as const;
+
+  readonly columns: AuditColumnDef[] = [
+    {
+      key: 'created_at',
+      headerKey: 'admin.audit.columns.timestamp',
+      cell: (r: Record<string, unknown>) => (r['created_at'] as string | undefined) ?? '',
+    },
+    {
+      key: 'actor',
+      headerKey: 'admin.audit.columns.actor',
+      cell: (r: Record<string, unknown>) => {
+        const a = r['actor'] as { display_name?: string; email?: string } | undefined;
+        return a?.display_name || a?.email || '';
+      },
+    },
+    {
+      key: 'threat_model',
+      headerKey: 'admin.audit.columns.threatModel',
+      cell: (r: Record<string, unknown>) => (r['threat_model_id'] as string | undefined) ?? '',
+    },
+    {
+      key: 'object',
+      headerKey: 'admin.audit.columns.object',
+      cell: (r: Record<string, unknown>) => {
+        const t = (r['object_type'] as string | undefined) ?? '';
+        const id = (r['object_id'] as string | undefined) ?? '';
+        return `${t} ${id}`.trim();
+      },
+    },
+    {
+      key: 'change_type',
+      headerKey: 'admin.audit.columns.changeType',
+      cell: (r: Record<string, unknown>) => (r['change_type'] as string | undefined) ?? '',
+    },
+    {
+      key: 'change_summary',
+      headerKey: 'admin.audit.columns.changeSummary',
+      cell: (r: Record<string, unknown>) => (r['change_summary'] as string | undefined) ?? '',
+    },
+  ];
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────
+
+  ngOnInit(): void {
+    // Read initial state from a snapshot so we don't create a reload loop.
+    // Then subscribe to queryParamMap for subsequent navigation changes
+    // (e.g. the detail panel's "view in context" sets `around`).
+    const snapshot = this.route.snapshot.queryParams as Record<string, string>;
+    this._applyQueryParams(snapshot);
+
+    const around = snapshot['around'];
+    if (around) {
+      this.anchorId = around;
+      this.load({ around, limit: this.limit });
+    } else {
+      this.load({ limit: this.limit });
+    }
+
+    // Subscribe for subsequent param changes (detail panel sets `around`).
+    this.route.queryParamMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(paramMap => {
+      const newAround = paramMap.get('around');
+      // Rebuild filter from current params
+      const params: Record<string, string> = {};
+      paramMap.keys.forEach(k => {
+        const v = paramMap.get(k);
+        if (v !== null) params[k] = v;
+      });
+      const newFilter = this._buildFilter(params);
+      const filterChanged =
+        JSON.stringify(newFilter) !== JSON.stringify(this.filter) || newAround !== this.anchorId;
+
+      if (!filterChanged) return; // guard against the initial emit
+
+      this.filter = newFilter;
+      if (newAround) {
+        this.anchorId = newAround;
+        this.load({ around: newAround, limit: this.limit });
+      } else {
+        this.anchorId = null;
+        this.load({ limit: this.limit });
+      }
+    });
+  }
+
+  // ── Event handlers ───────────────────────────────────────────────────────
+
+  /** Called by the filter bar when any filter value changes. */
+  onFilterChange(f: TmAuditFilter): void {
+    this.filter = f;
+    this.anchorId = null;
+    this.load({ limit: this.limit });
+    this.updateUrl();
+  }
+
+  /** Navigate to an older (earlier) page using the next cursor. */
+  onOlder(): void {
+    this.load({ cursor: this.nextCursor ?? undefined });
+  }
+
+  /** Navigate to a newer (later) page using the prev cursor. */
+  onNewer(): void {
+    this.load({ cursor: this.prevCursor ?? undefined });
+  }
+
+  /** Navigate into the detail panel for the clicked row. */
+  onRowClick(e: { id: string }): void {
+    void this.router.navigate([e.id], { relativeTo: this.route });
+  }
+
+  /** Retry the most recent load (simplest: reload the newest page). */
+  onRetry(): void {
+    this.load({ limit: this.limit });
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────────
+
+  /** Load a page of entries; sets loading/error state and triggers change detection. */
+  private load(page: AuditPageRequest): void {
+    this.loading = true;
+    this.hasError = false;
+    this.cdr.markForCheck();
+
+    this.auditService
+      .listTm(this.filter, { ...page, limit: this.limit })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: resp => {
+          this.rows = resp.entries;
+          this.total = resp.total;
+          this.nextCursor = resp.next_cursor ?? null;
+          this.prevCursor = resp.prev_cursor ?? null;
+          this.loading = false;
+          this.cdr.markForCheck();
+        },
+        error: (e: unknown) => {
+          this.hasError = true;
+          this.loading = false;
+          this.logger.error('Failed to load threat-model audit entries', e);
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  /** Mirror the current filter (without cursor/around) to the URL. */
+  private updateUrl(): void {
+    const queryParams: Record<string, string | undefined> = {};
+    for (const key of TM_FILTER_KEYS) {
+      queryParams[key] = this.filter[key];
+    }
+
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams,
+      queryParamsHandling: '',
+      replaceUrl: true,
+    });
+  }
+
+  /** Extract filter values from a raw query-params map. */
+  private _buildFilter(params: Record<string, string>): TmAuditFilter {
+    const f: TmAuditFilter = {};
+    for (const key of TM_FILTER_KEYS) {
+      const v = params[key];
+      if (v) (f as Record<string, string>)[key] = v;
+    }
+    return f;
+  }
+
+  /** Apply snapshot query params to `this.filter` (without triggering a reload). */
+  private _applyQueryParams(params: Record<string, string>): void {
+    this.filter = this._buildFilter(params);
+  }
+}

--- a/src/app/pages/admin/audit/views/tm-audit-view.component.ts
+++ b/src/app/pages/admin/audit/views/tm-audit-view.component.ts
@@ -73,6 +73,9 @@ export class TmAuditViewComponent implements OnInit {
   hasError = false;
   anchorId: string | null = null;
 
+  /** The most recent page request, replayed by retry. */
+  private lastPage: AuditPageRequest = {};
+
   readonly limit = 50;
   readonly stream = 'tm' as const;
 
@@ -169,14 +172,18 @@ export class TmAuditViewComponent implements OnInit {
     this.updateUrl();
   }
 
-  /** Navigate to an older (earlier) page using the next cursor. */
+  /** Navigate to an older (earlier) page using the next cursor. Leaves around mode. */
   onOlder(): void {
+    this.anchorId = null;
     this.load({ cursor: this.nextCursor ?? undefined });
+    this.updateUrl();
   }
 
-  /** Navigate to a newer (later) page using the prev cursor. */
+  /** Navigate to a newer (later) page using the prev cursor. Leaves around mode. */
   onNewer(): void {
+    this.anchorId = null;
     this.load({ cursor: this.prevCursor ?? undefined });
+    this.updateUrl();
   }
 
   /** Navigate into the detail panel for the clicked row. */
@@ -184,15 +191,16 @@ export class TmAuditViewComponent implements OnInit {
     void this.router.navigate([e.id], { relativeTo: this.route });
   }
 
-  /** Retry the most recent load (simplest: reload the newest page). */
+  /** Retry the most recent load, preserving the current page position. */
   onRetry(): void {
-    this.load({ limit: this.limit });
+    this.load(this.lastPage);
   }
 
   // ── Private helpers ──────────────────────────────────────────────────────
 
   /** Load a page of entries; sets loading/error state and triggers change detection. */
   private load(page: AuditPageRequest): void {
+    this.lastPage = page;
     this.loading = true;
     this.hasError = false;
     this.cdr.markForCheck();

--- a/src/app/pages/admin/settings/admin-settings.component.html
+++ b/src/app/pages/admin/settings/admin-settings.component.html
@@ -180,6 +180,15 @@
                     </button>
                     <button
                       mat-icon-button
+                      data-testid="setting-view-audit"
+                      [routerLink]="['/admin/audit/system']"
+                      [queryParams]="{ field_path: setting.key }"
+                      [matTooltip]="'admin.audit.viewInAuditLog' | transloco"
+                    >
+                      <mat-icon>history</mat-icon>
+                    </button>
+                    <button
+                      mat-icon-button
                       data-testid="settings-more-button"
                       [matMenuTriggerFor]="settingRowKebabMenu"
                       [matTooltip]="'common.actions' | transloco"

--- a/src/app/pages/admin/settings/admin-settings.component.html
+++ b/src/app/pages/admin/settings/admin-settings.component.html
@@ -184,6 +184,7 @@
                       [routerLink]="['/admin/audit/system']"
                       [queryParams]="{ field_path: setting.key }"
                       [matTooltip]="'admin.audit.viewInAuditLog' | transloco"
+                      [attr.aria-label]="'admin.audit.viewInAuditLog' | transloco"
                     >
                       <mat-icon>history</mat-icon>
                     </button>

--- a/src/app/shared/utils/blob-download.util.spec.ts
+++ b/src/app/shared/utils/blob-download.util.spec.ts
@@ -1,0 +1,31 @@
+import '@angular/compiler';
+import { vi, expect, describe, it, beforeEach, afterEach } from 'vitest';
+import { downloadBlob } from './blob-download.util';
+
+describe('downloadBlob', () => {
+  let clickSpy: ReturnType<typeof vi.fn>;
+  let anchor: HTMLAnchorElement;
+
+  beforeEach(() => {
+    clickSpy = vi.fn();
+    anchor = document.createElement('a');
+    anchor.click = clickSpy;
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+    vi.spyOn(document.body, 'appendChild').mockImplementation(node => node);
+    vi.spyOn(document.body, 'removeChild').mockImplementation(node => node);
+    (URL as unknown as { createObjectURL: () => string }).createObjectURL = vi.fn(
+      () => 'blob:mock',
+    );
+    (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('triggers an anchor download with the given filename and revokes the url', () => {
+    const blob = new Blob(['a,b,c'], { type: 'text/csv' });
+    downloadBlob(blob, 'export.csv');
+    expect(anchor.download).toBe('export.csv');
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock');
+  });
+});

--- a/src/app/shared/utils/blob-download.util.ts
+++ b/src/app/shared/utils/blob-download.util.ts
@@ -1,0 +1,15 @@
+/**
+ * Save a Blob to a file via a programmatic anchor download. Used for audit-log
+ * exports where the blob arrives asynchronously over HttpClient (so the File
+ * System Access picker, which needs a live user gesture, is not viable).
+ */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/src/assets/i18n/ar-SA.json
+++ b/src/assets/i18n/ar-SA.json
@@ -81,6 +81,93 @@
       "subtitle": "تكوين الملحقات لتوسيع وظائف TMI.",
       "title": "إدارة الملحقات"
     },
+    "audit": {
+      "columns": {
+        "actor": "الممثل",
+        "changeSummary": "ملخص التغيير",
+        "changeType": "نوع التغيير",
+        "fieldPath": "مسار الحقل",
+        "object": "الكائن",
+        "request": "الطلب",
+        "threatModel": "نموذج التهديد",
+        "timestamp": "الطابع الزمني"
+      },
+      "detail": {
+        "actor": "الممثل",
+        "changeSummary": "ملخص التغيير",
+        "changeType": "نوع التغيير",
+        "close": "إغلاق",
+        "copied": "تم النسخ",
+        "copyPermalink": "نسخ الرابط الدائم",
+        "email": "البريد الإلكتروني",
+        "fieldPath": "مسار الحقل",
+        "method": "طريقة HTTP",
+        "newValue": "القيمة الجديدة",
+        "notFound": "لم يتم العثور على إدخال التدقيق.",
+        "objectId": "معرف الكائن (ID)",
+        "objectType": "نوع الكائن",
+        "oldValue": "القيمة القديمة",
+        "path": "مسار الطلب",
+        "provider": "المزود",
+        "providerId": "معرف المزود (ID)",
+        "threatModel": "نموذج التهديد",
+        "timestamp": "الطابع الزمني",
+        "title": "إدخال التدقيق",
+        "version": "الإصدار",
+        "viewInContext": "عرض في السياق"
+      },
+      "empty": "لا توجد إدخالات تطابق هذه المرشحات.",
+      "enums": {
+        "changeType": {
+          "created": "تم الإنشاء",
+          "deleted": "تم الحذف",
+          "patched": "تم التصحيح",
+          "restored": "تم الاستعادة",
+          "rolled_back": "تم التراجع",
+          "updated": "تم التحديث"
+        },
+        "objectType": {
+          "asset": "الأصل",
+          "diagram": "رسم بياني",
+          "document": "وثيقة",
+          "note": "ملاحظة",
+          "repository": "المستودع",
+          "threat": "تهديد",
+          "threat_model": "نموذج التهديد"
+        }
+      },
+      "error": "فشل استعلام التدقيق.",
+      "export": {
+        "csv": "CSV",
+        "error": "فشل التصدير",
+        "menu": "تصدير",
+        "ndjson": "NDJSON"
+      },
+      "filters": {
+        "actor": "الممثل",
+        "actorPlaceholder": "البحث حسب البريد الإلكتروني",
+        "changeType": "نوع التغيير",
+        "clear": "مسح المرشحات",
+        "createdAfter": "تم الإنشاء بعد",
+        "createdBefore": "تم الإنشاء قبل",
+        "fieldPath": "مسار الحقل",
+        "httpMethod": "طريقة HTTP",
+        "objectType": "نوع الكائن",
+        "pathPrefix": "بادئة المسار",
+        "threatModelId": "معرف نموذج التهديد (ID)"
+      },
+      "pagination": {
+        "newer": "أحدث",
+        "older": "أقدم"
+      },
+      "retry": "إعادة محاولة",
+      "tabs": {
+        "system": "النظام",
+        "threatModels": "نماذج التهديد"
+      },
+      "title": "سجلات التدقيق",
+      "viewInAuditLog": "عرض في سجل التدقيق"
+    },
     "createAutomationUserDialog": {
       "email": "البريد الإلكتروني (اختياري)",
       "emailHint": "اختياري — الافتراضي هو عنوان @tmi.local المُنشأ تلقائياً",
@@ -176,6 +263,10 @@
       "addons": {
         "description": "تثبيت وتكوين الوظائف الإضافية للتطبيق.",
         "title": "الإضافات"
+      },
+      "audit": {
+        "description": "عرض سجلات التدقيق للنظام ونماذج التهديد.",
+        "title": "سجلات التدقيق"
       },
       "groups": {
         "description": "تكوين مجموعات المستخدمين والعضويات.",

--- a/src/assets/i18n/bn-BD.json
+++ b/src/assets/i18n/bn-BD.json
@@ -103,6 +103,93 @@
       "subtitle": "TMI কার্যকারিতা বাড়াতে অ্যাডঅন কনফিগার করুন",
       "title": "অ্যাডঅন পরিচালনা করুন"
     },
+    "audit": {
+      "columns": {
+        "actor": "অভিনেতা",
+        "changeSummary": "পরিবর্তনের সারাংশ",
+        "changeType": "পরিবর্তনের ধরন",
+        "fieldPath": "ক্ষেত্র পথ",
+        "object": "বস্তু",
+        "request": "অনুরোধ",
+        "threatModel": "হুমকি মডেল",
+        "timestamp": "সময়ের ছাপ"
+      },
+      "detail": {
+        "actor": "অভিনেতা",
+        "changeSummary": "পরিবর্তনের সারাংশ",
+        "changeType": "পরিবর্তনের ধরন",
+        "close": "বন্ধ করুন",
+        "copied": "অনুলিপি করা হয়েছে",
+        "copyPermalink": "স্থায়ী লিঙ্ক অনুলিপি করুন",
+        "email": "ইমেল",
+        "fieldPath": "ক্ষেত্র পথ",
+        "method": "HTTP পদ্ধতি",
+        "newValue": "নতুন মান",
+        "notFound": "অডিট এন্ট্রি পাওয়া যায়নি।",
+        "objectId": "বস্তু ID",
+        "objectType": "বস্তুর ধরন",
+        "oldValue": "পুরানো মান",
+        "path": "অনুরোধের পথ",
+        "provider": "প্রদানকারী",
+        "providerId": "প্রদানকারী ID",
+        "threatModel": "হুমকি মডেল",
+        "timestamp": "সময়ের ছাপ",
+        "title": "অডিট এন্ট্রি",
+        "version": "সংস্করণ",
+        "viewInContext": "প্রসঙ্গে দেখুন"
+      },
+      "empty": "এই ফিল্টারগুলি মেলে এমন কোনও এন্ট্রি নেই।",
+      "enums": {
+        "changeType": {
+          "created": "তৈরি করা হয়েছে",
+          "deleted": "মুছে ফেলা হয়েছে",
+          "patched": "প্যাচ করা হয়েছে",
+          "restored": "পুনরুদ্ধার করা হয়েছে",
+          "rolled_back": "রোল করা হয়েছে",
+          "updated": "আপডেট করা হয়েছে"
+        },
+        "objectType": {
+          "asset": "সম্পদ",
+          "diagram": "চিত্র",
+          "document": "নথি",
+          "note": "নোট",
+          "repository": "সংরক্ষণাগার",
+          "threat": "হুমকি",
+          "threat_model": "হুমকি মডেল"
+        }
+      },
+      "error": "অডিট প্রশ্ন ব্যর্থ হয়েছে।",
+      "export": {
+        "csv": "CSV",
+        "error": "রপ্তানি ব্যর্থ হয়েছে",
+        "menu": "রপ্তানি",
+        "ndjson": "NDJSON"
+      },
+      "filters": {
+        "actor": "অভিনেতা",
+        "actorPlaceholder": "ইমেল দ্বারা অনুসন্ধান করুন",
+        "changeType": "পরিবর্তনের ধরন",
+        "clear": "ফিল্টারগুলি সাফ করুন",
+        "createdAfter": "এরপরে তৈরি করা হয়েছে",
+        "createdBefore": "এর আগে তৈরি করা হয়েছে",
+        "fieldPath": "ক্ষেত্র পথ",
+        "httpMethod": "HTTP পদ্ধতি",
+        "objectType": "বস্তুর ধরন",
+        "pathPrefix": "পথের প্রিফিক্স",
+        "threatModelId": "হুমকি মডেল ID"
+      },
+      "pagination": {
+        "newer": "নতুনতর",
+        "older": "পুরাতনতর"
+      },
+      "retry": "পুনরায় চেষ্টা করুন",
+      "tabs": {
+        "system": "সিস্টেম",
+        "threatModels": "হুমকি মডেল"
+      },
+      "title": "অডিট লগ",
+      "viewInAuditLog": "অডিট লগে দেখুন"
+    },
     "createAutomationUserDialog": {
       "email": "ইমেইল (ঐচ্ছিক)",
       "emailHint": "ঐচ্ছিক — ডিফল্ট হলো স্বয়ংক্রিয়ভাবে তৈরি @tmi.local ঠিকানা",
@@ -198,6 +285,10 @@
       "addons": {
         "description": "অ্যাপ্লিকেশন অ্যাডঅন ইনস্টল এবং কনফিগার করুন",
         "title": "অ্যাডঅন"
+      },
+      "audit": {
+        "description": "সিস্টেম এবং হুমকি মডেল অডিট লগ দেখুন।",
+        "title": "অডিট লগ"
       },
       "groups": {
         "description": "ব্যবহারকারী গ্রুপ এবং সদস্যপদ কনফিগার করুন",

--- a/src/assets/i18n/de-DE.json
+++ b/src/assets/i18n/de-DE.json
@@ -81,6 +81,93 @@
       "subtitle": "Erweiterungen zur Erweiterung der TMI-Funktionalität konfigurieren.",
       "title": "Erweiterungen verwalten"
     },
+    "audit": {
+      "columns": {
+        "actor": "Akteur",
+        "changeSummary": "Änderungszusammenfassung",
+        "changeType": "Änderungstyp",
+        "fieldPath": "Feldpfad",
+        "object": "Objekt",
+        "request": "Anfrage",
+        "threatModel": "Threat Model",
+        "timestamp": "Zeitstempel"
+      },
+      "detail": {
+        "actor": "Akteur",
+        "changeSummary": "Änderungszusammenfassung",
+        "changeType": "Änderungstyp",
+        "close": "Schließen",
+        "copied": "Kopiert",
+        "copyPermalink": "Permalink kopieren",
+        "email": "E-Mail",
+        "fieldPath": "Feldpfad",
+        "method": "HTTP-Methode",
+        "newValue": "Neuer Wert",
+        "notFound": "Audit-Eintrag nicht gefunden.",
+        "objectId": "Objekt-ID",
+        "objectType": "Objekttyp",
+        "oldValue": "Alter Wert",
+        "path": "Anfragepfad",
+        "provider": "Anbieter",
+        "providerId": "Anbieter-ID",
+        "threatModel": "Threat Model",
+        "timestamp": "Zeitstempel",
+        "title": "Audit-Eintrag",
+        "version": "Version",
+        "viewInContext": "Im Kontext anzeigen"
+      },
+      "empty": "Keine Einträge stimmen mit diesen Filtern überein.",
+      "enums": {
+        "changeType": {
+          "created": "Erstellt",
+          "deleted": "Gelöscht",
+          "patched": "Aktualisiert",
+          "restored": "Wiederhergestellt",
+          "rolled_back": "Zurückgerollt",
+          "updated": "Aktualisiert"
+        },
+        "objectType": {
+          "asset": "Anlage",
+          "diagram": "Diagramm",
+          "document": "Dokument",
+          "note": "Notiz",
+          "repository": "Repository",
+          "threat": "Bedrohung",
+          "threat_model": "Threat Model"
+        }
+      },
+      "error": "Audit-Abfrage fehlgeschlagen.",
+      "export": {
+        "csv": "CSV",
+        "error": "Export fehlgeschlagen",
+        "menu": "Exportieren",
+        "ndjson": "NDJSON"
+      },
+      "filters": {
+        "actor": "Akteur",
+        "actorPlaceholder": "Nach E-Mail suchen",
+        "changeType": "Änderungstyp",
+        "clear": "Filter löschen",
+        "createdAfter": "Erstellt nach",
+        "createdBefore": "Erstellt vor",
+        "fieldPath": "Feldpfad",
+        "httpMethod": "HTTP-Methode",
+        "objectType": "Objekttyp",
+        "pathPrefix": "Pfadpräfix",
+        "threatModelId": "Threat Model-ID"
+      },
+      "pagination": {
+        "newer": "Neuer",
+        "older": "Älter"
+      },
+      "retry": "Wiederholen",
+      "tabs": {
+        "system": "System",
+        "threatModels": "Threat Models"
+      },
+      "title": "Audit-Protokolle",
+      "viewInAuditLog": "In Audit-Protokoll anzeigen"
+    },
     "createAutomationUserDialog": {
       "email": "E-Mail (optional)",
       "emailHint": "Optional — Standard ist eine automatisch generierte @tmi.local-Adresse",
@@ -176,6 +263,10 @@
       "addons": {
         "description": "Anwendungserweiterungen installieren und konfigurieren.",
         "title": "Erweiterungen"
+      },
+      "audit": {
+        "description": "System- und Threat Model-Audit-Protokolle anzeigen.",
+        "title": "Audit-Protokolle"
       },
       "groups": {
         "description": "Benutzergruppen und Mitgliedschaften konfigurieren.",

--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -95,6 +95,93 @@
       "subtitle": "Configure addons for extending TMI functionality.",
       "title": "Manage addons"
     },
+    "audit": {
+      "columns": {
+        "actor": "Actor",
+        "changeSummary": "Change summary",
+        "changeType": "Change type",
+        "fieldPath": "Field path",
+        "object": "Object",
+        "request": "Request",
+        "threatModel": "Threat model",
+        "timestamp": "Timestamp"
+      },
+      "detail": {
+        "actor": "Actor",
+        "changeSummary": "Change summary",
+        "changeType": "Change type",
+        "close": "Close",
+        "copied": "Copied",
+        "copyPermalink": "Copy permalink",
+        "email": "Email",
+        "fieldPath": "Field path",
+        "method": "HTTP method",
+        "newValue": "New value",
+        "notFound": "Audit entry not found.",
+        "objectId": "Object ID",
+        "objectType": "Object type",
+        "oldValue": "Old value",
+        "path": "Request path",
+        "provider": "Provider",
+        "providerId": "Provider ID",
+        "threatModel": "Threat model",
+        "timestamp": "Timestamp",
+        "title": "Audit entry",
+        "version": "Version",
+        "viewInContext": "View in context"
+      },
+      "empty": "No entries match these filters.",
+      "enums": {
+        "changeType": {
+          "created": "Created",
+          "deleted": "Deleted",
+          "patched": "Patched",
+          "restored": "Restored",
+          "rolled_back": "Rolled back",
+          "updated": "Updated"
+        },
+        "objectType": {
+          "asset": "Asset",
+          "diagram": "Diagram",
+          "document": "Document",
+          "note": "Note",
+          "repository": "Repository",
+          "threat": "Threat",
+          "threat_model": "Threat model"
+        }
+      },
+      "error": "Audit query failed.",
+      "export": {
+        "csv": "CSV",
+        "error": "Export failed",
+        "menu": "Export",
+        "ndjson": "NDJSON"
+      },
+      "filters": {
+        "actor": "Actor",
+        "actorPlaceholder": "Search by email",
+        "changeType": "Change type",
+        "clear": "Clear filters",
+        "createdAfter": "Created after",
+        "createdBefore": "Created before",
+        "fieldPath": "Field path",
+        "httpMethod": "HTTP method",
+        "objectType": "Object type",
+        "pathPrefix": "Path prefix",
+        "threatModelId": "Threat model ID"
+      },
+      "pagination": {
+        "newer": "Newer",
+        "older": "Older"
+      },
+      "retry": "Retry",
+      "tabs": {
+        "system": "System",
+        "threatModels": "Threat models"
+      },
+      "title": "Audit logs",
+      "viewInAuditLog": "View in audit log"
+    },
     "createAutomationUserDialog": {
       "email": "Email (optional)",
       "emailHint": "Optional — defaults to auto-generated @tmi.local address",
@@ -208,6 +295,10 @@
       "addons": {
         "description": "Install and configure application addons.",
         "title": "{{common.addons}}"
+      },
+      "audit": {
+        "description": "View system and threat model audit logs.",
+        "title": "Audit logs"
       },
       "groups": {
         "description": "Configure user groups and memberships.",
@@ -2164,8 +2255,6 @@
     "notAssociatedWithAsset": "Not associated with an asset.",
     "notAssociatedWithCell": "Not associated with a cell.",
     "notAssociatedWithDiagram": "Not associated with a diagram.",
-    "selectDiagramFirst": "Select a diagram first",
-    "selectDiagramFirst.comment": "Hint shown below the cell drop-down when no diagram is selected, prompting the user to pick one.",
     "sections": {
       "classification": "{{common.classification}}",
       "classification.comment": "Section header for threat classification fields (severity, type, CWE, CVSS).",
@@ -2178,6 +2267,8 @@
       "tracking": "Tracking",
       "tracking.comment": "Section header for tracking fields (issue URL, status, checkboxes)."
     },
+    "selectDiagramFirst": "Select a diagram first",
+    "selectDiagramFirst.comment": "Hint shown below the cell drop-down when no diagram is selected, prompting the user to pick one.",
     "threatPriority": {
       "deferred": "Deferred (p4)",
       "deferred.description": "Postponed with documented business approval; tracked but not scheduled.",

--- a/src/assets/i18n/en-US.usage.json
+++ b/src/assets/i18n/en-US.usage.json
@@ -5,7 +5,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21,7 +23,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43,7 +47,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -59,7 +65,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -75,7 +84,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -91,10 +102,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["page-title"],
+        "classes": [
+          "page-title"
+        ],
         "context": "<h1 class=\"page-title\" [transloco]=\"'about.contacttitle'\">Operated By</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 27
@@ -107,10 +122,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'about.description1'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 11
@@ -123,10 +142,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'about.description2'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 18
@@ -139,7 +162,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -155,7 +180,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -171,7 +198,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -187,7 +216,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -203,7 +235,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -219,7 +253,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -235,10 +271,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["page-title"],
+        "classes": [
+          "page-title"
+        ],
         "context": "<h1 class=\"page-title\" [transloco]=\"'about.opensourcetitle'\">Open Source</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 99
@@ -251,7 +291,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -267,7 +309,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -283,7 +327,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -305,10 +351,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["page-title"],
+        "classes": [
+          "page-title"
+        ],
         "context": "<h1 class=\"page-title\" [transloco]=\"'about.sourcetitle'\">TMI Project</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 59
@@ -321,10 +371,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["page-title"],
+        "classes": [
+          "page-title"
+        ],
         "context": "<h1 class=\"page-title\" [transloco]=\"'about.title'\">About TMI</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 7
@@ -337,10 +391,15 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content", "trademarks"],
+        "classes": [
+          "page-content",
+          "trademarks"
+        ],
         "context": "<p class=\"page-content trademarks\" [transloco]=\"'about.trademarks'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 169
@@ -353,10 +412,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["page-title"],
+        "classes": [
+          "page-title"
+        ],
         "context": "<h1 class=\"page-title\" [transloco]=\"'about.version'\">Version Information</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 45
@@ -369,7 +432,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -385,7 +451,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -401,7 +469,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -423,7 +493,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -439,7 +512,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -461,10 +537,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["bulk-indicator"],
+        "classes": [
+          "bulk-indicator"
+        ],
         "context": "<span class=\"bulk-indicator\" [transloco]=\"'addons.invokeDialog.allObjects'\">(All)</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 30
@@ -477,7 +557,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -493,7 +575,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error"],
+    "surfaces": [
+      "error"
+    ],
     "uses": [
       {
         "classes": [],
@@ -509,7 +593,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -525,7 +611,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -541,7 +629,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error"],
+    "surfaces": [
+      "error"
+    ],
     "uses": [
       {
         "classes": [],
@@ -557,7 +647,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error"],
+    "surfaces": [
+      "error"
+    ],
     "uses": [
       {
         "classes": [],
@@ -573,10 +665,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["section-label"],
+        "classes": [
+          "section-label"
+        ],
         "context": "<span class=\"section-label\" [transloco]=\"'addons.invokeDialog.parameters'\">Parameters</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 76
@@ -589,10 +685,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\" [transloco]=\"'addons.invokeDialog.threatModelId'\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 56
@@ -605,7 +705,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -621,7 +723,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error"],
+    "surfaces": [
+      "error"
+    ],
     "uses": [
       {
         "classes": [],
@@ -637,7 +741,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -653,7 +759,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -669,7 +777,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -685,7 +795,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -701,7 +813,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -717,7 +831,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -733,7 +849,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -749,7 +867,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -765,7 +885,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -781,7 +903,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -797,7 +921,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -813,7 +939,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -829,7 +957,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -845,7 +975,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -861,7 +993,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -877,7 +1011,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -893,7 +1029,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -909,7 +1047,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -925,7 +1065,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -941,7 +1083,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -957,7 +1101,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -973,7 +1119,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item", "tooltip"],
+    "surfaces": [
+      "menu-item",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -989,7 +1138,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1005,7 +1156,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1021,7 +1174,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1037,7 +1192,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1053,7 +1210,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1069,7 +1228,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1085,7 +1246,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1101,10 +1264,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["subtitle"],
+        "classes": [
+          "subtitle"
+        ],
         "context": "<p class=\"subtitle\" [transloco]=\"'admin.addons.subtitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/addons/admin-addons.component.html",
         "line": 5
@@ -1117,7 +1284,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1133,7 +1302,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1149,7 +1320,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1165,7 +1338,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1181,7 +1356,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1197,7 +1374,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1213,7 +1392,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1229,7 +1410,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1245,7 +1428,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1261,7 +1446,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1277,7 +1464,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1293,7 +1482,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1309,7 +1500,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1325,7 +1518,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1341,7 +1536,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1357,7 +1554,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1373,7 +1572,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1389,7 +1590,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1405,7 +1608,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1421,7 +1626,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1437,7 +1644,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1453,7 +1662,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1469,7 +1680,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1485,7 +1698,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1501,7 +1716,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1517,7 +1734,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1533,7 +1752,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1549,7 +1770,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1565,7 +1788,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1581,7 +1806,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1597,7 +1824,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1613,7 +1842,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1629,7 +1860,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1645,7 +1878,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1661,7 +1896,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1677,7 +1914,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1693,7 +1932,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1715,7 +1956,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1731,7 +1974,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1747,7 +1992,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1763,7 +2010,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1779,7 +2028,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1795,7 +2046,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1811,7 +2064,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1827,7 +2082,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1843,7 +2100,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1859,10 +2118,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["subtitle"],
+        "classes": [
+          "subtitle"
+        ],
         "context": "<p class=\"subtitle\" [transloco]=\"'admin.groups.subtitle'\">View and manage system groups</p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/groups/admin-groups.component.html",
         "line": 5
@@ -1875,7 +2138,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1891,7 +2156,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1907,7 +2174,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1923,7 +2192,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1939,7 +2210,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1955,7 +2228,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1971,7 +2246,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -1987,7 +2264,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2003,7 +2282,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2019,7 +2300,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2035,7 +2318,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2057,7 +2342,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2079,7 +2366,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2101,7 +2390,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2147,7 +2438,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item", "tooltip"],
+    "surfaces": [
+      "menu-item",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2169,7 +2463,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2191,7 +2487,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2207,7 +2505,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2223,7 +2523,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2245,7 +2547,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2261,7 +2565,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2277,7 +2583,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2299,7 +2607,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2321,7 +2631,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2343,7 +2655,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2365,10 +2679,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["subtitle"],
+        "classes": [
+          "subtitle"
+        ],
         "context": "<p class=\"subtitle\" [transloco]=\"'admin.quotas.subtitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
         "line": 5
@@ -2381,7 +2699,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2397,7 +2717,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2413,7 +2735,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2429,7 +2753,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2445,7 +2771,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2461,7 +2789,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2477,7 +2807,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2493,7 +2825,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2509,7 +2843,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2525,7 +2861,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2541,7 +2879,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2557,7 +2897,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2573,7 +2915,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2589,7 +2933,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2605,7 +2951,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2621,7 +2969,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2637,7 +2987,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2653,7 +3005,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2669,7 +3023,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2685,7 +3041,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2701,7 +3059,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2717,7 +3077,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2733,7 +3095,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2749,7 +3113,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2765,7 +3131,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2781,7 +3149,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2803,7 +3173,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2819,7 +3191,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2835,7 +3209,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2851,7 +3227,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2867,7 +3245,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2883,7 +3263,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2899,7 +3281,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2933,7 +3317,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2961,7 +3347,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2977,7 +3365,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -2993,7 +3383,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3009,7 +3401,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3025,7 +3419,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3041,7 +3437,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3057,7 +3455,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3073,7 +3474,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3089,7 +3492,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3105,7 +3510,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3121,7 +3528,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3137,7 +3546,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3153,7 +3565,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3169,7 +3583,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3249,7 +3665,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3329,7 +3747,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3409,7 +3829,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3489,10 +3911,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["subtitle"],
+        "classes": [
+          "subtitle"
+        ],
         "context": "<p class=\"subtitle\" [transloco]=\"'admin.settings.subtitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/settings/admin-settings.component.html",
         "line": 5
@@ -3505,7 +3931,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3521,7 +3949,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3601,7 +4031,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3681,7 +4113,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3761,7 +4195,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3841,10 +4277,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["admin-subtitle"],
+        "classes": [
+          "admin-subtitle"
+        ],
         "context": "<p class=\"admin-subtitle\" [transloco]=\"'admin.subtitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/admin.component.html",
         "line": 5
@@ -3857,7 +4297,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3873,7 +4315,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3889,7 +4333,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3905,7 +4351,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3921,7 +4369,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3937,7 +4387,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3953,7 +4405,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3969,7 +4423,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -3985,7 +4441,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4001,7 +4459,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4017,7 +4477,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4033,7 +4495,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4049,7 +4513,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4065,7 +4531,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4081,7 +4549,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4097,7 +4567,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4113,7 +4585,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4129,7 +4603,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4145,10 +4621,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["muted"],
+        "classes": [
+          "muted"
+        ],
         "context": "<span class=\"muted\" [transloco]=\"'admin.users.never'\">Never</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.html",
         "line": 111
@@ -4167,7 +4647,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4183,10 +4665,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["subtitle"],
+        "classes": [
+          "subtitle"
+        ],
         "context": "<p class=\"subtitle\" [transloco]=\"'admin.users.subtitle'\">View and manage system users</p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.html",
         "line": 5
@@ -4199,7 +4685,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4215,7 +4703,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4231,7 +4721,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4247,7 +4739,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4263,7 +4757,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4279,7 +4775,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4295,7 +4793,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4311,7 +4811,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4327,7 +4829,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4343,7 +4847,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4359,7 +4865,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4375,7 +4883,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4391,7 +4901,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4407,7 +4919,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4423,7 +4937,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4439,7 +4955,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4455,7 +4973,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4477,7 +4997,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4493,7 +5015,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4509,7 +5033,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4525,7 +5051,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4541,7 +5069,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4557,7 +5087,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4573,7 +5105,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4595,7 +5129,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4611,7 +5147,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4627,7 +5165,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4643,7 +5183,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4659,7 +5201,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4675,7 +5219,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4691,7 +5237,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4771,7 +5319,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4787,7 +5337,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4803,7 +5355,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4819,10 +5373,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["warning-text"],
+        "classes": [
+          "warning-text"
+        ],
         "context": "<p class=\"warning-text\" [transloco]=\"'admin.webhooks.hmacSecretDialog.warning'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/hmac-secret-dialog/hmac-secret-dialog.component.html",
         "line": 3
@@ -4835,7 +5393,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4851,7 +5411,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4867,7 +5429,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -4947,7 +5511,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5027,7 +5593,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5107,7 +5675,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5187,7 +5757,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5203,10 +5775,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["subtitle"],
+        "classes": [
+          "subtitle"
+        ],
         "context": "<p class=\"subtitle\" [transloco]=\"'admin.webhooks.subtitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
         "line": 5
@@ -5219,7 +5795,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5235,7 +5813,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5251,7 +5831,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5267,7 +5849,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5283,7 +5867,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5299,7 +5885,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5315,7 +5903,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error"],
+    "surfaces": [
+      "error"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5331,7 +5921,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5347,7 +5939,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5363,7 +5957,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5379,7 +5975,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5395,7 +5993,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error"],
+    "surfaces": [
+      "error"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5411,7 +6011,11 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "description", "page-title"],
+    "surfaces": [
+      "button",
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5445,7 +6049,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5467,7 +6073,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5501,7 +6109,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5517,7 +6127,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title", "tooltip"],
+    "surfaces": [
+      "page-title",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5539,7 +6152,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5555,7 +6170,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5571,7 +6188,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5587,7 +6206,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5603,7 +6224,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5619,10 +6242,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["page-title"],
+        "classes": [
+          "page-title"
+        ],
         "context": "<h1 class=\"page-title\">{{ 'adminSurveys.pageTitle' | transloco }}</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.html",
         "line": 3
@@ -5635,7 +6262,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5651,7 +6280,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5667,7 +6298,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5683,7 +6316,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5699,7 +6334,11 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "description", "page-title"],
+    "surfaces": [
+      "button",
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5715,7 +6354,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5731,7 +6372,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5747,7 +6390,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5763,7 +6409,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5779,7 +6427,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5795,7 +6445,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label", "placeholder"],
+    "surfaces": [
+      "label",
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5811,7 +6464,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5827,7 +6482,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5843,7 +6500,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5859,7 +6518,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5875,7 +6536,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5891,7 +6554,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5907,7 +6572,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label", "page-title"],
+    "surfaces": [
+      "label",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5923,7 +6591,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label", "placeholder"],
+    "surfaces": [
+      "label",
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5939,7 +6610,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5955,7 +6628,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5971,7 +6646,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -5987,7 +6664,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6003,10 +6682,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["hint"],
+        "classes": [
+          "hint"
+        ],
         "context": "<p class=\"hint\">{{ 'adminSurveys.templateBuilder.noQuestionsHint' | transloco }}</p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/components/template-builder/template-builder.component.html",
         "line": 216
@@ -6019,7 +6702,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6035,7 +6720,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6051,7 +6738,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6067,7 +6756,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6083,7 +6774,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6099,7 +6792,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6115,7 +6810,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6131,7 +6828,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6147,7 +6846,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6163,7 +6864,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6179,7 +6882,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6195,7 +6900,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6211,7 +6918,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6227,7 +6936,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6243,7 +6954,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6259,7 +6972,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6275,7 +6990,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6291,7 +7008,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6307,7 +7026,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6323,7 +7044,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6339,7 +7062,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6355,7 +7080,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label", "placeholder"],
+    "surfaces": [
+      "label",
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6371,7 +7099,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6387,7 +7117,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6403,7 +7135,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6419,7 +7153,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6435,7 +7171,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6451,7 +7189,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6467,7 +7207,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6483,7 +7225,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6499,7 +7243,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6515,7 +7261,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6531,7 +7279,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6547,7 +7297,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6563,7 +7315,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6579,7 +7333,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6595,7 +7351,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6611,7 +7369,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6627,7 +7387,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6643,7 +7405,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6659,7 +7423,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6675,7 +7441,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6691,7 +7459,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6707,7 +7477,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6723,7 +7495,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6739,10 +7513,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
-        "classes": ["chip-label"],
+        "classes": [
+          "chip-label"
+        ],
         "context": "<mat-label class=\"chip-label\">{{ 'assetEditor.classification' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
         "line": 79
@@ -6755,7 +7533,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6771,7 +7551,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6787,7 +7569,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label", "placeholder"],
+    "surfaces": [
+      "label",
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6809,7 +7594,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6825,7 +7612,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6841,7 +7630,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6857,7 +7648,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6879,7 +7672,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -6959,7 +7754,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7039,7 +7836,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7119,7 +7918,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7199,7 +8000,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7279,7 +8082,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7359,7 +8164,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7375,7 +8182,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7391,7 +8200,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7407,7 +8218,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7487,7 +8300,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7567,7 +8382,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7583,7 +8400,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7599,7 +8418,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7615,7 +8436,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7631,7 +8454,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7647,7 +8472,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7663,7 +8490,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7679,7 +8508,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7759,7 +8590,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7839,7 +8672,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7855,7 +8690,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7871,7 +8708,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7887,7 +8726,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7903,7 +8744,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7925,7 +8768,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7941,7 +8786,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7957,7 +8804,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -7973,7 +8822,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "placeholder"],
+    "surfaces": [
+      "description",
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8013,7 +8865,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8093,7 +8947,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8173,7 +9029,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8189,7 +9047,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8269,7 +9129,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8285,7 +9147,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item", "page-title"],
+    "surfaces": [
+      "menu-item",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8330,7 +9195,9 @@
         "line": 1914
       },
       {
-        "classes": ["title-prefix"],
+        "classes": [
+          "title-prefix"
+        ],
         "context": "<span class=\"title-prefix\">{{ 'auditTrail.title' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/audit-trail-page/audit-trail-page.component.html",
         "line": 4
@@ -8349,7 +9216,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8365,7 +9234,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8381,7 +9252,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8397,7 +9270,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8413,7 +9289,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8429,7 +9307,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8509,7 +9389,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8525,7 +9407,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8541,7 +9425,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8557,7 +9443,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8591,7 +9479,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8671,7 +9561,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8687,7 +9579,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8715,7 +9609,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8743,7 +9639,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8777,7 +9675,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8811,7 +9711,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8827,7 +9729,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8843,7 +9747,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8859,7 +9765,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8875,7 +9783,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8891,7 +9801,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8907,7 +9819,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8923,7 +9837,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["snackbar"],
+    "surfaces": [
+      "snackbar"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8945,7 +9861,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8961,7 +9879,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -8977,7 +9897,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9005,7 +9927,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9033,7 +9957,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9049,7 +9975,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9129,7 +10057,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9145,7 +10075,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9161,7 +10093,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9177,7 +10111,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9193,7 +10129,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9209,7 +10147,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9225,7 +10165,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9241,7 +10183,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9257,7 +10201,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9279,7 +10225,11 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "description", "page-title"],
+    "surfaces": [
+      "button",
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9301,7 +10251,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9323,10 +10275,15 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
-        "classes": ["toolbar-title"],
+        "classes": [
+          "toolbar-title"
+        ],
         "context": "<span class=\"toolbar-title\">{{ t('chat.title') }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.html",
         "line": 4
@@ -9351,7 +10308,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9373,7 +10332,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item", "tooltip"],
+    "surfaces": [
+      "menu-item",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9395,7 +10357,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9475,10 +10439,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["section-title"],
+        "classes": [
+          "section-title"
+        ],
         "context": "<h4 class=\"section-title\">{{ 'collaboration.collaboratorsHeader' | transloco }}</h4>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/collaboration-dialog/collaboration-dialog.component.html",
         "line": 17
@@ -9491,7 +10459,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9507,7 +10477,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item", "tooltip"],
+    "surfaces": [
+      "menu-item",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9529,7 +10502,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9545,7 +10520,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9567,7 +10544,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9583,7 +10562,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9623,7 +10605,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9645,7 +10629,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9661,7 +10647,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9677,7 +10665,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9693,7 +10683,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9773,7 +10765,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9789,7 +10783,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9805,7 +10801,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9821,7 +10819,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9843,7 +10843,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9865,7 +10867,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9881,7 +10885,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9897,7 +10903,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9913,7 +10921,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9935,7 +10945,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9957,7 +10969,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9979,7 +10993,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -9995,7 +11011,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -10023,7 +11041,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -10075,7 +11096,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -10367,7 +11390,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -10383,7 +11409,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -10463,7 +11491,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -10485,7 +11515,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -10507,7 +11539,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -10535,7 +11569,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item", "tooltip"],
+    "surfaces": [
+      "menu-item",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -10635,7 +11672,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "label"],
+    "surfaces": [
+      "description",
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -10663,7 +11703,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -10679,7 +11721,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -10695,7 +11739,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -10775,7 +11821,11 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "error", "tooltip"],
+    "surfaces": [
+      "button",
+      "error",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -11193,7 +12243,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -11209,7 +12261,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -11231,7 +12285,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -11271,7 +12328,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -11305,7 +12364,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -11321,7 +12382,13 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "description", "page-title", "snackbar", "tooltip"],
+    "surfaces": [
+      "button",
+      "description",
+      "page-title",
+      "snackbar",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -11835,7 +12902,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -11869,7 +12938,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -11903,7 +12974,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -11919,7 +12992,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["snackbar"],
+    "surfaces": [
+      "snackbar"
+    ],
     "uses": [
       {
         "classes": [],
@@ -11965,7 +13040,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12005,7 +13083,11 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "menu-item", "tooltip"],
+    "surfaces": [
+      "button",
+      "menu-item",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12111,7 +13193,10 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12175,7 +13260,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12196,7 +13283,9 @@
         "line": 217
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.created' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 293
@@ -12208,19 +13297,25 @@
         "line": 84
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.created' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 61
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.created' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
         "line": 66
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.created' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
         "line": 12
@@ -12233,7 +13328,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12249,7 +13346,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12271,7 +13370,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12305,7 +13406,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12321,7 +13425,11 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "menu-item", "tooltip"],
+    "surfaces": [
+      "button",
+      "menu-item",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12469,7 +13577,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12485,7 +13595,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12507,7 +13619,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12523,7 +13637,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12545,7 +13661,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12567,7 +13685,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "placeholder"],
+    "surfaces": [
+      "description",
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12589,7 +13710,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12605,7 +13728,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12621,7 +13746,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12637,7 +13764,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12653,7 +13782,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12675,7 +13806,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12829,7 +13962,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12845,7 +13980,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["snackbar"],
+    "surfaces": [
+      "snackbar"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12915,7 +14052,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12955,7 +14094,11 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "menu-item", "tooltip"],
+    "surfaces": [
+      "button",
+      "menu-item",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -12977,7 +14120,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13035,7 +14180,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13051,10 +14198,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.email' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 275
@@ -13067,7 +14218,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13089,7 +14242,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13117,7 +14272,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13145,7 +14302,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13173,7 +14332,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13189,7 +14350,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13205,7 +14368,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13285,16 +14450,22 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.id' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 334
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\" [transloco]=\"'common.id'\">ID</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 43
@@ -13307,7 +14478,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13387,7 +14560,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13439,7 +14614,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13491,7 +14668,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13519,7 +14698,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13541,7 +14723,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "menu-item"],
+    "surfaces": [
+      "button",
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13563,7 +14748,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "tooltip"],
+    "surfaces": [
+      "description",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13572,13 +14760,17 @@
         "line": 111
       },
       {
-        "classes": ["date-label"],
+        "classes": [
+          "date-label"
+        ],
         "context": "<span class=\"date-label\">{{ 'common.lastModified' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 335
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.lastModified' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 318
@@ -13590,31 +14782,41 @@
         "line": 162
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.lastModified' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
         "line": 72
       },
       {
-        "classes": ["summary-label"],
+        "classes": [
+          "summary-label"
+        ],
         "context": "<span class=\"summary-label\">{{ 'common.lastModified' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 396
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.lastModified' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 424
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.lastModified' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
         "line": 18
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.lastModified' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 67
@@ -13627,7 +14829,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13649,10 +14854,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["info-value"],
+        "classes": [
+          "info-value"
+        ],
         "context": "<span class=\"info-value\">{{ projectName ?? ('common.loading' | transloco) }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/response-detail/response-detail.component.html",
         "line": 91
@@ -13683,7 +14892,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13763,7 +14974,11 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "dialog-title", "tooltip"],
+    "surfaces": [
+      "button",
+      "dialog-title",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13839,7 +15054,10 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title", "tooltip"],
+    "surfaces": [
+      "dialog-title",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13861,7 +15079,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13889,7 +15109,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13911,7 +15133,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13933,7 +15157,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13961,7 +15187,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13983,7 +15211,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -13999,7 +15229,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14039,7 +15271,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14150,7 +15384,9 @@
         "line": 87
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\" [transloco]=\"'common.name'\">Name</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 38
@@ -14181,7 +15417,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14281,7 +15519,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14309,7 +15549,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14389,7 +15631,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14405,7 +15649,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14421,7 +15667,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14514,7 +15762,9 @@
         "line": 110
       },
       {
-        "classes": ["muted"],
+        "classes": [
+          "muted"
+        ],
         "context": "<span class=\"muted\" [transloco]=\"'common.none'\">None</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.html",
         "line": 129
@@ -14545,7 +15795,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14615,7 +15867,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14643,7 +15897,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14723,7 +15979,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14803,7 +16061,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14818,7 +16078,9 @@
         "line": 279
       },
       {
-        "classes": ["title-prefix"],
+        "classes": [
+          "title-prefix"
+        ],
         "context": "<span class=\"title-prefix\">{{ 'common.objectTypes.diagram' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
         "line": 22
@@ -14861,7 +16123,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14877,7 +16141,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14929,7 +16195,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14957,7 +16225,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14973,7 +16243,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -14982,7 +16254,9 @@
         "line": 236
       },
       {
-        "classes": ["title-prefix"],
+        "classes": [
+          "title-prefix"
+        ],
         "context": "<span class=\"title-prefix\">{{ 'common.objectTypes.note' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
         "line": 6
@@ -15031,7 +16305,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15059,7 +16335,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15075,7 +16353,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15155,7 +16435,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15171,7 +16453,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15251,7 +16535,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15273,7 +16559,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15325,7 +16613,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15334,7 +16624,9 @@
         "line": 73
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.objectTypes.survey' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 282
@@ -15389,7 +16681,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15405,7 +16699,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15485,7 +16781,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15565,7 +16863,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15581,7 +16881,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15661,7 +16963,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15700,7 +17004,9 @@
         "line": 2516
       },
       {
-        "classes": ["title-prefix"],
+        "classes": [
+          "title-prefix"
+        ],
         "context": "<span class=\"title-prefix\">{{ 'common.objectTypes.threat' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 6
@@ -15719,7 +17025,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15746,7 +17054,9 @@
         "line": 2421
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\" [transloco]=\"'common.objectTypes.threatModel'\">Threat Model</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 51
@@ -15758,7 +17068,9 @@
         "line": 278
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.objectTypes.threatModel' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 326
@@ -15776,7 +17088,9 @@
         "line": 231
       },
       {
-        "classes": ["title-prefix"],
+        "classes": [
+          "title-prefix"
+        ],
         "context": "<span class=\"title-prefix\">{{ 'common.objectTypes.threatModel' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
         "line": 17
@@ -15789,7 +17103,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15869,7 +17185,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "page-title"],
+    "surfaces": [
+      "button",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15909,7 +17228,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15967,7 +17288,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -15989,7 +17312,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16011,7 +17336,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16045,7 +17372,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16067,7 +17396,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16089,16 +17420,22 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.project' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/response-detail/response-detail.component.html",
         "line": 90
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.project' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 152
@@ -16111,7 +17448,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16191,7 +17530,11 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title", "page-title", "tooltip"],
+    "surfaces": [
+      "dialog-title",
+      "page-title",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16261,7 +17604,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16343,7 +17688,11 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "description", "page-title"],
+    "surfaces": [
+      "button",
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16413,7 +17762,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16435,7 +17786,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16457,7 +17810,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16479,7 +17834,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16669,7 +18027,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16685,7 +18045,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16707,7 +18069,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16729,10 +18093,16 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "label", "tooltip"],
+    "surfaces": [
+      "button",
+      "label",
+      "tooltip"
+    ],
     "uses": [
       {
-        "classes": ["score-label"],
+        "classes": [
+          "score-label"
+        ],
         "context": "<span class=\"score-label\"> {{ 'common.score' | transloco }}: </span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
         "line": 89
@@ -16757,7 +18127,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16779,7 +18151,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16859,7 +18233,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16881,7 +18257,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16897,7 +18275,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16913,7 +18293,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16929,7 +18311,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -16981,7 +18365,11 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "label", "page-title"],
+    "surfaces": [
+      "description",
+      "label",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17002,7 +18390,9 @@
         "line": 209
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.status' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 257
@@ -17062,13 +18452,17 @@
         "line": 95
       },
       {
-        "classes": ["status-label"],
+        "classes": [
+          "status-label"
+        ],
         "context": "<span class=\"status-label\">{{ 'common.status' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 339
       },
       {
-        "classes": ["summary-label"],
+        "classes": [
+          "summary-label"
+        ],
         "context": "<span class=\"summary-label\">{{ 'common.status' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 171
@@ -17080,7 +18474,9 @@
         "line": 215
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.status' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 230
@@ -17117,7 +18513,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17133,7 +18531,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17149,7 +18549,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17171,7 +18573,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17193,7 +18597,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17221,7 +18627,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17243,7 +18651,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title", "label"],
+    "surfaces": [
+      "dialog-title",
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17277,7 +18688,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17305,7 +18718,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17327,7 +18742,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17343,7 +18760,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17359,7 +18778,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17368,7 +18789,9 @@
         "line": 105
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\" [transloco]=\"'common.type'\">Type</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 26
@@ -17381,7 +18804,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17397,7 +18822,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17425,7 +18852,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17453,7 +18882,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error"],
+    "surfaces": [
+      "error"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17469,7 +18900,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error", "placeholder"],
+    "surfaces": [
+      "error",
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17485,7 +18919,11 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error", "label", "placeholder"],
+    "surfaces": [
+      "error",
+      "label",
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17693,7 +19131,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17773,7 +19213,11 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error", "label", "placeholder"],
+    "surfaces": [
+      "error",
+      "label",
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17909,7 +19353,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -17924,7 +19371,9 @@
         "line": 139
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'common.version' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 288
@@ -17937,7 +19386,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18017,7 +19468,11 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "dialog-title", "tooltip"],
+    "surfaces": [
+      "button",
+      "dialog-title",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18081,7 +19536,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18097,7 +19554,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18113,7 +19572,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18129,7 +19590,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18145,7 +19608,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18161,7 +19626,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18177,7 +19644,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18193,7 +19662,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18209,7 +19680,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18225,7 +19698,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18241,7 +19716,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18257,7 +19734,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18273,7 +19752,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18289,7 +19770,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18305,7 +19788,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18321,7 +19806,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18337,7 +19824,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18353,7 +19842,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18369,7 +19860,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error"],
+    "surfaces": [
+      "error"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18385,7 +19878,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18401,7 +19896,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18417,7 +19914,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18497,7 +19996,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18577,7 +20078,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18657,7 +20160,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18737,7 +20242,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18817,7 +20324,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18897,7 +20406,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -18977,7 +20488,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -19057,7 +20570,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -19137,7 +20652,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -19217,7 +20734,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -19297,7 +20816,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -19377,7 +20898,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -19457,7 +20980,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -19537,7 +21062,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -19617,7 +21144,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -19697,7 +21226,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -19777,7 +21308,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -19857,7 +21390,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -19937,7 +21472,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20017,7 +21554,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20097,7 +21636,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20177,7 +21718,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20257,7 +21800,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20337,7 +21882,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20417,7 +21964,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20497,7 +22046,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20577,7 +22128,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20657,7 +22210,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20737,7 +22292,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20817,7 +22374,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20897,7 +22456,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20913,7 +22474,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20929,7 +22492,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20945,7 +22510,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20961,7 +22528,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20977,7 +22546,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -20993,7 +22564,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21009,7 +22582,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21037,7 +22612,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21053,7 +22630,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21069,7 +22648,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21085,7 +22666,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21107,7 +22690,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21129,7 +22714,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21151,7 +22738,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21231,10 +22820,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["vector-label"],
+        "classes": [
+          "vector-label"
+        ],
         "context": "<span class=\"vector-label\"> {{ 'cvssCalculator.vectorString' | transloco }}: </span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
         "line": 78
@@ -21247,7 +22840,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21269,7 +22864,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title", "label"],
+    "surfaces": [
+      "dialog-title",
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21285,7 +22883,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21301,7 +22902,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21317,7 +22920,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21333,7 +22938,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21349,7 +22956,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21365,10 +22974,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
-        "classes": ["section-label"],
+        "classes": [
+          "section-label"
+        ],
         "context": "<mat-label class=\"section-label\">{{ 'cwePicker.matchingWeaknesses' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cwe-picker-dialog/cwe-picker-dialog.component.html",
         "line": 13
@@ -21381,10 +22994,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
-        "classes": ["no-results"],
+        "classes": [
+          "no-results"
+        ],
         "context": "<div class=\"no-results\">{{ 'cwePicker.noResults' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cwe-picker-dialog/cwe-picker-dialog.component.html",
         "line": 21
@@ -21397,7 +23014,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21413,7 +23032,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21429,7 +23050,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "description"],
+    "surfaces": [
+      "button",
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21451,7 +23075,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21473,7 +23099,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21495,7 +23123,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21511,7 +23141,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21527,7 +23159,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21543,7 +23177,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21559,7 +23195,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21581,7 +23220,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21603,7 +23244,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21625,7 +23268,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21647,7 +23293,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21663,7 +23311,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21679,7 +23329,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21695,7 +23347,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21723,7 +23377,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21751,7 +23407,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21767,7 +23425,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21783,7 +23443,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21805,7 +23467,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21827,7 +23491,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21843,7 +23509,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21859,7 +23527,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21875,7 +23545,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21891,7 +23563,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21971,7 +23645,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -21987,7 +23663,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22003,7 +23681,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22019,7 +23699,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22035,7 +23717,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22051,7 +23735,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22067,7 +23754,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22083,7 +23773,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22105,7 +23797,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22127,7 +23821,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22149,7 +23845,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22171,7 +23869,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22187,7 +23887,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22203,16 +23905,22 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["label"],
+        "classes": [
+          "label"
+        ],
         "context": "<span class=\"label\">{{ 'debugDialogs.common.affectedCells' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 70
       },
       {
-        "classes": ["label"],
+        "classes": [
+          "label"
+        ],
         "context": "<span class=\"label\">{{ 'debugDialogs.common.affectedCells' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 155
@@ -22225,16 +23933,22 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["label"],
+        "classes": [
+          "label"
+        ],
         "context": "<span class=\"label\">{{ 'debugDialogs.common.cellIds' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 75
       },
       {
-        "classes": ["label"],
+        "classes": [
+          "label"
+        ],
         "context": "<span class=\"label\">{{ 'debugDialogs.common.cellIds' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 160
@@ -22247,7 +23961,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22269,7 +23985,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22291,7 +24009,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22307,7 +24027,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22323,10 +24045,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["label"],
+        "classes": [
+          "label"
+        ],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.canRedo' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 17
@@ -22339,10 +24065,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["label"],
+        "classes": [
+          "label"
+        ],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.canUndo' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 13
@@ -22355,7 +24085,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22377,10 +24109,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["label"],
+        "classes": [
+          "label"
+        ],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.currentIndex' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 33
@@ -22393,16 +24129,22 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["label"],
+        "classes": [
+          "label"
+        ],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.id' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 62
       },
       {
-        "classes": ["label"],
+        "classes": [
+          "label"
+        ],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.id' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 147
@@ -22415,10 +24157,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["label"],
+        "classes": [
+          "label"
+        ],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.maxStackSize' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 29
@@ -22431,10 +24177,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["empty-state"],
+        "classes": [
+          "empty-state"
+        ],
         "context": "<div class=\"empty-state\">{{ 'debugDialogs.historyDialog.noRedoEntries' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 134
@@ -22447,10 +24197,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["empty-state"],
+        "classes": [
+          "empty-state"
+        ],
         "context": "<div class=\"empty-state\">{{ 'debugDialogs.historyDialog.noUndoEntries' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 49
@@ -22463,7 +24217,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22485,7 +24241,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22507,7 +24265,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22529,7 +24289,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22545,10 +24307,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["label"],
+        "classes": [
+          "label"
+        ],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.redoStackSize' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 25
@@ -22561,7 +24327,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22577,16 +24345,22 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["label"],
+        "classes": [
+          "label"
+        ],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.timestamp' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 66
       },
       {
-        "classes": ["label"],
+        "classes": [
+          "label"
+        ],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.timestamp' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 151
@@ -22599,7 +24373,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22615,7 +24391,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22631,10 +24409,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["label"],
+        "classes": [
+          "label"
+        ],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.undoStackSize' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 21
@@ -22647,7 +24429,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22663,7 +24447,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22679,7 +24465,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22695,7 +24483,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22711,7 +24501,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22727,7 +24519,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22743,7 +24537,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22759,7 +24555,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22775,7 +24573,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22855,7 +24655,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22877,7 +24679,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22893,10 +24697,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["panel-title"],
+        "classes": [
+          "panel-title"
+        ],
         "context": "<span class=\"panel-title\">{{ 'dfd.iconPicker.title' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/icon-picker-panel/icon-picker-panel.component.html",
         "line": 4
@@ -22909,7 +24717,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22925,7 +24735,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22941,7 +24753,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22957,7 +24771,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22973,7 +24789,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -22989,7 +24807,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23005,7 +24825,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23021,10 +24843,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
-        "classes": ["position-label"],
+        "classes": [
+          "position-label"
+        ],
         "context": "<div class=\"position-label\">{{ 'dfd.portLabel.positionLabel' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/port-label-popover/port-label-popover.component.html",
         "line": 22
@@ -23037,7 +24863,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23053,7 +24881,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23069,10 +24899,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["popover-title"],
+        "classes": [
+          "popover-title"
+        ],
         "context": "<span class=\"popover-title\">{{ 'dfd.portLabel.title' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/port-label-popover/port-label-popover.component.html",
         "line": 3
@@ -23085,7 +24919,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23101,7 +24937,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23117,10 +24955,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["section-label"],
+        "classes": [
+          "section-label"
+        ],
         "context": "<div class=\"section-label\">{{ 'dfd.stylePanel.defaultColors' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/color-picker/color-picker.component.html",
         "line": 4
@@ -23133,10 +24975,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["section-label"],
+        "classes": [
+          "section-label"
+        ],
         "context": "<div class=\"section-label\">{{ 'dfd.stylePanel.diagramColors' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/color-picker/color-picker.component.html",
         "line": 21
@@ -23149,7 +24995,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23165,7 +25013,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23181,7 +25031,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23197,7 +25049,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23213,7 +25067,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23293,7 +25149,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23373,7 +25231,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23453,7 +25313,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23533,7 +25395,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23613,7 +25477,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23693,7 +25559,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23773,7 +25641,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23853,7 +25723,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23933,7 +25805,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23949,7 +25823,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23965,7 +25841,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23981,7 +25859,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -23997,7 +25877,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24013,7 +25895,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24029,7 +25913,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24045,7 +25931,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24061,10 +25949,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["panel-title"],
+        "classes": [
+          "panel-title"
+        ],
         "context": "<span class=\"panel-title\">{{ 'dfd.stylePanel.title' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/style-panel/style-panel.component.html",
         "line": 4
@@ -24077,7 +25969,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24093,7 +25987,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24109,7 +26005,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24143,7 +26041,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24165,7 +26065,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24193,7 +26095,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["snackbar"],
+    "surfaces": [
+      "snackbar"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24209,7 +26113,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24225,7 +26131,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24247,7 +26155,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24269,7 +26179,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24285,7 +26197,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24307,7 +26221,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24329,7 +26245,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24351,7 +26269,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24373,7 +26293,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24401,7 +26323,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24423,7 +26347,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24445,7 +26371,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24467,7 +26395,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24489,7 +26419,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24511,7 +26443,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24533,7 +26467,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24555,7 +26491,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24583,7 +26521,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24605,7 +26545,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24633,7 +26575,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24655,7 +26599,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24671,7 +26617,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24687,7 +26635,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24703,7 +26653,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24719,7 +26671,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24735,7 +26689,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24751,7 +26707,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24773,7 +26731,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24789,7 +26749,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24811,7 +26773,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24827,7 +26791,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24849,7 +26815,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24865,7 +26833,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24887,7 +26857,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24909,7 +26881,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24931,7 +26905,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24953,7 +26929,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -24975,10 +26953,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["post-create-hint"],
+        "classes": [
+          "post-create-hint"
+        ],
         "context": "<p class=\"post-create-hint\" [transloco]=\"'documentEditor.postCreate.hint'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
         "line": 27
@@ -24991,7 +26973,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25007,7 +26991,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25087,10 +27073,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["source-label"],
+        "classes": [
+          "source-label"
+        ],
         "context": "<label class=\"source-label\" [transloco]=\"'documentEditor.source.label'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
         "line": 41
@@ -25103,7 +27093,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25119,7 +27111,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25135,7 +27129,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25157,7 +27153,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25179,7 +27177,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25201,7 +27201,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25223,7 +27225,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25245,7 +27249,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25261,7 +27267,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25277,7 +27285,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25299,7 +27309,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25357,10 +27369,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["callback-message"],
+        "classes": [
+          "callback-message"
+        ],
         "context": "<p class=\"callback-message\" [transloco]=\"'documentSources.callback.linking'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/content-callback/content-callback.component.html",
         "line": 6
@@ -25373,7 +27389,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25437,7 +27455,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25453,7 +27473,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25469,7 +27491,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25549,7 +27573,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25565,7 +27591,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25581,7 +27609,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25597,7 +27627,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25613,7 +27645,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25683,7 +27717,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25763,7 +27799,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25785,7 +27823,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25801,7 +27841,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25881,7 +27923,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25961,7 +28005,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25977,7 +28023,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -25993,7 +28041,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26015,7 +28065,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26037,7 +28089,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26053,7 +28107,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26069,7 +28125,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26085,7 +28143,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26101,7 +28161,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26123,7 +28185,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26145,7 +28209,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26167,10 +28233,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
-        "classes": ["title-prefix"],
+        "classes": [
+          "title-prefix"
+        ],
         "context": "<span class=\"title-prefix\">{{ 'editor.description' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
         "line": 34
@@ -26183,7 +28253,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26199,7 +28271,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26215,7 +28289,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26231,7 +28307,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26247,7 +28325,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26269,7 +28349,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26285,7 +28367,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26301,7 +28385,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26317,7 +28403,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26339,10 +28427,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["animation-label"],
+        "classes": [
+          "animation-label"
+        ],
         "context": "<div class=\"animation-label\">{{ 'editor.helpDialog.panLabel' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/help-dialog/help-dialog.component.html",
         "line": 34
@@ -26355,7 +28447,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26371,10 +28465,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["animation-label"],
+        "classes": [
+          "animation-label"
+        ],
         "context": "<div class=\"animation-label\">{{ 'editor.helpDialog.zoomLabel' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/help-dialog/help-dialog.component.html",
         "line": 65
@@ -26387,7 +28485,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26403,7 +28503,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26419,7 +28521,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26435,7 +28539,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26451,7 +28557,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26467,7 +28575,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26483,7 +28593,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26499,7 +28611,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26515,7 +28629,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26531,7 +28647,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26547,7 +28665,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26563,7 +28683,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26579,7 +28701,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26595,7 +28719,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26617,7 +28743,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26633,7 +28761,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26649,7 +28779,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26665,7 +28797,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26681,7 +28815,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26697,7 +28833,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26713,7 +28851,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26729,7 +28869,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26745,7 +28887,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26761,7 +28905,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26777,7 +28923,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26793,10 +28941,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'homeDescription'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/home/home.component.html",
         "line": 13
@@ -26809,10 +28961,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["page-title"],
+        "classes": [
+          "page-title"
+        ],
         "context": "<h1 class=\"page-title\" [transloco]=\"'homeWelcomeTitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/home/home.component.html",
         "line": 7
@@ -26825,7 +28981,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26847,7 +29005,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26863,7 +29024,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26879,7 +29042,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26895,7 +29060,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26911,7 +29078,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26927,10 +29096,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["login-explanation"],
+        "classes": [
+          "login-explanation"
+        ],
         "context": "<p class=\"login-explanation\">{{ 'login.explanation' | transloco }}</p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/auth/components/login/login.component.html",
         "line": 16
@@ -26943,7 +29116,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -26959,7 +29134,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27039,7 +29216,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27119,7 +29298,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27141,7 +29322,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27157,7 +29340,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27179,10 +29364,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["provider-section-title"],
+        "classes": [
+          "provider-section-title"
+        ],
         "context": "<h3 class=\"provider-section-title\">{{ 'login.oauthProvidersTitle' | transloco }}</h3>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/auth/components/login/login.component.html",
         "line": 36
@@ -27195,10 +29384,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["provider-section-title"],
+        "classes": [
+          "provider-section-title"
+        ],
         "context": "<h3 class=\"provider-section-title\">{{ 'login.samlProvidersTitle' | transloco }}</h3>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/auth/components/login/login.component.html",
         "line": 65
@@ -27211,7 +29404,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27227,10 +29423,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["signing-in-message"],
+        "classes": [
+          "signing-in-message"
+        ],
         "context": "<p class=\"signing-in-message\">{{ 'login.signingIn' | transloco }}</p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/auth/components/auth-callback/auth-callback.component.html",
         "line": 11
@@ -27243,7 +29443,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27259,7 +29461,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27275,7 +29479,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error"],
+    "surfaces": [
+      "error"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27291,7 +29497,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error"],
+    "surfaces": [
+      "error"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27307,7 +29515,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error"],
+    "surfaces": [
+      "error"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27323,7 +29533,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27339,7 +29551,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27355,7 +29569,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27371,7 +29587,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27387,7 +29605,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27409,7 +29629,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["snackbar"],
+    "surfaces": [
+      "snackbar"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27431,7 +29653,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27447,7 +29671,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item", "tooltip"],
+    "surfaces": [
+      "menu-item",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27469,7 +29696,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27491,7 +29720,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27513,7 +29745,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27535,7 +29770,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "menu-item"],
+    "surfaces": [
+      "button",
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27557,10 +29795,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["app-title"],
+        "classes": [
+          "app-title"
+        ],
         "context": "<span class=\"app-title\" [transloco]=\"'navbar.appTitle'\">TMI: Threat Modeling Improved</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.html",
         "line": 76
@@ -27573,7 +29815,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27589,7 +29833,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "menu-item"],
+    "surfaces": [
+      "button",
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27611,7 +29858,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27627,7 +29876,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27643,7 +29894,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27659,7 +29912,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27675,7 +29930,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27691,7 +29948,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27713,7 +29972,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "menu-item"],
+    "surfaces": [
+      "button",
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27735,7 +29997,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27757,7 +30021,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27773,7 +30039,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27795,7 +30063,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27823,7 +30093,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27845,7 +30117,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27861,7 +30135,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27877,7 +30153,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27893,7 +30171,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27921,7 +30201,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27943,7 +30225,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -27965,7 +30249,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28011,7 +30297,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28033,7 +30321,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28061,7 +30351,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28143,7 +30435,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28165,7 +30459,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28193,7 +30489,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28209,7 +30507,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28289,7 +30589,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28369,7 +30671,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28449,7 +30753,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28471,7 +30777,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28551,7 +30859,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28573,7 +30883,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28595,7 +30907,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28675,7 +30989,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28755,7 +31071,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28777,7 +31095,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28793,7 +31113,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28809,7 +31131,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28831,7 +31155,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28853,7 +31179,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28875,7 +31203,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28891,7 +31221,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28907,7 +31239,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28923,7 +31257,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28939,7 +31275,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28955,7 +31293,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28971,7 +31311,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -28987,7 +31329,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29009,7 +31353,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29031,7 +31377,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29047,7 +31395,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29063,7 +31413,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29079,7 +31431,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29095,7 +31449,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29111,7 +31467,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29127,7 +31485,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29143,7 +31503,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29159,7 +31521,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29175,7 +31539,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29191,7 +31557,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29207,7 +31575,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29223,7 +31593,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29239,7 +31611,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29255,7 +31629,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29271,7 +31647,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29305,7 +31683,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29321,7 +31701,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29337,7 +31719,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29365,7 +31749,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29381,7 +31767,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29397,7 +31785,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29413,7 +31803,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29429,7 +31821,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29451,7 +31845,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29467,7 +31863,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29585,7 +31983,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29601,7 +32001,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29617,7 +32019,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29633,7 +32037,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29649,7 +32055,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29665,7 +32073,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29681,7 +32091,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29697,7 +32109,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29713,7 +32128,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29729,10 +32147,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.changesContent'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 130
@@ -29745,7 +32167,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29761,10 +32185,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.complianceContent'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 123
@@ -29777,7 +32205,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29793,7 +32223,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29809,7 +32242,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29825,7 +32261,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29841,10 +32279,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.dataSecurityContent1'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 98
@@ -29857,10 +32299,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.dataSecurityContent2'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 104
@@ -29873,7 +32319,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29889,10 +32337,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.dataSharingContent1'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 55
@@ -29905,10 +32357,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.dataSharingContent2'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 92
@@ -29921,7 +32377,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29937,7 +32396,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29953,7 +32414,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29969,7 +32432,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -29985,7 +32450,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30001,10 +32468,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.informationCollectionContent1'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 24
@@ -30017,10 +32488,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.informationCollectionContent2'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 39
@@ -30033,10 +32508,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.informationCollectionContent3'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 45
@@ -30049,7 +32528,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30065,7 +32547,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30081,7 +32565,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30097,7 +32583,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30113,7 +32602,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30129,10 +32621,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.intro2'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 18
@@ -30145,7 +32641,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30161,7 +32659,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30177,10 +32678,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["page-title"],
+        "classes": [
+          "page-title"
+        ],
         "context": "<h1 class=\"page-title\" [transloco]=\"'privacy.title'\">Privacy Policy</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 3
@@ -30199,10 +32704,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.userRightsContent1'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 111
@@ -30215,10 +32724,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.userRightsContent2'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 115
@@ -30231,7 +32744,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30247,7 +32762,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30269,7 +32786,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30291,7 +32810,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30313,7 +32834,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30335,7 +32858,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30357,7 +32882,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30379,7 +32906,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30395,7 +32924,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30411,7 +32942,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error"],
+    "surfaces": [
+      "error"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30427,7 +32960,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30443,7 +32978,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error"],
+    "surfaces": [
+      "error"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30459,7 +32996,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30475,7 +33014,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30491,7 +33032,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30507,7 +33050,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30523,7 +33068,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30539,7 +33086,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30555,7 +33104,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30571,7 +33122,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30651,7 +33204,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30673,7 +33228,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30695,7 +33252,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30717,7 +33276,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30739,7 +33300,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30761,7 +33324,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30783,7 +33348,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30805,7 +33372,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30821,7 +33390,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30837,7 +33408,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30853,7 +33426,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30869,7 +33444,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30885,7 +33462,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30901,7 +33480,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30917,7 +33498,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30933,7 +33516,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30949,7 +33534,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -30965,7 +33552,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -31045,7 +33634,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -31125,7 +33716,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -31205,7 +33798,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -31285,7 +33880,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -31301,7 +33898,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -31381,7 +33980,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -31461,7 +34062,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -31541,7 +34144,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -31621,7 +34226,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -31701,7 +34308,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -31781,7 +34390,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -31861,10 +34472,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["subtitle"],
+        "classes": [
+          "subtitle"
+        ],
         "context": "<p class=\"subtitle\" [transloco]=\"'projects.subtitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
         "line": 5
@@ -31877,7 +34492,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -31957,7 +34574,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -31973,7 +34592,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -31989,7 +34610,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32005,7 +34628,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32021,7 +34646,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32037,7 +34664,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32053,7 +34682,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32069,7 +34700,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32085,7 +34718,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32101,7 +34736,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32117,7 +34754,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32133,7 +34772,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32149,7 +34790,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32165,7 +34808,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32181,7 +34826,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32197,7 +34844,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32213,7 +34862,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32235,7 +34886,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "dialog-title"],
+    "surfaces": [
+      "description",
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32251,7 +34905,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32331,7 +34987,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "dialog-title"],
+    "surfaces": [
+      "description",
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32347,7 +35006,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32369,7 +35030,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32397,7 +35060,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32413,7 +35078,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32429,7 +35096,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32445,7 +35114,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32461,10 +35132,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["decision-result-label"],
+        "classes": [
+          "decision-result-label"
+        ],
         "context": "<div class=\"decision-result-label\">{{ t('ssvcCalculator.decisionLabel') }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
         "line": 85
@@ -32477,7 +35152,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32557,7 +35234,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32637,7 +35316,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32717,7 +35398,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32797,7 +35480,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32877,7 +35562,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -32957,7 +35644,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33037,7 +35726,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33117,7 +35808,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33133,7 +35826,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33149,7 +35844,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33165,7 +35862,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33181,7 +35880,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33197,7 +35898,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33213,7 +35916,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33229,7 +35934,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33245,7 +35952,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33325,7 +36034,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33341,7 +36052,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33357,7 +36070,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33373,7 +36088,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33389,7 +36106,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33405,7 +36124,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33421,7 +36142,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33437,7 +36160,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33453,7 +36178,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33469,10 +36196,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["step-title"],
+        "classes": [
+          "step-title"
+        ],
         "context": "<h3 class=\"step-title\">{{ t('ssvcCalculator.summary') }}</h3>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
         "line": 67
@@ -33485,7 +36216,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33501,7 +36234,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33517,7 +36252,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33533,7 +36270,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33549,7 +36288,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33565,7 +36306,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33581,7 +36324,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33597,7 +36342,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33613,7 +36360,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33629,7 +36378,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33645,7 +36396,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33661,7 +36414,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33677,7 +36432,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33693,7 +36450,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33709,7 +36468,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33725,7 +36486,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33805,7 +36568,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33885,7 +36650,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -33965,7 +36732,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34045,7 +36814,11 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "description", "page-title"],
+    "surfaces": [
+      "button",
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34061,7 +36834,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34077,7 +36852,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34093,7 +36870,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34109,7 +36888,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34125,7 +36906,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34205,7 +36988,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34285,7 +37070,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34365,7 +37152,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34445,7 +37234,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34461,7 +37252,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34541,7 +37334,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34621,7 +37416,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34643,7 +37440,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34659,7 +37458,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34675,7 +37476,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34691,7 +37494,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34707,7 +37512,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34723,7 +37530,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34739,10 +37548,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-description"],
+        "classes": [
+          "page-description"
+        ],
         "context": "<p class=\"page-description\">{{ 'surveys.list.pageDescription' | transloco }}</p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
         "line": 14
@@ -34755,10 +37568,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["page-title"],
+        "classes": [
+          "page-title"
+        ],
         "context": "<h1 class=\"page-title\">{{ 'surveys.list.pageTitle' | transloco }}</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
         "line": 3
@@ -34771,7 +37588,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34787,7 +37607,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34803,7 +37626,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "page-title"],
+    "surfaces": [
+      "button",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34819,7 +37645,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34835,7 +37663,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34851,7 +37681,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -34931,7 +37763,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35011,7 +37845,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35027,7 +37863,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35043,7 +37881,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35059,7 +37899,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35075,7 +37917,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35091,7 +37935,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35107,10 +37953,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["page-title"],
+        "classes": [
+          "page-title"
+        ],
         "context": "<h1 class=\"page-title\">{{ 'surveys.responses.pageTitle' | transloco }}</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
         "line": 3
@@ -35123,7 +37973,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35139,7 +37991,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35155,7 +38009,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35235,7 +38091,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35251,7 +38109,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35285,7 +38145,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35313,7 +38175,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35347,7 +38211,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35381,7 +38247,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35415,7 +38283,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35495,7 +38365,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35511,7 +38383,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35527,7 +38401,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35543,7 +38419,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35623,7 +38501,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35639,7 +38519,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35661,7 +38543,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35683,7 +38567,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35705,7 +38591,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35727,7 +38615,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35749,7 +38639,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35771,7 +38663,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35787,7 +38681,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35803,7 +38699,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35819,7 +38717,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35835,7 +38735,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["error"],
+    "surfaces": [
+      "error"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35851,7 +38753,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35931,7 +38835,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35947,7 +38853,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35963,7 +38871,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -35979,7 +38889,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36059,7 +38971,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36075,7 +38989,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36091,7 +39007,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36171,7 +39089,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36187,7 +39107,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36203,7 +39125,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36219,7 +39143,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36241,7 +39167,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36263,7 +39191,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36285,7 +39215,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36307,7 +39239,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36329,7 +39263,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36351,7 +39287,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36367,7 +39305,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36389,7 +39329,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36405,7 +39347,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36421,7 +39365,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36501,7 +39447,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36517,7 +39465,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36533,7 +39483,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36549,7 +39501,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36565,7 +39519,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36581,7 +39537,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36597,7 +39555,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36613,7 +39573,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36693,7 +39655,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36709,7 +39673,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36725,7 +39691,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36805,7 +39773,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36885,7 +39855,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -36965,7 +39937,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -37045,7 +40019,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -37125,7 +40101,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -37205,7 +40183,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -37285,7 +40265,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -37365,7 +40347,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -37445,7 +40429,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -37525,7 +40511,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -37605,7 +40593,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -37685,7 +40675,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -37765,7 +40757,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -37845,7 +40839,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -37925,7 +40921,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38005,7 +41003,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38085,7 +41085,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38165,7 +41167,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38181,7 +41185,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38197,7 +41203,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38277,7 +41285,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38357,7 +41367,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38437,7 +41449,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38517,7 +41531,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38597,10 +41613,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["subtitle"],
+        "classes": [
+          "subtitle"
+        ],
         "context": "<p class=\"subtitle\" [transloco]=\"'teams.subtitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
         "line": 5
@@ -38613,7 +41633,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38629,7 +41651,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38709,7 +41733,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38725,7 +41751,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38741,10 +41769,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["mapping-label"],
+        "classes": [
+          "mapping-label"
+        ],
         "context": "<span class=\"mapping-label\">{{ 'threatEditor.cvss' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 397
@@ -38757,7 +41789,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38837,7 +41871,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38917,7 +41953,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -38997,7 +42035,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39077,10 +42117,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["mapping-label"],
+        "classes": [
+          "mapping-label"
+        ],
         "context": "<span class=\"mapping-label\">{{ 'threatEditor.cweMappings' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 358
@@ -39093,7 +42137,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39109,7 +42155,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39125,10 +42173,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["mapping-label"],
+        "classes": [
+          "mapping-label"
+        ],
         "context": "<span class=\"mapping-label\">{{ 'threatEditor.frameworkMappings' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 323
@@ -39141,7 +42193,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39157,7 +42211,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39173,7 +42229,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39201,7 +42259,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39217,7 +42277,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39233,7 +42295,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39249,7 +42313,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39265,7 +42331,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39281,7 +42349,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39297,7 +42367,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39313,7 +42385,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39393,7 +42467,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39473,7 +42549,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39553,7 +42631,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39633,7 +42713,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39713,7 +42795,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39793,7 +42877,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39873,7 +42959,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -39953,7 +43041,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40033,7 +43123,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40113,7 +43205,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40129,7 +43223,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40209,7 +43305,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40231,7 +43329,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40247,7 +43347,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40327,7 +43429,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40407,7 +43511,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40423,7 +43529,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40503,7 +43611,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40519,7 +43629,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40599,7 +43711,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40679,7 +43793,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40759,7 +43875,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40839,7 +43957,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40919,7 +44039,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -40999,7 +44121,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -41079,7 +44203,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -41159,7 +44285,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -41239,7 +44367,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -41319,7 +44449,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -41399,7 +44531,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -41479,7 +44613,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -41559,7 +44695,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -41639,7 +44777,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -41719,7 +44859,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -41799,7 +44941,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -41879,7 +45023,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -41959,7 +45105,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42039,7 +45187,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42119,7 +45269,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42199,7 +45351,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42279,7 +45433,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42359,7 +45515,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42381,7 +45539,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42397,7 +45557,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42419,7 +45581,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42435,7 +45599,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42451,7 +45617,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42467,7 +45635,10 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "description"],
+    "surfaces": [
+      "button",
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42483,7 +45654,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42499,7 +45672,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42515,10 +45690,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'threatModels.created' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 442
@@ -42531,10 +45710,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'threatModels.createdBy' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 434
@@ -42547,10 +45730,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["page-title"],
+        "classes": [
+          "page-title"
+        ],
         "context": "<h1 class=\"page-title\" [transloco]=\"'threatModels.dashboard'\">Dashboard</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 2
@@ -42563,7 +45750,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42579,7 +45768,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42595,7 +45786,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42611,7 +45804,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42691,7 +45886,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42707,7 +45904,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42723,7 +45922,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42745,7 +45946,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42761,7 +45964,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42777,7 +45982,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42799,7 +46006,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42815,7 +46024,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42831,7 +46042,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42847,7 +46060,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42863,7 +46078,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42879,7 +46096,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42895,7 +46114,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42917,7 +46138,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item", "tooltip"],
+    "surfaces": [
+      "menu-item",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42933,7 +46157,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42949,7 +46175,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42965,7 +46193,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -42981,7 +46211,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43003,7 +46235,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43025,7 +46259,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43041,7 +46277,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43057,7 +46295,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43073,16 +46313,22 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'threatModels.idLabel' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 410
       },
       {
-        "classes": ["dialog-subtitle"],
+        "classes": [
+          "dialog-subtitle"
+        ],
         "context": "<div class=\"dialog-subtitle\">{{ 'threatModels.idLabel' | transloco }}: {{ diagramId }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
         "line": 17
@@ -43095,7 +46341,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43111,7 +46359,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43127,7 +46377,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43143,7 +46395,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43159,10 +46413,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["import-message"],
+        "classes": [
+          "import-message"
+        ],
         "context": "<p class=\"import-message\">{{ 'threatModels.importing' | transloco }}</p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 691
@@ -43175,7 +46433,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43191,7 +46451,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43207,7 +46469,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43223,7 +46487,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43239,7 +46505,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43255,7 +46523,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43271,7 +46541,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43287,7 +46559,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43303,7 +46577,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43319,7 +46595,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43335,7 +46613,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43415,7 +46695,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43431,7 +46713,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43447,7 +46731,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43463,7 +46749,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43543,7 +46831,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43565,7 +46855,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43581,7 +46873,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43597,7 +46891,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43613,7 +46909,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43629,7 +46927,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43645,7 +46945,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43661,7 +46963,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43677,7 +46981,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43693,7 +46999,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43709,7 +47017,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43725,7 +47035,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43741,7 +47053,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43757,7 +47071,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43779,7 +47095,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43801,7 +47119,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43817,10 +47137,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["section-title"],
+        "classes": [
+          "section-title"
+        ],
         "context": "<span class=\"section-title\" [transloco]=\"'threatModels.sections.inputs'\">Inputs</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 466
@@ -43839,7 +47163,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43855,10 +47181,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["section-title"],
+        "classes": [
+          "section-title"
+        ],
         "context": "<span class=\"section-title\" [transloco]=\"'threatModels.sections.outputs'\">Outputs</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 1150
@@ -43877,7 +47207,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43893,7 +47225,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43909,7 +47243,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label", "tooltip"],
+    "surfaces": [
+      "label",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43924,13 +47261,17 @@
         "line": 257
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'threatModels.securityReviewer' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 274
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'threatModels.securityReviewer' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 301
@@ -43943,7 +47284,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43965,7 +47308,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -43981,7 +47326,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -44061,7 +47408,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -44141,7 +47490,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -44221,7 +47572,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -44301,7 +47654,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -44381,7 +47736,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -44461,7 +47818,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -44541,7 +47900,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -44621,7 +47982,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -44701,7 +48064,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -44781,7 +48146,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -44861,7 +48228,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -44877,7 +48246,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -44957,7 +48328,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45037,7 +48410,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45117,7 +48492,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45197,7 +48574,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45277,7 +48656,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45357,7 +48738,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45437,7 +48820,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45517,7 +48902,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45597,7 +48984,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45677,7 +49066,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45692,7 +49083,9 @@
         "line": 185
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'threatModels.statusLastUpdated' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 245
@@ -45705,7 +49098,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45721,7 +49116,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45743,10 +49140,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["title-prefix"],
+        "classes": [
+          "title-prefix"
+        ],
         "context": "<span class=\"title-prefix\">{{ 'threatModels.threatModelPrefix' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 7
@@ -45759,7 +49160,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45775,7 +49178,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45791,7 +49196,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45807,7 +49214,9 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45823,7 +49232,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45839,7 +49250,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45855,7 +49268,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45871,7 +49286,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item"],
+    "surfaces": [
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45887,7 +49304,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45903,7 +49322,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45919,7 +49340,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45941,7 +49364,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45957,7 +49382,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45973,7 +49400,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -45989,7 +49418,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46005,7 +49436,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46021,10 +49454,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["section-title"],
+        "classes": [
+          "section-title"
+        ],
         "context": "<h2 class=\"section-title\" [transloco]=\"'threatModels.yourThreatModels'\">Your Threat Models</h2>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 7
@@ -46037,7 +49474,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46053,7 +49492,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46069,7 +49510,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46085,7 +49529,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46101,7 +49547,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46117,7 +49566,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46133,7 +49584,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46149,7 +49602,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46165,7 +49620,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46181,7 +49638,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46197,7 +49656,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46213,7 +49675,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46229,7 +49693,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46245,7 +49711,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46261,7 +49729,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46277,10 +49748,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'tos.section1.content'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
         "line": 19
@@ -46293,7 +49768,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46309,10 +49786,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'tos.section2.content'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
         "line": 26
@@ -46325,7 +49806,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46341,10 +49824,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'tos.section3.content'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
         "line": 33
@@ -46357,7 +49844,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46373,10 +49862,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'tos.section4.content'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
         "line": 40
@@ -46389,7 +49882,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46405,7 +49900,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46421,7 +49919,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46437,7 +49938,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46453,10 +49956,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'tos.section6.content'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
         "line": 54
@@ -46469,7 +49976,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46485,10 +49994,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["page-content"],
+        "classes": [
+          "page-content"
+        ],
         "context": "<p class=\"page-content\" [transloco]=\"'tos.section7.content'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
         "line": 60
@@ -46501,7 +50014,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46517,7 +50032,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46533,7 +50051,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46549,7 +50070,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46565,7 +50088,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46574,7 +50099,9 @@
         "line": 19
       },
       {
-        "classes": ["page-title"],
+        "classes": [
+          "page-title"
+        ],
         "context": "<h1 class=\"page-title\" [transloco]=\"'tos.title'\">Terms of Service</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
         "line": 3
@@ -46587,7 +50114,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46603,7 +50132,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46619,7 +50150,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46699,7 +50232,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46779,7 +50314,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46795,7 +50332,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46875,7 +50414,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46891,7 +50432,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46907,7 +50450,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46923,7 +50468,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -46939,7 +50486,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47019,7 +50568,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47035,7 +50586,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47051,7 +50604,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47067,7 +50622,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47083,7 +50640,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47163,7 +50722,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47243,7 +50804,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47323,7 +50886,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47403,7 +50968,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47419,7 +50986,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47435,7 +51004,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47515,7 +51086,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "page-title"],
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47524,7 +51098,9 @@
         "line": 86
       },
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'triage.detail.reviewedBy' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 310
@@ -47537,7 +51113,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47553,7 +51131,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47569,10 +51149,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["section-title"],
+        "classes": [
+          "section-title"
+        ],
         "context": "<span class=\"section-title\" [transloco]=\"'triage.detail.surveyResponses'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 368
@@ -47585,10 +51169,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["section-title"],
+        "classes": [
+          "section-title"
+        ],
         "context": "<span class=\"section-title\" [transloco]=\"'triage.detail.triageNotes'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 156
@@ -47601,7 +51189,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47681,7 +51271,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47761,7 +51353,11 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "description", "page-title"],
+    "surfaces": [
+      "button",
+      "description",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47795,7 +51391,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47811,7 +51409,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47827,7 +51427,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47843,7 +51445,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47859,7 +51463,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47881,7 +51488,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47961,7 +51570,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47983,7 +51595,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -47999,7 +51613,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48015,7 +51631,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48031,7 +51649,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48047,7 +51667,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48063,10 +51685,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["not-submitted"],
+        "classes": [
+          "not-submitted"
+        ],
         "context": "<span class=\"not-submitted\">{{ 'triage.list.notSubmitted' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
         "line": 190
@@ -48079,7 +51705,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "tooltip"],
+    "surfaces": [
+      "button",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48101,7 +51730,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48117,10 +51748,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'triage.list.submitted' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 301
@@ -48139,10 +51774,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
-        "classes": ["info-label"],
+        "classes": [
+          "info-label"
+        ],
         "context": "<span class=\"info-label\">{{ 'triage.list.submitter' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 267
@@ -48161,7 +51800,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48241,7 +51882,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48321,7 +51964,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48343,7 +51988,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48365,7 +52012,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48387,7 +52036,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48409,7 +52060,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48431,7 +52084,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48453,7 +52108,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48533,7 +52190,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48549,7 +52208,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48565,7 +52226,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "label"],
+    "surfaces": [
+      "description",
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48587,7 +52251,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48603,7 +52269,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48619,7 +52287,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48635,10 +52305,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
-        "classes": ["page-title"],
+        "classes": [
+          "page-title"
+        ],
         "context": "<h1 class=\"page-title\">{{ 'triage.queue' | transloco }}</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
         "line": 4
@@ -48651,7 +52325,9 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48731,7 +52407,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48747,7 +52425,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48763,7 +52443,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48785,7 +52467,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48801,7 +52485,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48817,7 +52503,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48833,7 +52521,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48849,7 +52539,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48871,7 +52563,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48887,7 +52581,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48903,7 +52599,10 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder", "tooltip"],
+    "surfaces": [
+      "placeholder",
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48931,7 +52630,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48947,7 +52648,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48969,7 +52672,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description", "dialog-title"],
+    "surfaces": [
+      "description",
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -48985,7 +52691,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49001,7 +52709,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49017,7 +52727,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49033,7 +52745,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49049,7 +52763,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49065,7 +52781,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49081,7 +52799,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "menu-item"],
+    "surfaces": [
+      "button",
+      "menu-item"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49103,7 +52824,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["tooltip"],
+    "surfaces": [
+      "tooltip"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49125,7 +52848,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49141,7 +52866,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49157,7 +52884,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49173,7 +52902,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49189,7 +52920,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49205,7 +52938,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49221,7 +52956,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49237,7 +52974,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49253,7 +52992,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49275,7 +53016,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49291,7 +53034,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49307,7 +53052,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49323,7 +53070,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49339,7 +53088,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49355,7 +53106,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49371,7 +53124,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49387,7 +53142,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49403,7 +53160,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["label"],
+    "surfaces": [
+      "label"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49419,7 +53178,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49435,7 +53196,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49451,7 +53214,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49467,7 +53232,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49483,7 +53250,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49499,7 +53268,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49515,7 +53286,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49531,7 +53304,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49547,7 +53322,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49563,7 +53340,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49579,7 +53358,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49595,7 +53376,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49611,7 +53394,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49627,7 +53412,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49643,7 +53430,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["dialog-title"],
+    "surfaces": [
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49659,7 +53448,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49675,7 +53466,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49691,7 +53484,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49707,7 +53502,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49723,7 +53520,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button"],
+    "surfaces": [
+      "button"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49745,7 +53544,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49761,7 +53562,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["placeholder"],
+    "surfaces": [
+      "placeholder"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49777,7 +53580,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49799,7 +53604,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49821,7 +53628,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49843,7 +53652,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49865,7 +53676,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49887,7 +53700,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49909,7 +53724,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49925,7 +53742,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["button", "dialog-title"],
+    "surfaces": [
+      "button",
+      "dialog-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49959,7 +53779,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49975,7 +53797,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -49991,7 +53815,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50007,7 +53833,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50023,7 +53851,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50039,7 +53869,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50055,7 +53887,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50071,7 +53905,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50087,7 +53923,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50103,7 +53941,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50119,7 +53959,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50135,7 +53977,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50151,7 +53995,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50167,7 +54013,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50183,7 +54031,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50199,7 +54049,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50215,7 +54067,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50231,7 +54085,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50247,7 +54103,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50263,7 +54121,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50279,7 +54139,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50295,7 +54157,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50311,7 +54175,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50327,7 +54193,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50343,7 +54211,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50359,7 +54229,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50375,7 +54247,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50391,7 +54265,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50407,7 +54283,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50423,7 +54301,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50439,7 +54319,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50455,7 +54337,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50471,7 +54355,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50487,7 +54373,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50503,7 +54391,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50519,7 +54409,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50535,7 +54427,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50551,7 +54445,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50567,7 +54463,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50583,7 +54481,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["general"],
+    "surfaces": [
+      "general"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50599,7 +54499,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50615,7 +54517,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50631,7 +54535,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50647,10 +54553,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["subtitle"],
+        "classes": [
+          "subtitle"
+        ],
         "context": "<p class=\"subtitle\" [transloco]=\"'userProjects.subtitle'\"></p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
         "line": 5
@@ -50663,7 +54573,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item", "page-title"],
+    "surfaces": [
+      "menu-item",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50685,7 +54598,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["page-title"],
+    "surfaces": [
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50701,7 +54616,9 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
         "classes": [],
@@ -50717,10 +54634,14 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["description"],
+    "surfaces": [
+      "description"
+    ],
     "uses": [
       {
-        "classes": ["subtitle"],
+        "classes": [
+          "subtitle"
+        ],
         "context": "<p class=\"subtitle\" [transloco]=\"'userTeams.subtitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 5
@@ -50733,7 +54654,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": ["menu-item", "page-title"],
+    "surfaces": [
+      "menu-item",
+      "page-title"
+    ],
     "uses": [
       {
         "classes": [],

--- a/src/assets/i18n/en-US.usage.json
+++ b/src/assets/i18n/en-US.usage.json
@@ -5,9 +5,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -23,9 +21,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -47,9 +43,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -65,10 +59,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -84,9 +75,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -102,14 +91,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "page-title"
-        ],
+        "classes": ["page-title"],
         "context": "<h1 class=\"page-title\" [transloco]=\"'about.contacttitle'\">Operated By</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 27
@@ -122,14 +107,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'about.description1'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 11
@@ -142,14 +123,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'about.description2'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 18
@@ -162,9 +139,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -180,9 +155,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -198,9 +171,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -216,10 +187,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -235,9 +203,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -253,9 +219,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -271,14 +235,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "page-title"
-        ],
+        "classes": ["page-title"],
         "context": "<h1 class=\"page-title\" [transloco]=\"'about.opensourcetitle'\">Open Source</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 99
@@ -291,9 +251,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -309,9 +267,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -327,9 +283,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -351,14 +305,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "page-title"
-        ],
+        "classes": ["page-title"],
         "context": "<h1 class=\"page-title\" [transloco]=\"'about.sourcetitle'\">TMI Project</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 59
@@ -371,14 +321,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "page-title"
-        ],
+        "classes": ["page-title"],
         "context": "<h1 class=\"page-title\" [transloco]=\"'about.title'\">About TMI</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 7
@@ -391,15 +337,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content",
-          "trademarks"
-        ],
+        "classes": ["page-content", "trademarks"],
         "context": "<p class=\"page-content trademarks\" [transloco]=\"'about.trademarks'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 169
@@ -412,14 +353,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "page-title"
-        ],
+        "classes": ["page-title"],
         "context": "<h1 class=\"page-title\" [transloco]=\"'about.version'\">Version Information</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 45
@@ -432,10 +369,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -451,9 +385,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -469,9 +401,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -493,10 +423,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -512,10 +439,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -537,14 +461,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "bulk-indicator"
-        ],
+        "classes": ["bulk-indicator"],
         "context": "<span class=\"bulk-indicator\" [transloco]=\"'addons.invokeDialog.allObjects'\">(All)</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 30
@@ -557,9 +477,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -575,9 +493,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error"
-    ],
+    "surfaces": ["error"],
     "uses": [
       {
         "classes": [],
@@ -593,9 +509,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -611,9 +525,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -629,9 +541,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error"
-    ],
+    "surfaces": ["error"],
     "uses": [
       {
         "classes": [],
@@ -647,9 +557,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error"
-    ],
+    "surfaces": ["error"],
     "uses": [
       {
         "classes": [],
@@ -665,14 +573,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "section-label"
-        ],
+        "classes": ["section-label"],
         "context": "<span class=\"section-label\" [transloco]=\"'addons.invokeDialog.parameters'\">Parameters</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 76
@@ -685,14 +589,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\" [transloco]=\"'addons.invokeDialog.threatModelId'\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 56
@@ -705,9 +605,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -723,9 +621,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error"
-    ],
+    "surfaces": ["error"],
     "uses": [
       {
         "classes": [],
@@ -741,9 +637,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -759,9 +653,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -777,9 +669,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -795,9 +685,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -813,9 +701,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -831,9 +717,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -849,9 +733,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -867,9 +749,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -885,9 +765,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -903,9 +781,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -921,9 +797,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -939,9 +813,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -957,9 +829,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -975,9 +845,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -993,9 +861,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1011,9 +877,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -1029,9 +893,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -1047,9 +909,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -1065,9 +925,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1083,9 +941,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1101,9 +957,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1119,10 +973,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item",
-      "tooltip"
-    ],
+    "surfaces": ["menu-item", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -1138,9 +989,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1156,9 +1005,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1174,9 +1021,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -1192,9 +1037,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -1210,9 +1053,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -1228,9 +1069,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -1246,9 +1085,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -1264,14 +1101,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "subtitle"
-        ],
+        "classes": ["subtitle"],
         "context": "<p class=\"subtitle\" [transloco]=\"'admin.addons.subtitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/addons/admin-addons.component.html",
         "line": 5
@@ -1284,9 +1117,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -1302,9 +1133,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -1320,9 +1149,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -1338,9 +1165,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -1356,9 +1181,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -1374,9 +1197,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -1392,9 +1213,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1410,9 +1229,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1428,9 +1245,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1446,9 +1261,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -1464,9 +1277,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1482,9 +1293,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1500,9 +1309,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -1518,9 +1325,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -1536,9 +1341,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -1554,9 +1357,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -1572,9 +1373,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -1590,9 +1389,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -1608,9 +1405,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -1626,9 +1421,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -1644,9 +1437,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1662,9 +1453,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -1680,9 +1469,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -1698,9 +1485,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1716,9 +1501,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -1734,9 +1517,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1752,9 +1533,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1770,9 +1549,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -1788,9 +1565,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1806,9 +1581,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1824,9 +1597,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1842,9 +1613,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -1860,9 +1629,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -1878,9 +1645,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -1896,9 +1661,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -1914,9 +1677,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -1932,9 +1693,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -1956,9 +1715,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -1974,9 +1731,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -1992,9 +1747,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -2010,9 +1763,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -2028,9 +1779,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -2046,9 +1795,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -2064,9 +1811,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -2082,9 +1827,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -2100,9 +1843,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -2118,14 +1859,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "subtitle"
-        ],
+        "classes": ["subtitle"],
         "context": "<p class=\"subtitle\" [transloco]=\"'admin.groups.subtitle'\">View and manage system groups</p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/groups/admin-groups.component.html",
         "line": 5
@@ -2138,9 +1875,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -2156,9 +1891,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -2174,9 +1907,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -2192,9 +1923,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -2210,9 +1939,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -2228,9 +1955,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -2246,9 +1971,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -2264,9 +1987,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -2282,9 +2003,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -2300,9 +2019,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -2318,9 +2035,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2342,9 +2057,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2366,9 +2079,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2390,9 +2101,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2438,10 +2147,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item",
-      "tooltip"
-    ],
+    "surfaces": ["menu-item", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -2463,9 +2169,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -2487,9 +2191,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -2505,9 +2207,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -2523,9 +2223,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -2547,9 +2245,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -2565,9 +2261,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -2583,9 +2277,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -2607,9 +2299,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -2631,9 +2321,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -2655,9 +2343,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -2679,14 +2365,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "subtitle"
-        ],
+        "classes": ["subtitle"],
         "context": "<p class=\"subtitle\" [transloco]=\"'admin.quotas.subtitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
         "line": 5
@@ -2699,9 +2381,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -2717,9 +2397,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -2735,9 +2413,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -2753,9 +2429,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2771,9 +2445,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2789,9 +2461,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2807,9 +2477,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2825,9 +2493,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2843,9 +2509,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2861,9 +2525,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2879,9 +2541,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2897,9 +2557,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2915,9 +2573,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2933,9 +2589,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2951,9 +2605,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2969,9 +2621,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -2987,9 +2637,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3005,9 +2653,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3023,9 +2669,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3041,9 +2685,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3059,9 +2701,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3077,9 +2717,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -3095,9 +2733,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -3113,9 +2749,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -3131,9 +2765,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -3149,9 +2781,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -3173,9 +2803,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3191,9 +2819,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3209,9 +2835,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3227,9 +2851,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -3245,9 +2867,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -3263,9 +2883,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3281,9 +2899,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -3317,9 +2933,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3347,9 +2961,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -3365,9 +2977,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3383,9 +2993,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3401,9 +3009,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3419,9 +3025,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3437,9 +3041,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -3455,10 +3057,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -3474,9 +3073,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -3492,9 +3089,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -3510,9 +3105,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -3528,9 +3121,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -3546,10 +3137,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -3565,9 +3153,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -3583,9 +3169,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3665,9 +3249,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3747,9 +3329,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3829,9 +3409,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -3911,14 +3489,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "subtitle"
-        ],
+        "classes": ["subtitle"],
         "context": "<p class=\"subtitle\" [transloco]=\"'admin.settings.subtitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/settings/admin-settings.component.html",
         "line": 5
@@ -3931,9 +3505,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -3949,9 +3521,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4031,9 +3601,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4113,9 +3681,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4195,9 +3761,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4277,14 +3841,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "admin-subtitle"
-        ],
+        "classes": ["admin-subtitle"],
         "context": "<p class=\"admin-subtitle\" [transloco]=\"'admin.subtitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/admin.component.html",
         "line": 5
@@ -4297,9 +3857,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -4315,9 +3873,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -4333,9 +3889,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4351,9 +3905,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4369,9 +3921,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4387,9 +3937,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4405,9 +3953,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4423,9 +3969,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -4441,9 +3985,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -4459,9 +4001,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4477,9 +4017,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -4495,9 +4033,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -4513,9 +4049,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4531,9 +4065,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -4549,9 +4081,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4567,9 +4097,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4585,9 +4113,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4603,9 +4129,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4621,14 +4145,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "muted"
-        ],
+        "classes": ["muted"],
         "context": "<span class=\"muted\" [transloco]=\"'admin.users.never'\">Never</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.html",
         "line": 111
@@ -4647,9 +4167,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -4665,14 +4183,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "subtitle"
-        ],
+        "classes": ["subtitle"],
         "context": "<p class=\"subtitle\" [transloco]=\"'admin.users.subtitle'\">View and manage system users</p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.html",
         "line": 5
@@ -4685,9 +4199,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -4703,9 +4215,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4721,9 +4231,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4739,9 +4247,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4757,9 +4263,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4775,9 +4279,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -4793,9 +4295,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -4811,9 +4311,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4829,9 +4327,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -4847,9 +4343,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -4865,9 +4359,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -4883,9 +4375,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4901,9 +4391,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -4919,9 +4407,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -4937,9 +4423,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -4955,9 +4439,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4973,9 +4455,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -4997,9 +4477,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -5015,9 +4493,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -5033,9 +4509,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -5051,9 +4525,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -5069,9 +4541,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -5087,9 +4557,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -5105,9 +4573,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -5129,9 +4595,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -5147,9 +4611,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -5165,9 +4627,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -5183,9 +4643,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -5201,9 +4659,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -5219,9 +4675,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -5237,9 +4691,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -5319,9 +4771,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -5337,9 +4787,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -5355,9 +4803,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -5373,14 +4819,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "warning-text"
-        ],
+        "classes": ["warning-text"],
         "context": "<p class=\"warning-text\" [transloco]=\"'admin.webhooks.hmacSecretDialog.warning'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/hmac-secret-dialog/hmac-secret-dialog.component.html",
         "line": 3
@@ -5393,9 +4835,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -5411,9 +4851,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -5429,9 +4867,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -5511,9 +4947,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -5593,9 +5027,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -5675,9 +5107,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -5757,9 +5187,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -5775,14 +5203,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "subtitle"
-        ],
+        "classes": ["subtitle"],
         "context": "<p class=\"subtitle\" [transloco]=\"'admin.webhooks.subtitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
         "line": 5
@@ -5795,9 +5219,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -5813,9 +5235,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -5831,9 +5251,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -5849,9 +5267,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -5867,9 +5283,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -5885,9 +5299,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -5903,9 +5315,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error"
-    ],
+    "surfaces": ["error"],
     "uses": [
       {
         "classes": [],
@@ -5921,9 +5331,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -5939,9 +5347,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -5957,9 +5363,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -5975,9 +5379,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -5993,9 +5395,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error"
-    ],
+    "surfaces": ["error"],
     "uses": [
       {
         "classes": [],
@@ -6011,11 +5411,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["button", "description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -6049,9 +5445,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6073,9 +5467,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6109,9 +5501,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -6127,10 +5517,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title",
-      "tooltip"
-    ],
+    "surfaces": ["page-title", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -6152,9 +5539,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6170,9 +5555,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -6188,9 +5571,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -6206,9 +5587,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -6224,9 +5603,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -6242,14 +5619,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "page-title"
-        ],
+        "classes": ["page-title"],
         "context": "<h1 class=\"page-title\">{{ 'adminSurveys.pageTitle' | transloco }}</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.html",
         "line": 3
@@ -6262,9 +5635,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -6280,9 +5651,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -6298,9 +5667,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -6316,9 +5683,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -6334,11 +5699,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["button", "description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -6354,9 +5715,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -6372,9 +5731,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6390,10 +5747,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -6409,9 +5763,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -6427,9 +5779,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -6445,10 +5795,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label",
-      "placeholder"
-    ],
+    "surfaces": ["label", "placeholder"],
     "uses": [
       {
         "classes": [],
@@ -6464,9 +5811,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -6482,9 +5827,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -6500,9 +5843,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -6518,9 +5859,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6536,9 +5875,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6554,9 +5891,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -6572,10 +5907,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label",
-      "page-title"
-    ],
+    "surfaces": ["label", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -6591,10 +5923,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label",
-      "placeholder"
-    ],
+    "surfaces": ["label", "placeholder"],
     "uses": [
       {
         "classes": [],
@@ -6610,9 +5939,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -6628,9 +5955,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -6646,9 +5971,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -6664,9 +5987,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -6682,14 +6003,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "hint"
-        ],
+        "classes": ["hint"],
         "context": "<p class=\"hint\">{{ 'adminSurveys.templateBuilder.noQuestionsHint' | transloco }}</p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/components/template-builder/template-builder.component.html",
         "line": 216
@@ -6702,9 +6019,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -6720,9 +6035,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -6738,9 +6051,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -6756,9 +6067,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -6774,9 +6083,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6792,9 +6099,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6810,9 +6115,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6828,9 +6131,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6846,9 +6147,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6864,9 +6163,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6882,9 +6179,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6900,9 +6195,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6918,9 +6211,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6936,9 +6227,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6954,9 +6243,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6972,9 +6259,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -6990,9 +6275,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7008,9 +6291,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7026,9 +6307,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -7044,9 +6323,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -7062,9 +6339,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7080,10 +6355,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label",
-      "placeholder"
-    ],
+    "surfaces": ["label", "placeholder"],
     "uses": [
       {
         "classes": [],
@@ -7099,9 +6371,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -7117,9 +6387,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -7135,9 +6403,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -7153,9 +6419,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -7171,9 +6435,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7189,9 +6451,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7207,9 +6467,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7225,9 +6483,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7243,9 +6499,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7261,9 +6515,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7279,9 +6531,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7297,9 +6547,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7315,9 +6563,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7333,9 +6579,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7351,9 +6595,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7369,9 +6611,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -7387,9 +6627,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -7405,9 +6643,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7423,9 +6659,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -7441,9 +6675,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -7459,9 +6691,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7477,9 +6707,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7495,9 +6723,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -7513,14 +6739,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
-        "classes": [
-          "chip-label"
-        ],
+        "classes": ["chip-label"],
         "context": "<mat-label class=\"chip-label\">{{ 'assetEditor.classification' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
         "line": 79
@@ -7533,9 +6755,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -7551,9 +6771,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -7569,10 +6787,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label",
-      "placeholder"
-    ],
+    "surfaces": ["label", "placeholder"],
     "uses": [
       {
         "classes": [],
@@ -7594,9 +6809,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -7612,9 +6825,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -7630,9 +6841,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -7648,9 +6857,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -7672,9 +6879,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7754,9 +6959,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7836,9 +7039,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -7918,9 +7119,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8000,9 +7199,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8082,9 +7279,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8164,9 +7359,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8182,9 +7375,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8200,9 +7391,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8218,9 +7407,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8300,9 +7487,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8382,9 +7567,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8400,9 +7583,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8418,9 +7599,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8436,9 +7615,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8454,9 +7631,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8472,9 +7647,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8490,9 +7663,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -8508,9 +7679,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8590,9 +7759,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8672,9 +7839,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -8690,9 +7855,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -8708,9 +7871,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -8726,9 +7887,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -8744,9 +7903,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -8768,9 +7925,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -8786,9 +7941,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -8804,9 +7957,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -8822,10 +7973,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "placeholder"
-    ],
+    "surfaces": ["description", "placeholder"],
     "uses": [
       {
         "classes": [],
@@ -8865,9 +8013,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -8947,9 +8093,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -9029,9 +8173,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -9047,9 +8189,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -9129,9 +8269,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -9147,10 +8285,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item",
-      "page-title"
-    ],
+    "surfaces": ["menu-item", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -9195,9 +8330,7 @@
         "line": 1914
       },
       {
-        "classes": [
-          "title-prefix"
-        ],
+        "classes": ["title-prefix"],
         "context": "<span class=\"title-prefix\">{{ 'auditTrail.title' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/audit-trail-page/audit-trail-page.component.html",
         "line": 4
@@ -9216,9 +8349,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -9234,9 +8365,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -9252,9 +8381,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -9270,10 +8397,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -9289,9 +8413,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -9307,9 +8429,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -9389,9 +8509,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -9407,9 +8525,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -9425,9 +8541,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -9443,9 +8557,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -9479,9 +8591,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -9561,9 +8671,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -9579,9 +8687,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -9609,9 +8715,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -9639,9 +8743,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -9675,9 +8777,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -9711,9 +8811,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -9729,9 +8827,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -9747,9 +8843,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -9765,9 +8859,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -9783,9 +8875,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -9801,9 +8891,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -9819,9 +8907,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -9837,9 +8923,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "snackbar"
-    ],
+    "surfaces": ["snackbar"],
     "uses": [
       {
         "classes": [],
@@ -9861,9 +8945,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -9879,9 +8961,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -9897,9 +8977,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -9927,9 +9005,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -9957,9 +9033,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -9975,9 +9049,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10057,9 +9129,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -10075,9 +9145,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10093,9 +9161,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10111,9 +9177,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10129,9 +9193,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10147,9 +9209,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10165,9 +9225,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10183,9 +9241,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -10201,9 +9257,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -10225,11 +9279,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["button", "description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -10251,9 +9301,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -10275,15 +9323,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
-        "classes": [
-          "toolbar-title"
-        ],
+        "classes": ["toolbar-title"],
         "context": "<span class=\"toolbar-title\">{{ t('chat.title') }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.html",
         "line": 4
@@ -10308,9 +9351,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -10332,10 +9373,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item",
-      "tooltip"
-    ],
+    "surfaces": ["menu-item", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -10357,9 +9395,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10439,14 +9475,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "section-title"
-        ],
+        "classes": ["section-title"],
         "context": "<h4 class=\"section-title\">{{ 'collaboration.collaboratorsHeader' | transloco }}</h4>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/collaboration-dialog/collaboration-dialog.component.html",
         "line": 17
@@ -10459,9 +9491,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -10477,10 +9507,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item",
-      "tooltip"
-    ],
+    "surfaces": ["menu-item", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -10502,9 +9529,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10520,9 +9545,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -10544,9 +9567,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10562,10 +9583,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -10605,9 +9623,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10629,9 +9645,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10647,9 +9661,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10665,9 +9677,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -10683,9 +9693,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10765,9 +9773,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -10783,9 +9789,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -10801,9 +9805,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -10819,9 +9821,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -10843,9 +9843,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -10867,9 +9865,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10885,9 +9881,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -10903,9 +9897,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -10921,9 +9913,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10945,9 +9935,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10969,9 +9957,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -10993,9 +9979,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -11011,9 +9995,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -11041,10 +10023,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -11096,9 +10075,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -11390,10 +10367,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -11409,9 +10383,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -11491,9 +10463,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -11515,9 +10485,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -11539,9 +10507,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -11569,10 +10535,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item",
-      "tooltip"
-    ],
+    "surfaces": ["menu-item", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -11672,10 +10635,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "label"
-    ],
+    "surfaces": ["description", "label"],
     "uses": [
       {
         "classes": [],
@@ -11703,9 +10663,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -11721,9 +10679,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -11739,9 +10695,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -11821,11 +10775,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "error",
-      "tooltip"
-    ],
+    "surfaces": ["button", "error", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -12243,9 +11193,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -12261,9 +11209,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -12285,10 +11231,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -12328,9 +11271,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -12364,9 +11305,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -12382,13 +11321,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "description",
-      "page-title",
-      "snackbar",
-      "tooltip"
-    ],
+    "surfaces": ["button", "description", "page-title", "snackbar", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -12902,9 +11835,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -12938,9 +11869,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -12974,9 +11903,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -12992,9 +11919,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "snackbar"
-    ],
+    "surfaces": ["snackbar"],
     "uses": [
       {
         "classes": [],
@@ -13040,10 +11965,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -13083,11 +12005,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "menu-item",
-      "tooltip"
-    ],
+    "surfaces": ["button", "menu-item", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -13193,10 +12111,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -13260,9 +12175,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -13283,9 +12196,7 @@
         "line": 217
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.created' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 293
@@ -13297,25 +12208,19 @@
         "line": 84
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.created' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 61
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.created' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
         "line": 66
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.created' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
         "line": 12
@@ -13328,9 +12233,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -13346,9 +12249,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -13370,9 +12271,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -13406,10 +12305,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -13425,11 +12321,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "menu-item",
-      "tooltip"
-    ],
+    "surfaces": ["button", "menu-item", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -13577,9 +12469,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -13595,9 +12485,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -13619,9 +12507,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -13637,9 +12523,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -13661,9 +12545,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -13685,10 +12567,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "placeholder"
-    ],
+    "surfaces": ["description", "placeholder"],
     "uses": [
       {
         "classes": [],
@@ -13710,9 +12589,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -13728,9 +12605,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -13746,9 +12621,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -13764,9 +12637,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -13782,9 +12653,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -13806,9 +12675,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -13962,9 +12829,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -13980,9 +12845,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "snackbar"
-    ],
+    "surfaces": ["snackbar"],
     "uses": [
       {
         "classes": [],
@@ -14052,9 +12915,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -14094,11 +12955,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "menu-item",
-      "tooltip"
-    ],
+    "surfaces": ["button", "menu-item", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -14120,9 +12977,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -14180,9 +13035,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -14198,14 +13051,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.email' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 275
@@ -14218,9 +13067,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -14242,9 +13089,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -14272,9 +13117,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -14302,9 +13145,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -14332,9 +13173,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -14350,9 +13189,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -14368,9 +13205,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -14450,22 +13285,16 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.id' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 334
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\" [transloco]=\"'common.id'\">ID</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 43
@@ -14478,9 +13307,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -14560,9 +13387,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -14614,9 +13439,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -14668,9 +13491,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -14698,10 +13519,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -14723,10 +13541,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "menu-item"
-    ],
+    "surfaces": ["button", "menu-item"],
     "uses": [
       {
         "classes": [],
@@ -14748,10 +13563,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "tooltip"
-    ],
+    "surfaces": ["description", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -14760,17 +13572,13 @@
         "line": 111
       },
       {
-        "classes": [
-          "date-label"
-        ],
+        "classes": ["date-label"],
         "context": "<span class=\"date-label\">{{ 'common.lastModified' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 335
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.lastModified' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 318
@@ -14782,41 +13590,31 @@
         "line": 162
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.lastModified' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
         "line": 72
       },
       {
-        "classes": [
-          "summary-label"
-        ],
+        "classes": ["summary-label"],
         "context": "<span class=\"summary-label\">{{ 'common.lastModified' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 396
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.lastModified' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 424
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.lastModified' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
         "line": 18
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.lastModified' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 67
@@ -14829,10 +13627,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -14854,14 +13649,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "info-value"
-        ],
+        "classes": ["info-value"],
         "context": "<span class=\"info-value\">{{ projectName ?? ('common.loading' | transloco) }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/response-detail/response-detail.component.html",
         "line": 91
@@ -14892,9 +13683,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -14974,11 +13763,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "dialog-title",
-      "tooltip"
-    ],
+    "surfaces": ["button", "dialog-title", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -15054,10 +13839,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title",
-      "tooltip"
-    ],
+    "surfaces": ["dialog-title", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -15079,9 +13861,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -15109,9 +13889,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -15133,9 +13911,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -15157,9 +13933,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -15187,9 +13961,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -15211,9 +13983,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -15229,9 +13999,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -15271,9 +14039,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -15384,9 +14150,7 @@
         "line": 87
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\" [transloco]=\"'common.name'\">Name</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 38
@@ -15417,9 +14181,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -15519,9 +14281,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -15549,9 +14309,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -15631,9 +14389,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -15649,9 +14405,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -15667,9 +14421,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -15762,9 +14514,7 @@
         "line": 110
       },
       {
-        "classes": [
-          "muted"
-        ],
+        "classes": ["muted"],
         "context": "<span class=\"muted\" [transloco]=\"'common.none'\">None</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.html",
         "line": 129
@@ -15795,9 +14545,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -15867,9 +14615,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -15897,9 +14643,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -15979,9 +14723,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -16061,9 +14803,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -16078,9 +14818,7 @@
         "line": 279
       },
       {
-        "classes": [
-          "title-prefix"
-        ],
+        "classes": ["title-prefix"],
         "context": "<span class=\"title-prefix\">{{ 'common.objectTypes.diagram' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
         "line": 22
@@ -16123,9 +14861,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -16141,9 +14877,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -16195,9 +14929,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -16225,9 +14957,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -16243,9 +14973,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -16254,9 +14982,7 @@
         "line": 236
       },
       {
-        "classes": [
-          "title-prefix"
-        ],
+        "classes": ["title-prefix"],
         "context": "<span class=\"title-prefix\">{{ 'common.objectTypes.note' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
         "line": 6
@@ -16305,9 +15031,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -16335,9 +15059,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -16353,9 +15075,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -16435,9 +15155,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -16453,9 +15171,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -16535,9 +15251,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -16559,9 +15273,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -16613,9 +15325,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -16624,9 +15334,7 @@
         "line": 73
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.objectTypes.survey' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 282
@@ -16681,9 +15389,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -16699,9 +15405,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -16781,9 +15485,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -16863,9 +15565,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -16881,9 +15581,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -16963,9 +15661,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -17004,9 +15700,7 @@
         "line": 2516
       },
       {
-        "classes": [
-          "title-prefix"
-        ],
+        "classes": ["title-prefix"],
         "context": "<span class=\"title-prefix\">{{ 'common.objectTypes.threat' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 6
@@ -17025,9 +15719,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -17054,9 +15746,7 @@
         "line": 2421
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\" [transloco]=\"'common.objectTypes.threatModel'\">Threat Model</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 51
@@ -17068,9 +15758,7 @@
         "line": 278
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.objectTypes.threatModel' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 326
@@ -17088,9 +15776,7 @@
         "line": 231
       },
       {
-        "classes": [
-          "title-prefix"
-        ],
+        "classes": ["title-prefix"],
         "context": "<span class=\"title-prefix\">{{ 'common.objectTypes.threatModel' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
         "line": 17
@@ -17103,9 +15789,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -17185,10 +15869,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "page-title"
-    ],
+    "surfaces": ["button", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -17228,9 +15909,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -17288,9 +15967,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -17312,9 +15989,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -17336,9 +16011,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -17372,9 +16045,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -17396,9 +16067,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -17420,22 +16089,16 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.project' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/response-detail/response-detail.component.html",
         "line": 90
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.project' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 152
@@ -17448,9 +16111,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -17530,11 +16191,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title",
-      "page-title",
-      "tooltip"
-    ],
+    "surfaces": ["dialog-title", "page-title", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -17604,9 +16261,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -17688,11 +16343,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["button", "description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -17762,9 +16413,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -17786,9 +16435,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -17810,9 +16457,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -17834,10 +16479,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -18027,9 +16669,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -18045,9 +16685,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -18069,9 +16707,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -18093,16 +16729,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "label",
-      "tooltip"
-    ],
+    "surfaces": ["button", "label", "tooltip"],
     "uses": [
       {
-        "classes": [
-          "score-label"
-        ],
+        "classes": ["score-label"],
         "context": "<span class=\"score-label\"> {{ 'common.score' | transloco }}: </span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
         "line": 89
@@ -18127,9 +16757,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -18151,9 +16779,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -18233,9 +16859,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -18257,9 +16881,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -18275,9 +16897,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -18293,9 +16913,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -18311,9 +16929,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -18365,11 +16981,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "label",
-      "page-title"
-    ],
+    "surfaces": ["description", "label", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -18390,9 +17002,7 @@
         "line": 209
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.status' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 257
@@ -18452,17 +17062,13 @@
         "line": 95
       },
       {
-        "classes": [
-          "status-label"
-        ],
+        "classes": ["status-label"],
         "context": "<span class=\"status-label\">{{ 'common.status' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 339
       },
       {
-        "classes": [
-          "summary-label"
-        ],
+        "classes": ["summary-label"],
         "context": "<span class=\"summary-label\">{{ 'common.status' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 171
@@ -18474,9 +17080,7 @@
         "line": 215
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.status' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 230
@@ -18513,9 +17117,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -18531,9 +17133,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -18549,9 +17149,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -18573,9 +17171,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -18597,9 +17193,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -18627,9 +17221,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -18651,10 +17243,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title",
-      "label"
-    ],
+    "surfaces": ["dialog-title", "label"],
     "uses": [
       {
         "classes": [],
@@ -18688,9 +17277,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -18718,9 +17305,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -18742,9 +17327,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -18760,9 +17343,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -18778,9 +17359,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -18789,9 +17368,7 @@
         "line": 105
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\" [transloco]=\"'common.type'\">Type</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 26
@@ -18804,9 +17381,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -18822,9 +17397,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -18852,9 +17425,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -18882,9 +17453,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error"
-    ],
+    "surfaces": ["error"],
     "uses": [
       {
         "classes": [],
@@ -18900,10 +17469,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error",
-      "placeholder"
-    ],
+    "surfaces": ["error", "placeholder"],
     "uses": [
       {
         "classes": [],
@@ -18919,11 +17485,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error",
-      "label",
-      "placeholder"
-    ],
+    "surfaces": ["error", "label", "placeholder"],
     "uses": [
       {
         "classes": [],
@@ -19131,9 +17693,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -19213,11 +17773,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error",
-      "label",
-      "placeholder"
-    ],
+    "surfaces": ["error", "label", "placeholder"],
     "uses": [
       {
         "classes": [],
@@ -19353,10 +17909,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -19371,9 +17924,7 @@
         "line": 139
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'common.version' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 288
@@ -19386,9 +17937,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -19468,11 +18017,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "dialog-title",
-      "tooltip"
-    ],
+    "surfaces": ["button", "dialog-title", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -19536,9 +18081,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -19554,9 +18097,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -19572,9 +18113,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -19590,9 +18129,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -19608,9 +18145,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -19626,9 +18161,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -19644,9 +18177,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -19662,9 +18193,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -19680,9 +18209,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -19698,9 +18225,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -19716,9 +18241,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -19734,9 +18257,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -19752,9 +18273,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -19770,9 +18289,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -19788,9 +18305,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -19806,9 +18321,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -19824,9 +18337,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -19842,9 +18353,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -19860,9 +18369,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error"
-    ],
+    "surfaces": ["error"],
     "uses": [
       {
         "classes": [],
@@ -19878,9 +18385,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -19896,9 +18401,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -19914,9 +18417,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -19996,9 +18497,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -20078,9 +18577,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -20160,9 +18657,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -20242,9 +18737,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -20324,9 +18817,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -20406,9 +18897,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -20488,9 +18977,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -20570,9 +19057,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -20652,9 +19137,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -20734,9 +19217,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -20816,9 +19297,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -20898,9 +19377,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -20980,9 +19457,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -21062,9 +19537,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -21144,9 +19617,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -21226,9 +19697,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -21308,9 +19777,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -21390,9 +19857,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -21472,9 +19937,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -21554,9 +20017,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -21636,9 +20097,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -21718,9 +20177,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -21800,9 +20257,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -21882,9 +20337,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -21964,9 +20417,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22046,9 +20497,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22128,9 +20577,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22210,9 +20657,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22292,9 +20737,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22374,9 +20817,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22456,9 +20897,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22474,9 +20913,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22492,9 +20929,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22510,9 +20945,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22528,9 +20961,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22546,9 +20977,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22564,9 +20993,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22582,9 +21009,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22612,9 +21037,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -22630,9 +21053,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22648,9 +21069,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -22666,9 +21085,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -22690,9 +21107,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22714,9 +21129,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22738,9 +21151,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22820,14 +21231,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "vector-label"
-        ],
+        "classes": ["vector-label"],
         "context": "<span class=\"vector-label\"> {{ 'cvssCalculator.vectorString' | transloco }}: </span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
         "line": 78
@@ -22840,9 +21247,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -22864,10 +21269,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title",
-      "label"
-    ],
+    "surfaces": ["dialog-title", "label"],
     "uses": [
       {
         "classes": [],
@@ -22883,10 +21285,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -22902,9 +21301,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -22920,9 +21317,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -22938,9 +21333,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -22956,9 +21349,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -22974,14 +21365,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
-        "classes": [
-          "section-label"
-        ],
+        "classes": ["section-label"],
         "context": "<mat-label class=\"section-label\">{{ 'cwePicker.matchingWeaknesses' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cwe-picker-dialog/cwe-picker-dialog.component.html",
         "line": 13
@@ -22994,14 +21381,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
-        "classes": [
-          "no-results"
-        ],
+        "classes": ["no-results"],
         "context": "<div class=\"no-results\">{{ 'cwePicker.noResults' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cwe-picker-dialog/cwe-picker-dialog.component.html",
         "line": 21
@@ -23014,9 +21397,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -23032,9 +21413,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -23050,10 +21429,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "description"
-    ],
+    "surfaces": ["button", "description"],
     "uses": [
       {
         "classes": [],
@@ -23075,9 +21451,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -23099,9 +21473,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -23123,9 +21495,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -23141,9 +21511,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -23159,9 +21527,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -23177,9 +21543,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -23195,10 +21559,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -23220,9 +21581,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -23244,9 +21603,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -23268,10 +21625,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -23293,9 +21647,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -23311,9 +21663,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -23329,9 +21679,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -23347,9 +21695,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -23377,9 +21723,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -23407,9 +21751,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -23425,9 +21767,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -23443,9 +21783,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -23467,9 +21805,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -23491,9 +21827,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -23509,9 +21843,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -23527,9 +21859,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -23545,9 +21875,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -23563,9 +21891,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -23645,9 +21971,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -23663,9 +21987,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -23681,9 +22003,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -23699,9 +22019,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -23717,9 +22035,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -23735,10 +22051,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -23754,10 +22067,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -23773,9 +22083,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -23797,9 +22105,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -23821,9 +22127,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -23845,9 +22149,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -23869,9 +22171,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -23887,9 +22187,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -23905,22 +22203,16 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "label"
-        ],
+        "classes": ["label"],
         "context": "<span class=\"label\">{{ 'debugDialogs.common.affectedCells' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 70
       },
       {
-        "classes": [
-          "label"
-        ],
+        "classes": ["label"],
         "context": "<span class=\"label\">{{ 'debugDialogs.common.affectedCells' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 155
@@ -23933,22 +22225,16 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "label"
-        ],
+        "classes": ["label"],
         "context": "<span class=\"label\">{{ 'debugDialogs.common.cellIds' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 75
       },
       {
-        "classes": [
-          "label"
-        ],
+        "classes": ["label"],
         "context": "<span class=\"label\">{{ 'debugDialogs.common.cellIds' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 160
@@ -23961,9 +22247,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -23985,9 +22269,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -24009,9 +22291,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -24027,9 +22307,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -24045,14 +22323,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "label"
-        ],
+        "classes": ["label"],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.canRedo' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 17
@@ -24065,14 +22339,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "label"
-        ],
+        "classes": ["label"],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.canUndo' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 13
@@ -24085,9 +22355,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -24109,14 +22377,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "label"
-        ],
+        "classes": ["label"],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.currentIndex' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 33
@@ -24129,22 +22393,16 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "label"
-        ],
+        "classes": ["label"],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.id' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 62
       },
       {
-        "classes": [
-          "label"
-        ],
+        "classes": ["label"],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.id' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 147
@@ -24157,14 +22415,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "label"
-        ],
+        "classes": ["label"],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.maxStackSize' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 29
@@ -24177,14 +22431,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "empty-state"
-        ],
+        "classes": ["empty-state"],
         "context": "<div class=\"empty-state\">{{ 'debugDialogs.historyDialog.noRedoEntries' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 134
@@ -24197,14 +22447,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "empty-state"
-        ],
+        "classes": ["empty-state"],
         "context": "<div class=\"empty-state\">{{ 'debugDialogs.historyDialog.noUndoEntries' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 49
@@ -24217,9 +22463,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24241,9 +22485,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24265,9 +22507,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24289,9 +22529,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24307,14 +22545,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "label"
-        ],
+        "classes": ["label"],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.redoStackSize' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 25
@@ -24327,9 +22561,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -24345,22 +22577,16 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "label"
-        ],
+        "classes": ["label"],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.timestamp' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 66
       },
       {
-        "classes": [
-          "label"
-        ],
+        "classes": ["label"],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.timestamp' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 151
@@ -24373,9 +22599,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -24391,9 +22615,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24409,14 +22631,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "label"
-        ],
+        "classes": ["label"],
         "context": "<span class=\"label\">{{ 'debugDialogs.historyDialog.undoStackSize' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
         "line": 21
@@ -24429,9 +22647,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24447,9 +22663,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24465,9 +22679,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24483,9 +22695,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24501,9 +22711,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -24519,9 +22727,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -24537,9 +22743,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -24555,9 +22759,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24573,9 +22775,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24655,9 +22855,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24679,9 +22877,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24697,14 +22893,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "panel-title"
-        ],
+        "classes": ["panel-title"],
         "context": "<span class=\"panel-title\">{{ 'dfd.iconPicker.title' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/icon-picker-panel/icon-picker-panel.component.html",
         "line": 4
@@ -24717,9 +22909,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -24735,9 +22925,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24753,9 +22941,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24771,9 +22957,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24789,9 +22973,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24807,9 +22989,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24825,9 +23005,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -24843,14 +23021,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
-        "classes": [
-          "position-label"
-        ],
+        "classes": ["position-label"],
         "context": "<div class=\"position-label\">{{ 'dfd.portLabel.positionLabel' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/port-label-popover/port-label-popover.component.html",
         "line": 22
@@ -24863,9 +23037,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -24881,9 +23053,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -24899,14 +23069,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "popover-title"
-        ],
+        "classes": ["popover-title"],
         "context": "<span class=\"popover-title\">{{ 'dfd.portLabel.title' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/port-label-popover/port-label-popover.component.html",
         "line": 3
@@ -24919,9 +23085,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -24937,9 +23101,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -24955,14 +23117,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "section-label"
-        ],
+        "classes": ["section-label"],
         "context": "<div class=\"section-label\">{{ 'dfd.stylePanel.defaultColors' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/color-picker/color-picker.component.html",
         "line": 4
@@ -24975,14 +23133,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "section-label"
-        ],
+        "classes": ["section-label"],
         "context": "<div class=\"section-label\">{{ 'dfd.stylePanel.diagramColors' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/color-picker/color-picker.component.html",
         "line": 21
@@ -24995,9 +23149,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -25013,9 +23165,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -25031,9 +23181,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -25049,9 +23197,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -25067,9 +23213,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -25149,9 +23293,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -25231,9 +23373,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -25313,9 +23453,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -25395,9 +23533,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -25477,9 +23613,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -25559,9 +23693,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -25641,9 +23773,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -25723,9 +23853,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -25805,9 +23933,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -25823,9 +23949,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -25841,9 +23965,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -25859,9 +23981,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -25877,9 +23997,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -25895,9 +24013,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -25913,9 +24029,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -25931,9 +24045,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -25949,14 +24061,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "panel-title"
-        ],
+        "classes": ["panel-title"],
         "context": "<span class=\"panel-title\">{{ 'dfd.stylePanel.title' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/style-panel/style-panel.component.html",
         "line": 4
@@ -25969,9 +24077,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -25987,9 +24093,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26005,9 +24109,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26041,9 +24143,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26065,9 +24165,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26095,9 +24193,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "snackbar"
-    ],
+    "surfaces": ["snackbar"],
     "uses": [
       {
         "classes": [],
@@ -26113,9 +24209,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -26131,9 +24225,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26155,9 +24247,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26179,9 +24269,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26197,9 +24285,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26221,9 +24307,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26245,9 +24329,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26269,9 +24351,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26293,9 +24373,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26323,9 +24401,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26347,9 +24423,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26371,9 +24445,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26395,9 +24467,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26419,9 +24489,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26443,9 +24511,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26467,9 +24533,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26491,9 +24555,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26521,9 +24583,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26545,9 +24605,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26575,9 +24633,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26599,9 +24655,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26617,9 +24671,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26635,9 +24687,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26653,9 +24703,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26671,9 +24719,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26689,9 +24735,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26707,9 +24751,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26731,9 +24773,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26749,9 +24789,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26773,9 +24811,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26791,9 +24827,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26815,9 +24849,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -26833,9 +24865,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26857,9 +24887,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26881,9 +24909,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26905,9 +24931,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26929,9 +24953,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26953,14 +24975,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "post-create-hint"
-        ],
+        "classes": ["post-create-hint"],
         "context": "<p class=\"post-create-hint\" [transloco]=\"'documentEditor.postCreate.hint'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
         "line": 27
@@ -26973,9 +24991,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -26991,9 +25007,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27073,14 +25087,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "source-label"
-        ],
+        "classes": ["source-label"],
         "context": "<label class=\"source-label\" [transloco]=\"'documentEditor.source.label'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
         "line": 41
@@ -27093,9 +25103,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -27111,9 +25119,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27129,9 +25135,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27153,9 +25157,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -27177,9 +25179,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27201,9 +25201,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -27225,9 +25223,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -27249,9 +25245,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27267,9 +25261,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27285,9 +25277,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27309,9 +25299,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27369,14 +25357,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "callback-message"
-        ],
+        "classes": ["callback-message"],
         "context": "<p class=\"callback-message\" [transloco]=\"'documentSources.callback.linking'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/content-callback/content-callback.component.html",
         "line": 6
@@ -27389,9 +25373,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27455,9 +25437,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27473,9 +25453,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27491,9 +25469,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27573,9 +25549,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27591,9 +25565,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27609,9 +25581,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -27627,9 +25597,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -27645,9 +25613,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27717,9 +25683,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27799,9 +25763,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27823,9 +25785,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27841,9 +25801,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -27923,9 +25881,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -28005,9 +25961,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -28023,9 +25977,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -28041,9 +25993,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -28065,9 +26015,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28089,9 +26037,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28107,9 +26053,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28125,9 +26069,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28143,9 +26085,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28161,9 +26101,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -28185,9 +26123,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -28209,9 +26145,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -28233,14 +26167,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
-        "classes": [
-          "title-prefix"
-        ],
+        "classes": ["title-prefix"],
         "context": "<span class=\"title-prefix\">{{ 'editor.description' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
         "line": 34
@@ -28253,9 +26183,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -28271,9 +26199,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -28289,9 +26215,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -28307,9 +26231,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -28325,9 +26247,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -28349,9 +26269,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -28367,9 +26285,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -28385,9 +26301,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -28403,9 +26317,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -28427,14 +26339,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "animation-label"
-        ],
+        "classes": ["animation-label"],
         "context": "<div class=\"animation-label\">{{ 'editor.helpDialog.panLabel' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/help-dialog/help-dialog.component.html",
         "line": 34
@@ -28447,9 +26355,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -28465,14 +26371,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "animation-label"
-        ],
+        "classes": ["animation-label"],
         "context": "<div class=\"animation-label\">{{ 'editor.helpDialog.zoomLabel' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/help-dialog/help-dialog.component.html",
         "line": 65
@@ -28485,9 +26387,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -28503,9 +26403,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -28521,9 +26419,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -28539,9 +26435,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -28557,9 +26451,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -28575,9 +26467,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -28593,9 +26483,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -28611,9 +26499,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -28629,9 +26515,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28647,9 +26531,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28665,9 +26547,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28683,9 +26563,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28701,9 +26579,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28719,9 +26595,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28743,9 +26617,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28761,9 +26633,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28779,9 +26649,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28797,9 +26665,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28815,9 +26681,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28833,9 +26697,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28851,9 +26713,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28869,9 +26729,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -28887,9 +26745,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -28905,9 +26761,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -28923,9 +26777,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -28941,14 +26793,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'homeDescription'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/home/home.component.html",
         "line": 13
@@ -28961,14 +26809,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "page-title"
-        ],
+        "classes": ["page-title"],
         "context": "<h1 class=\"page-title\" [transloco]=\"'homeWelcomeTitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/home/home.component.html",
         "line": 7
@@ -28981,9 +26825,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -29005,10 +26847,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -29024,9 +26863,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -29042,9 +26879,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -29060,9 +26895,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -29078,9 +26911,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -29096,14 +26927,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "login-explanation"
-        ],
+        "classes": ["login-explanation"],
         "context": "<p class=\"login-explanation\">{{ 'login.explanation' | transloco }}</p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/auth/components/login/login.component.html",
         "line": 16
@@ -29116,9 +26943,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -29134,9 +26959,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -29216,9 +27039,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -29298,9 +27119,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -29322,9 +27141,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -29340,9 +27157,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -29364,14 +27179,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "provider-section-title"
-        ],
+        "classes": ["provider-section-title"],
         "context": "<h3 class=\"provider-section-title\">{{ 'login.oauthProvidersTitle' | transloco }}</h3>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/auth/components/login/login.component.html",
         "line": 36
@@ -29384,14 +27195,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "provider-section-title"
-        ],
+        "classes": ["provider-section-title"],
         "context": "<h3 class=\"provider-section-title\">{{ 'login.samlProvidersTitle' | transloco }}</h3>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/auth/components/login/login.component.html",
         "line": 65
@@ -29404,10 +27211,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -29423,14 +27227,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "signing-in-message"
-        ],
+        "classes": ["signing-in-message"],
         "context": "<p class=\"signing-in-message\">{{ 'login.signingIn' | transloco }}</p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/auth/components/auth-callback/auth-callback.component.html",
         "line": 11
@@ -29443,9 +27243,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -29461,9 +27259,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -29479,9 +27275,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error"
-    ],
+    "surfaces": ["error"],
     "uses": [
       {
         "classes": [],
@@ -29497,9 +27291,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error"
-    ],
+    "surfaces": ["error"],
     "uses": [
       {
         "classes": [],
@@ -29515,9 +27307,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error"
-    ],
+    "surfaces": ["error"],
     "uses": [
       {
         "classes": [],
@@ -29533,9 +27323,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -29551,9 +27339,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -29569,9 +27355,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -29587,9 +27371,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -29605,9 +27387,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -29629,9 +27409,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "snackbar"
-    ],
+    "surfaces": ["snackbar"],
     "uses": [
       {
         "classes": [],
@@ -29653,9 +27431,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -29671,10 +27447,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item",
-      "tooltip"
-    ],
+    "surfaces": ["menu-item", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -29696,9 +27469,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -29720,10 +27491,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -29745,10 +27513,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -29770,10 +27535,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "menu-item"
-    ],
+    "surfaces": ["button", "menu-item"],
     "uses": [
       {
         "classes": [],
@@ -29795,14 +27557,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "app-title"
-        ],
+        "classes": ["app-title"],
         "context": "<span class=\"app-title\" [transloco]=\"'navbar.appTitle'\">TMI: Threat Modeling Improved</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.html",
         "line": 76
@@ -29815,9 +27573,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -29833,10 +27589,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "menu-item"
-    ],
+    "surfaces": ["button", "menu-item"],
     "uses": [
       {
         "classes": [],
@@ -29858,9 +27611,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -29876,9 +27627,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -29894,9 +27643,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -29912,9 +27659,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -29930,9 +27675,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -29948,9 +27691,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -29972,10 +27713,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "menu-item"
-    ],
+    "surfaces": ["button", "menu-item"],
     "uses": [
       {
         "classes": [],
@@ -29997,9 +27735,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -30021,9 +27757,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -30039,9 +27773,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -30063,9 +27795,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -30093,9 +27823,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -30117,9 +27845,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -30135,9 +27861,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -30153,9 +27877,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -30171,9 +27893,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -30201,9 +27921,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -30225,9 +27943,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -30249,9 +27965,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -30297,9 +28011,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -30321,9 +28033,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -30351,9 +28061,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -30435,9 +28143,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -30459,9 +28165,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -30489,9 +28193,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -30507,9 +28209,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -30589,9 +28289,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -30671,9 +28369,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -30753,9 +28449,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -30777,9 +28471,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -30859,9 +28551,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -30883,9 +28573,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -30907,9 +28595,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -30989,9 +28675,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31071,9 +28755,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31095,9 +28777,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31113,9 +28793,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -31131,9 +28809,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31155,9 +28831,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31179,9 +28853,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31203,9 +28875,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31221,9 +28891,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31239,9 +28907,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31257,9 +28923,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31275,9 +28939,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31293,9 +28955,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31311,9 +28971,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31329,9 +28987,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31353,9 +29009,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31377,9 +29031,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31395,9 +29047,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31413,9 +29063,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31431,9 +29079,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31449,9 +29095,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31467,9 +29111,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31485,9 +29127,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31503,9 +29143,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31521,9 +29159,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31539,9 +29175,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31557,9 +29191,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31575,9 +29207,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31593,9 +29223,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31611,9 +29239,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31629,9 +29255,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31647,9 +29271,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31683,9 +29305,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31701,9 +29321,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31719,9 +29337,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31749,9 +29365,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31767,9 +29381,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31785,9 +29397,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31803,9 +29413,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31821,9 +29429,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31845,9 +29451,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31863,9 +29467,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -31983,9 +29585,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -32001,9 +29601,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -32019,9 +29617,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -32037,9 +29633,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -32055,9 +29649,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -32073,9 +29665,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -32091,9 +29681,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -32109,10 +29697,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -32128,10 +29713,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -32147,14 +29729,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.changesContent'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 130
@@ -32167,9 +29745,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -32185,14 +29761,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.complianceContent'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 123
@@ -32205,9 +29777,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -32223,10 +29793,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -32242,10 +29809,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -32261,9 +29825,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -32279,14 +29841,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.dataSecurityContent1'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 98
@@ -32299,14 +29857,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.dataSecurityContent2'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 104
@@ -32319,9 +29873,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -32337,14 +29889,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.dataSharingContent1'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 55
@@ -32357,14 +29905,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.dataSharingContent2'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 92
@@ -32377,10 +29921,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -32396,9 +29937,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -32414,9 +29953,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -32432,9 +29969,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -32450,9 +29985,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -32468,14 +30001,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.informationCollectionContent1'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 24
@@ -32488,14 +30017,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.informationCollectionContent2'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 39
@@ -32508,14 +30033,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.informationCollectionContent3'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 45
@@ -32528,10 +30049,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -32547,9 +30065,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -32565,9 +30081,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -32583,10 +30097,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -32602,10 +30113,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -32621,14 +30129,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.intro2'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 18
@@ -32641,9 +30145,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -32659,10 +30161,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -32678,14 +30177,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "page-title"
-        ],
+        "classes": ["page-title"],
         "context": "<h1 class=\"page-title\" [transloco]=\"'privacy.title'\">Privacy Policy</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 3
@@ -32704,14 +30199,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.userRightsContent1'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 111
@@ -32724,14 +30215,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'privacy.userRightsContent2'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
         "line": 115
@@ -32744,9 +30231,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -32762,9 +30247,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -32786,9 +30269,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -32810,9 +30291,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -32834,9 +30313,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -32858,9 +30335,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -32882,9 +30357,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -32906,9 +30379,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -32924,9 +30395,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -32942,9 +30411,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error"
-    ],
+    "surfaces": ["error"],
     "uses": [
       {
         "classes": [],
@@ -32960,9 +30427,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -32978,9 +30443,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error"
-    ],
+    "surfaces": ["error"],
     "uses": [
       {
         "classes": [],
@@ -32996,9 +30459,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -33014,9 +30475,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -33032,9 +30491,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -33050,9 +30507,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -33068,9 +30523,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -33086,9 +30539,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -33104,9 +30555,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -33122,9 +30571,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -33204,9 +30651,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -33228,9 +30673,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -33252,9 +30695,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -33276,9 +30717,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -33300,9 +30739,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -33324,9 +30761,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -33348,9 +30783,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -33372,9 +30805,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -33390,9 +30821,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -33408,9 +30837,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -33426,9 +30853,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -33444,9 +30869,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -33462,9 +30885,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -33480,9 +30901,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -33498,9 +30917,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -33516,9 +30933,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -33534,9 +30949,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -33552,9 +30965,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -33634,9 +31045,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -33716,9 +31125,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -33798,9 +31205,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -33880,9 +31285,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -33898,9 +31301,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -33980,9 +31381,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34062,9 +31461,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34144,9 +31541,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34226,9 +31621,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34308,9 +31701,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34390,9 +31781,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34472,14 +31861,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "subtitle"
-        ],
+        "classes": ["subtitle"],
         "context": "<p class=\"subtitle\" [transloco]=\"'projects.subtitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
         "line": 5
@@ -34492,9 +31877,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34574,9 +31957,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -34592,9 +31973,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34610,9 +31989,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34628,9 +32005,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34646,9 +32021,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34664,9 +32037,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34682,9 +32053,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34700,9 +32069,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34718,9 +32085,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34736,9 +32101,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34754,9 +32117,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34772,9 +32133,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34790,9 +32149,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34808,9 +32165,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34826,9 +32181,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34844,9 +32197,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34862,9 +32213,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -34886,10 +32235,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "dialog-title"
-    ],
+    "surfaces": ["description", "dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -34905,9 +32251,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -34987,10 +32331,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "dialog-title"
-    ],
+    "surfaces": ["description", "dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -35006,9 +32347,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35030,9 +32369,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35060,9 +32397,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -35078,9 +32413,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -35096,9 +32429,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -35114,9 +32445,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -35132,14 +32461,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "decision-result-label"
-        ],
+        "classes": ["decision-result-label"],
         "context": "<div class=\"decision-result-label\">{{ t('ssvcCalculator.decisionLabel') }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
         "line": 85
@@ -35152,9 +32477,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35234,9 +32557,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35316,9 +32637,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35398,9 +32717,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35480,9 +32797,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35562,9 +32877,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35644,9 +32957,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35726,9 +33037,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35808,9 +33117,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35826,9 +33133,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35844,9 +33149,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35862,9 +33165,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35880,9 +33181,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35898,9 +33197,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35916,9 +33213,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35934,9 +33229,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -35952,9 +33245,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36034,9 +33325,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -36052,9 +33341,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -36070,9 +33357,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36088,9 +33373,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36106,9 +33389,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36124,9 +33405,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36142,9 +33421,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36160,9 +33437,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36178,9 +33453,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36196,14 +33469,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "step-title"
-        ],
+        "classes": ["step-title"],
         "context": "<h3 class=\"step-title\">{{ t('ssvcCalculator.summary') }}</h3>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
         "line": 67
@@ -36216,9 +33485,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36234,9 +33501,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36252,9 +33517,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36270,9 +33533,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36288,9 +33549,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36306,9 +33565,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36324,9 +33581,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -36342,9 +33597,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36360,9 +33613,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36378,9 +33629,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36396,9 +33645,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36414,9 +33661,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36432,9 +33677,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36450,9 +33693,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36468,9 +33709,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36486,9 +33725,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36568,9 +33805,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36650,9 +33885,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36732,9 +33965,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36814,11 +34045,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["button", "description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -36834,9 +34061,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -36852,9 +34077,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36870,9 +34093,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -36888,9 +34109,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36906,9 +34125,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -36988,9 +34205,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -37070,9 +34285,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -37152,9 +34365,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -37234,9 +34445,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -37252,9 +34461,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -37334,9 +34541,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -37416,9 +34621,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -37440,9 +34643,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -37458,9 +34659,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -37476,9 +34675,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -37494,9 +34691,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -37512,9 +34707,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -37530,9 +34723,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -37548,14 +34739,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-description"
-        ],
+        "classes": ["page-description"],
         "context": "<p class=\"page-description\">{{ 'surveys.list.pageDescription' | transloco }}</p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
         "line": 14
@@ -37568,14 +34755,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "page-title"
-        ],
+        "classes": ["page-title"],
         "context": "<h1 class=\"page-title\">{{ 'surveys.list.pageTitle' | transloco }}</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
         "line": 3
@@ -37588,10 +34771,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -37607,10 +34787,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -37626,10 +34803,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "page-title"
-    ],
+    "surfaces": ["button", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -37645,9 +34819,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -37663,9 +34835,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -37681,9 +34851,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -37763,9 +34931,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -37845,9 +35011,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -37863,9 +35027,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -37881,9 +35043,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -37899,9 +35059,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -37917,9 +35075,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -37935,9 +35091,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -37953,14 +35107,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "page-title"
-        ],
+        "classes": ["page-title"],
         "context": "<h1 class=\"page-title\">{{ 'surveys.responses.pageTitle' | transloco }}</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
         "line": 3
@@ -37973,9 +35123,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -37991,9 +35139,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38009,9 +35155,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38091,9 +35235,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -38109,9 +35251,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38145,9 +35285,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38175,9 +35313,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38211,9 +35347,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38247,9 +35381,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38283,9 +35415,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38365,9 +35495,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38383,9 +35511,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38401,9 +35527,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38419,9 +35543,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38501,9 +35623,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -38519,9 +35639,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -38543,9 +35661,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38567,9 +35683,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38591,9 +35705,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38615,9 +35727,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38639,9 +35749,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -38663,9 +35771,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -38681,9 +35787,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -38699,9 +35803,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -38717,9 +35819,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -38735,9 +35835,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "error"
-    ],
+    "surfaces": ["error"],
     "uses": [
       {
         "classes": [],
@@ -38753,9 +35851,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38835,9 +35931,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -38853,9 +35947,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -38871,9 +35963,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -38889,9 +35979,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38971,9 +36059,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -38989,9 +36075,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -39007,9 +36091,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -39089,9 +36171,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -39107,9 +36187,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -39125,9 +36203,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -39143,9 +36219,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -39167,9 +36241,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -39191,9 +36263,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -39215,9 +36285,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -39239,9 +36307,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -39263,9 +36329,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -39287,9 +36351,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -39305,9 +36367,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -39329,9 +36389,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -39347,9 +36405,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -39365,9 +36421,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -39447,9 +36501,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -39465,9 +36517,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -39483,9 +36533,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -39501,9 +36549,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -39519,9 +36565,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -39537,9 +36581,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -39555,9 +36597,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -39573,9 +36613,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -39655,9 +36693,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -39673,9 +36709,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -39691,9 +36725,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -39773,9 +36805,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -39855,9 +36885,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -39937,9 +36965,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -40019,9 +37045,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -40101,9 +37125,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -40183,9 +37205,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -40265,9 +37285,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -40347,9 +37365,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -40429,9 +37445,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -40511,9 +37525,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -40593,9 +37605,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -40675,9 +37685,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -40757,9 +37765,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -40839,9 +37845,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -40921,9 +37925,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -41003,9 +38005,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -41085,9 +38085,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -41167,9 +38165,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -41185,9 +38181,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -41203,9 +38197,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -41285,9 +38277,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -41367,9 +38357,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -41449,9 +38437,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -41531,9 +38517,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -41613,14 +38597,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "subtitle"
-        ],
+        "classes": ["subtitle"],
         "context": "<p class=\"subtitle\" [transloco]=\"'teams.subtitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
         "line": 5
@@ -41633,9 +38613,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -41651,9 +38629,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -41733,9 +38709,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -41751,9 +38725,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -41769,14 +38741,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "mapping-label"
-        ],
+        "classes": ["mapping-label"],
         "context": "<span class=\"mapping-label\">{{ 'threatEditor.cvss' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 397
@@ -41789,9 +38757,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -41871,9 +38837,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -41953,9 +38917,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42035,9 +38997,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42117,14 +39077,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "mapping-label"
-        ],
+        "classes": ["mapping-label"],
         "context": "<span class=\"mapping-label\">{{ 'threatEditor.cweMappings' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 358
@@ -42137,9 +39093,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42155,9 +39109,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -42173,14 +39125,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "mapping-label"
-        ],
+        "classes": ["mapping-label"],
         "context": "<span class=\"mapping-label\">{{ 'threatEditor.frameworkMappings' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 323
@@ -42193,9 +39141,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -42211,9 +39157,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -42229,9 +39173,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42259,9 +39201,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42277,9 +39217,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42295,9 +39233,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42313,9 +39249,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42331,9 +39265,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42349,9 +39281,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42367,9 +39297,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -42385,9 +39313,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42467,9 +39393,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42549,9 +39473,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42631,9 +39553,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42713,9 +39633,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42795,9 +39713,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42877,9 +39793,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -42959,9 +39873,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -43041,9 +39953,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -43123,9 +40033,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -43205,9 +40113,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -43223,9 +40129,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -43305,9 +40209,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -43329,9 +40231,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -43347,9 +40247,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -43429,9 +40327,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -43511,9 +40407,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -43529,9 +40423,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -43611,9 +40503,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -43629,9 +40519,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -43711,9 +40599,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -43793,9 +40679,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -43875,9 +40759,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -43957,9 +40839,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -44039,9 +40919,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -44121,9 +40999,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -44203,9 +41079,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -44285,9 +41159,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -44367,9 +41239,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -44449,9 +41319,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -44531,9 +41399,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -44613,9 +41479,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -44695,9 +41559,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -44777,9 +41639,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -44859,9 +41719,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -44941,9 +41799,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -45023,9 +41879,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -45105,9 +41959,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -45187,9 +42039,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -45269,9 +42119,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -45351,9 +42199,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -45433,9 +42279,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -45515,9 +42359,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -45539,9 +42381,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -45557,9 +42397,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -45581,9 +42419,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -45599,9 +42435,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -45617,9 +42451,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -45635,10 +42467,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "description"
-    ],
+    "surfaces": ["button", "description"],
     "uses": [
       {
         "classes": [],
@@ -45654,9 +42483,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -45672,9 +42499,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -45690,14 +42515,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'threatModels.created' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 442
@@ -45710,14 +42531,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'threatModels.createdBy' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 434
@@ -45730,14 +42547,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "page-title"
-        ],
+        "classes": ["page-title"],
         "context": "<h1 class=\"page-title\" [transloco]=\"'threatModels.dashboard'\">Dashboard</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 2
@@ -45750,9 +42563,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -45768,9 +42579,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -45786,9 +42595,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -45804,9 +42611,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -45886,9 +42691,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -45904,9 +42707,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -45922,9 +42723,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -45946,9 +42745,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -45964,9 +42761,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -45982,9 +42777,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -46006,9 +42799,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -46024,9 +42815,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -46042,9 +42831,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -46060,9 +42847,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -46078,9 +42863,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -46096,9 +42879,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -46114,9 +42895,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -46138,10 +42917,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item",
-      "tooltip"
-    ],
+    "surfaces": ["menu-item", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -46157,9 +42933,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46175,9 +42949,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46193,9 +42965,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46211,9 +42981,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -46235,9 +43003,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -46259,9 +43025,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -46277,9 +43041,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46295,9 +43057,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -46313,22 +43073,16 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'threatModels.idLabel' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 410
       },
       {
-        "classes": [
-          "dialog-subtitle"
-        ],
+        "classes": ["dialog-subtitle"],
         "context": "<div class=\"dialog-subtitle\">{{ 'threatModels.idLabel' | transloco }}: {{ diagramId }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
         "line": 17
@@ -46341,9 +43095,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46359,9 +43111,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46377,9 +43127,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46395,9 +43143,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46413,14 +43159,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "import-message"
-        ],
+        "classes": ["import-message"],
         "context": "<p class=\"import-message\">{{ 'threatModels.importing' | transloco }}</p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 691
@@ -46433,9 +43175,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -46451,9 +43191,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -46469,9 +43207,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46487,9 +43223,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46505,9 +43239,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46523,9 +43255,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -46541,9 +43271,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46559,9 +43287,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46577,9 +43303,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46595,9 +43319,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46613,9 +43335,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46695,9 +43415,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46713,9 +43431,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46731,9 +43447,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46749,9 +43463,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -46831,9 +43543,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -46855,9 +43565,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -46873,9 +43581,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -46891,9 +43597,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -46909,9 +43613,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -46927,9 +43629,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -46945,9 +43645,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -46963,9 +43661,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -46981,9 +43677,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -46999,9 +43693,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -47017,9 +43709,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -47035,9 +43725,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -47053,9 +43741,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -47071,9 +43757,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -47095,9 +43779,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -47119,9 +43801,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -47137,14 +43817,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "section-title"
-        ],
+        "classes": ["section-title"],
         "context": "<span class=\"section-title\" [transloco]=\"'threatModels.sections.inputs'\">Inputs</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 466
@@ -47163,9 +43839,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -47181,14 +43855,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "section-title"
-        ],
+        "classes": ["section-title"],
         "context": "<span class=\"section-title\" [transloco]=\"'threatModels.sections.outputs'\">Outputs</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 1150
@@ -47207,9 +43877,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -47225,9 +43893,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -47243,10 +43909,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label",
-      "tooltip"
-    ],
+    "surfaces": ["label", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -47261,17 +43924,13 @@
         "line": 257
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'threatModels.securityReviewer' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 274
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'threatModels.securityReviewer' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 301
@@ -47284,9 +43943,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -47308,9 +43965,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -47326,9 +43981,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -47408,9 +44061,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -47490,9 +44141,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -47572,9 +44221,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -47654,9 +44301,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -47736,9 +44381,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -47818,9 +44461,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -47900,9 +44541,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -47982,9 +44621,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -48064,9 +44701,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -48146,9 +44781,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -48228,9 +44861,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -48246,9 +44877,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -48328,9 +44957,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -48410,9 +45037,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -48492,9 +45117,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -48574,9 +45197,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -48656,9 +45277,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -48738,9 +45357,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -48820,9 +45437,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -48902,9 +45517,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -48984,9 +45597,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -49066,9 +45677,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -49083,9 +45692,7 @@
         "line": 185
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'threatModels.statusLastUpdated' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 245
@@ -49098,9 +45705,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -49116,9 +45721,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -49140,14 +45743,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "title-prefix"
-        ],
+        "classes": ["title-prefix"],
         "context": "<span class=\"title-prefix\">{{ 'threatModels.threatModelPrefix' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 7
@@ -49160,9 +45759,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -49178,9 +45775,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -49196,9 +45791,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -49214,9 +45807,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -49232,9 +45823,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -49250,9 +45839,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -49268,9 +45855,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -49286,9 +45871,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item"
-    ],
+    "surfaces": ["menu-item"],
     "uses": [
       {
         "classes": [],
@@ -49304,9 +45887,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -49322,9 +45903,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -49340,9 +45919,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -49364,9 +45941,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -49382,9 +45957,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -49400,9 +45973,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -49418,9 +45989,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -49436,9 +46005,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -49454,14 +46021,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "section-title"
-        ],
+        "classes": ["section-title"],
         "context": "<h2 class=\"section-title\" [transloco]=\"'threatModels.yourThreatModels'\">Your Threat Models</h2>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 7
@@ -49474,9 +46037,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -49492,9 +46053,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -49510,10 +46069,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -49529,9 +46085,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -49547,10 +46101,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -49566,9 +46117,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -49584,9 +46133,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -49602,9 +46149,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -49620,9 +46165,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -49638,9 +46181,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -49656,10 +46197,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -49675,9 +46213,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -49693,9 +46229,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -49711,9 +46245,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -49729,10 +46261,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -49748,14 +46277,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'tos.section1.content'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
         "line": 19
@@ -49768,9 +46293,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -49786,14 +46309,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'tos.section2.content'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
         "line": 26
@@ -49806,9 +46325,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -49824,14 +46341,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'tos.section3.content'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
         "line": 33
@@ -49844,9 +46357,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -49862,14 +46373,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'tos.section4.content'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
         "line": 40
@@ -49882,9 +46389,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -49900,10 +46405,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -49919,10 +46421,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -49938,9 +46437,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -49956,14 +46453,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'tos.section6.content'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
         "line": 54
@@ -49976,9 +46469,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -49994,14 +46485,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "page-content"
-        ],
+        "classes": ["page-content"],
         "context": "<p class=\"page-content\" [transloco]=\"'tos.section7.content'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
         "line": 60
@@ -50014,9 +46501,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -50032,10 +46517,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -50051,10 +46533,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -50070,9 +46549,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -50088,9 +46565,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -50099,9 +46574,7 @@
         "line": 19
       },
       {
-        "classes": [
-          "page-title"
-        ],
+        "classes": ["page-title"],
         "context": "<h1 class=\"page-title\" [transloco]=\"'tos.title'\">Terms of Service</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
         "line": 3
@@ -50114,9 +46587,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -50132,9 +46603,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -50150,9 +46619,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -50232,9 +46699,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -50314,9 +46779,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -50332,9 +46795,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -50414,9 +46875,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -50432,9 +46891,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -50450,9 +46907,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -50468,9 +46923,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -50486,9 +46939,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -50568,9 +47019,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -50586,9 +47035,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -50604,9 +47051,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -50622,9 +47067,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -50640,9 +47083,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -50722,9 +47163,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -50804,9 +47243,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -50886,9 +47323,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -50968,9 +47403,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -50986,9 +47419,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -51004,9 +47435,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -51086,10 +47515,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -51098,9 +47524,7 @@
         "line": 86
       },
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'triage.detail.reviewedBy' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 310
@@ -51113,9 +47537,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -51131,9 +47553,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -51149,14 +47569,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "section-title"
-        ],
+        "classes": ["section-title"],
         "context": "<span class=\"section-title\" [transloco]=\"'triage.detail.surveyResponses'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 368
@@ -51169,14 +47585,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "section-title"
-        ],
+        "classes": ["section-title"],
         "context": "<span class=\"section-title\" [transloco]=\"'triage.detail.triageNotes'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 156
@@ -51189,9 +47601,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -51271,9 +47681,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -51353,11 +47761,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "description",
-      "page-title"
-    ],
+    "surfaces": ["button", "description", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -51391,9 +47795,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -51409,9 +47811,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -51427,9 +47827,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -51445,9 +47843,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -51463,10 +47859,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -51488,9 +47881,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -51570,10 +47961,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -51595,9 +47983,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -51613,9 +47999,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -51631,9 +48015,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -51649,9 +48031,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -51667,9 +48047,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -51685,14 +48063,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "not-submitted"
-        ],
+        "classes": ["not-submitted"],
         "context": "<span class=\"not-submitted\">{{ 'triage.list.notSubmitted' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
         "line": 190
@@ -51705,10 +48079,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "tooltip"
-    ],
+    "surfaces": ["button", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -51730,9 +48101,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -51748,14 +48117,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'triage.list.submitted' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 301
@@ -51774,14 +48139,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
-        "classes": [
-          "info-label"
-        ],
+        "classes": ["info-label"],
         "context": "<span class=\"info-label\">{{ 'triage.list.submitter' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 267
@@ -51800,9 +48161,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -51882,9 +48241,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -51964,9 +48321,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -51988,9 +48343,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52012,9 +48365,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52036,9 +48387,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52060,9 +48409,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52084,9 +48431,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52108,9 +48453,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52190,9 +48533,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -52208,9 +48549,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -52226,10 +48565,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "label"
-    ],
+    "surfaces": ["description", "label"],
     "uses": [
       {
         "classes": [],
@@ -52251,9 +48587,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -52269,9 +48603,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52287,9 +48619,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52305,14 +48635,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
-        "classes": [
-          "page-title"
-        ],
+        "classes": ["page-title"],
         "context": "<h1 class=\"page-title\">{{ 'triage.queue' | transloco }}</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
         "line": 4
@@ -52325,9 +48651,7 @@
     "ellipsis_candidate": false,
     "found_by": "leaf",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52407,9 +48731,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52425,9 +48747,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -52443,9 +48763,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52467,9 +48785,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -52485,9 +48801,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -52503,9 +48817,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -52521,9 +48833,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -52539,9 +48849,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -52563,9 +48871,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -52581,9 +48887,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -52599,10 +48903,7 @@
     "ellipsis_candidate": true,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder",
-      "tooltip"
-    ],
+    "surfaces": ["placeholder", "tooltip"],
     "uses": [
       {
         "classes": [],
@@ -52630,9 +48931,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52648,9 +48947,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -52672,10 +48969,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "dialog-title"
-    ],
+    "surfaces": ["description", "dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -52691,9 +48985,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -52709,9 +49001,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -52727,9 +49017,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -52745,9 +49033,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -52763,9 +49049,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52781,9 +49065,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52799,10 +49081,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "menu-item"
-    ],
+    "surfaces": ["button", "menu-item"],
     "uses": [
       {
         "classes": [],
@@ -52824,9 +49103,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
+    "surfaces": ["tooltip"],
     "uses": [
       {
         "classes": [],
@@ -52848,9 +49125,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -52866,9 +49141,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52884,9 +49157,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52902,9 +49173,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52920,9 +49189,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52938,9 +49205,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52956,9 +49221,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52974,9 +49237,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -52992,9 +49253,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53016,9 +49275,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53034,9 +49291,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53052,9 +49307,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -53070,9 +49323,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -53088,9 +49339,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53106,9 +49355,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53124,9 +49371,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -53142,9 +49387,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -53160,9 +49403,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "label"
-    ],
+    "surfaces": ["label"],
     "uses": [
       {
         "classes": [],
@@ -53178,9 +49419,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -53196,9 +49435,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -53214,9 +49451,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53232,9 +49467,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53250,9 +49483,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -53268,9 +49499,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53286,9 +49515,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53304,9 +49531,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53322,9 +49547,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53340,9 +49563,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53358,9 +49579,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53376,9 +49595,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53394,9 +49611,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -53412,9 +49627,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53430,9 +49643,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "dialog-title"
-    ],
+    "surfaces": ["dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -53448,9 +49659,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -53466,9 +49675,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -53484,9 +49691,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53502,9 +49707,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -53520,9 +49723,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
+    "surfaces": ["button"],
     "uses": [
       {
         "classes": [],
@@ -53544,9 +49745,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -53562,9 +49761,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "placeholder"
-    ],
+    "surfaces": ["placeholder"],
     "uses": [
       {
         "classes": [],
@@ -53580,9 +49777,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -53604,9 +49799,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -53628,9 +49821,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -53652,9 +49843,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -53676,9 +49865,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -53700,9 +49887,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -53724,9 +49909,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -53742,10 +49925,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "button",
-      "dialog-title"
-    ],
+    "surfaces": ["button", "dialog-title"],
     "uses": [
       {
         "classes": [],
@@ -53779,9 +49959,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -53797,9 +49975,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53815,9 +49991,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -53833,9 +50007,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -53851,9 +50023,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53869,9 +50039,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53887,9 +50055,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53905,9 +50071,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53923,9 +50087,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53941,9 +50103,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53959,9 +50119,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53977,9 +50135,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -53995,9 +50151,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54013,9 +50167,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -54031,9 +50183,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54049,9 +50199,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54067,9 +50215,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54085,9 +50231,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54103,9 +50247,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54121,9 +50263,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54139,9 +50279,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54157,9 +50295,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54175,9 +50311,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54193,9 +50327,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54211,9 +50343,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54229,9 +50359,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54247,9 +50375,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54265,9 +50391,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54283,9 +50407,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54301,9 +50423,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54319,9 +50439,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54337,9 +50455,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54355,9 +50471,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54373,9 +50487,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -54391,9 +50503,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54409,9 +50519,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54427,9 +50535,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54445,9 +50551,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54463,9 +50567,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54481,9 +50583,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
+    "surfaces": ["general"],
     "uses": [
       {
         "classes": [],
@@ -54499,9 +50599,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -54517,9 +50615,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -54535,9 +50631,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -54553,14 +50647,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "subtitle"
-        ],
+        "classes": ["subtitle"],
         "context": "<p class=\"subtitle\" [transloco]=\"'userProjects.subtitle'\"></p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
         "line": 5
@@ -54573,10 +50663,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item",
-      "page-title"
-    ],
+    "surfaces": ["menu-item", "page-title"],
     "uses": [
       {
         "classes": [],
@@ -54598,9 +50685,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
+    "surfaces": ["page-title"],
     "uses": [
       {
         "classes": [],
@@ -54616,9 +50701,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
         "classes": [],
@@ -54634,14 +50717,10 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
+    "surfaces": ["description"],
     "uses": [
       {
-        "classes": [
-          "subtitle"
-        ],
+        "classes": ["subtitle"],
         "context": "<p class=\"subtitle\" [transloco]=\"'userTeams.subtitle'\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 5
@@ -54654,10 +50733,7 @@
     "ellipsis_candidate": false,
     "found_by": "fully-qualified",
     "needs_translator_comment": false,
-    "surfaces": [
-      "menu-item",
-      "page-title"
-    ],
+    "surfaces": ["menu-item", "page-title"],
     "uses": [
       {
         "classes": [],

--- a/src/assets/i18n/es-ES.json
+++ b/src/assets/i18n/es-ES.json
@@ -81,6 +81,93 @@
       "subtitle": "Configurar complementos para ampliar la funcionalidad de TMI.",
       "title": "Gestionar complementos"
     },
+    "audit": {
+      "columns": {
+        "actor": "Actor",
+        "changeSummary": "Resumen de cambios",
+        "changeType": "Tipo de cambio",
+        "fieldPath": "Ruta del campo",
+        "object": "Objeto",
+        "request": "Solicitud",
+        "threatModel": "Modelo de amenaza",
+        "timestamp": "Marca de tiempo"
+      },
+      "detail": {
+        "actor": "Actor",
+        "changeSummary": "Resumen de cambios",
+        "changeType": "Tipo de cambio",
+        "close": "Cerrar",
+        "copied": "Copiado",
+        "copyPermalink": "Copiar enlace permanente",
+        "email": "Correo electrónico",
+        "fieldPath": "Ruta del campo",
+        "method": "Método HTTP",
+        "newValue": "Valor nuevo",
+        "notFound": "Entrada de auditoría no encontrada.",
+        "objectId": "ID de objeto",
+        "objectType": "Tipo de objeto",
+        "oldValue": "Valor anterior",
+        "path": "Ruta de solicitud",
+        "provider": "Proveedor",
+        "providerId": "ID de proveedor",
+        "threatModel": "Modelo de amenaza",
+        "timestamp": "Marca de tiempo",
+        "title": "Entrada de auditoría",
+        "version": "Versión",
+        "viewInContext": "Ver en contexto"
+      },
+      "empty": "No hay entradas que coincidan con estos filtros.",
+      "enums": {
+        "changeType": {
+          "created": "Creado",
+          "deleted": "Eliminado",
+          "patched": "Parcheado",
+          "restored": "Restaurado",
+          "rolled_back": "Revocado",
+          "updated": "Actualizado"
+        },
+        "objectType": {
+          "asset": "Activo",
+          "diagram": "Diagrama",
+          "document": "Documento",
+          "note": "Nota",
+          "repository": "Repositorio",
+          "threat": "Amenaza",
+          "threat_model": "Modelo de amenaza"
+        }
+      },
+      "error": "Consulta de auditoría fallida.",
+      "export": {
+        "csv": "CSV",
+        "error": "Error en la exportación",
+        "menu": "Exportar",
+        "ndjson": "NDJSON"
+      },
+      "filters": {
+        "actor": "Actor",
+        "actorPlaceholder": "Buscar por correo electrónico",
+        "changeType": "Tipo de cambio",
+        "clear": "Limpiar filtros",
+        "createdAfter": "Creado después de",
+        "createdBefore": "Creado antes de",
+        "fieldPath": "Ruta del campo",
+        "httpMethod": "Método HTTP",
+        "objectType": "Tipo de objeto",
+        "pathPrefix": "Prefijo de ruta",
+        "threatModelId": "ID de modelo de amenaza"
+      },
+      "pagination": {
+        "newer": "Más reciente",
+        "older": "Más antiguo"
+      },
+      "retry": "Reintentar",
+      "tabs": {
+        "system": "Sistema",
+        "threatModels": "Modelos de amenaza"
+      },
+      "title": "Registros de auditoría",
+      "viewInAuditLog": "Ver en registro de auditoría"
+    },
     "createAutomationUserDialog": {
       "email": "Correo electrónico (opcional)",
       "emailHint": "Opcional — el valor predeterminado es una dirección @tmi.local generada automáticamente",
@@ -176,6 +263,10 @@
       "addons": {
         "description": "Instalar y configurar complementos de la aplicación.",
         "title": "Complementos"
+      },
+      "audit": {
+        "description": "Ver registros de auditoría del sistema y modelos de amenaza.",
+        "title": "Registros de auditoría"
       },
       "groups": {
         "description": "Configurar grupos de usuarios y membresías.",

--- a/src/assets/i18n/fr-FR.json
+++ b/src/assets/i18n/fr-FR.json
@@ -81,6 +81,93 @@
       "subtitle": "Configurer les addons pour étendre les fonctionnalités de TMI.",
       "title": "Gérer les addons"
     },
+    "audit": {
+      "columns": {
+        "actor": "Acteur",
+        "changeSummary": "Résumé des modifications",
+        "changeType": "Type de modification",
+        "fieldPath": "Chemin du champ",
+        "object": "Objet",
+        "request": "Requête",
+        "threatModel": "Modèle de menace",
+        "timestamp": "Horodatage"
+      },
+      "detail": {
+        "actor": "Acteur",
+        "changeSummary": "Résumé des modifications",
+        "changeType": "Type de modification",
+        "close": "Fermer",
+        "copied": "Copié",
+        "copyPermalink": "Copier le lien permanent",
+        "email": "E-mail",
+        "fieldPath": "Chemin du champ",
+        "method": "Méthode HTTP",
+        "newValue": "Nouvelle valeur",
+        "notFound": "Entrée d'audit non trouvée.",
+        "objectId": "ID d'objet",
+        "objectType": "Type d'objet",
+        "oldValue": "Ancienne valeur",
+        "path": "Chemin de la requête",
+        "provider": "Fournisseur",
+        "providerId": "ID du fournisseur",
+        "threatModel": "Modèle de menace",
+        "timestamp": "Horodatage",
+        "title": "Entrée d'audit",
+        "version": "Version",
+        "viewInContext": "Afficher dans le contexte"
+      },
+      "empty": "Aucune entrée ne correspond à ces filtres.",
+      "enums": {
+        "changeType": {
+          "created": "Créé",
+          "deleted": "Supprimé",
+          "patched": "Patché",
+          "restored": "Restauré",
+          "rolled_back": "Annulé",
+          "updated": "Mis à jour"
+        },
+        "objectType": {
+          "asset": "Ressource",
+          "diagram": "Diagramme",
+          "document": "Document",
+          "note": "Note",
+          "repository": "Référentiel",
+          "threat": "Menace",
+          "threat_model": "Modèle de menace"
+        }
+      },
+      "error": "Échec de la requête d'audit.",
+      "export": {
+        "csv": "CSV",
+        "error": "L'export a échoué",
+        "menu": "Exporter",
+        "ndjson": "NDJSON"
+      },
+      "filters": {
+        "actor": "Acteur",
+        "actorPlaceholder": "Rechercher par e-mail",
+        "changeType": "Type de modification",
+        "clear": "Effacer les filtres",
+        "createdAfter": "Créé après",
+        "createdBefore": "Créé avant",
+        "fieldPath": "Chemin du champ",
+        "httpMethod": "Méthode HTTP",
+        "objectType": "Type d'objet",
+        "pathPrefix": "Préfixe du chemin",
+        "threatModelId": "ID du modèle de menace"
+      },
+      "pagination": {
+        "newer": "Plus récent",
+        "older": "Plus ancien"
+      },
+      "retry": "Réessayer",
+      "tabs": {
+        "system": "Système",
+        "threatModels": "Modèles de menace"
+      },
+      "title": "Journaux d'audit",
+      "viewInAuditLog": "Afficher dans le journal d'audit"
+    },
     "createAutomationUserDialog": {
       "email": "E-mail (optionnel)",
       "emailHint": "Optionnel — par défaut, une adresse @tmi.local générée automatiquement",
@@ -176,6 +263,10 @@
       "addons": {
         "description": "Installer et configurer les addons de l'application.",
         "title": "Extensions"
+      },
+      "audit": {
+        "description": "Afficher les journaux d'audit du système et des modèles de menace.",
+        "title": "Journaux d'audit"
       },
       "groups": {
         "description": "Configurer les groupes d'utilisateurs et les appartenances.",

--- a/src/assets/i18n/he-IL.json
+++ b/src/assets/i18n/he-IL.json
@@ -81,6 +81,93 @@
       "subtitle": "הגדר תוספים להרחבת פונקציונליות TMI.",
       "title": "ניהול תוספים"
     },
+    "audit": {
+      "columns": {
+        "actor": "מבצע",
+        "changeSummary": "סיכום השינוי",
+        "changeType": "סוג השינוי",
+        "fieldPath": "נתיב שדה",
+        "object": "אובייקט",
+        "request": "בקשה",
+        "threatModel": "דגם איום",
+        "timestamp": "חותמת זמן"
+      },
+      "detail": {
+        "actor": "מבצע",
+        "changeSummary": "סיכום השינוי",
+        "changeType": "סוג השינוי",
+        "close": "סגור",
+        "copied": "הועתק",
+        "copyPermalink": "העתק קישור קבוע",
+        "email": "דוא״ל",
+        "fieldPath": "נתיב שדה",
+        "method": "שיטת HTTP",
+        "newValue": "ערך חדש",
+        "notFound": "רישום ביקורת לא נמצא.",
+        "objectId": "ID אובייקט",
+        "objectType": "סוג אובייקט",
+        "oldValue": "ערך קודם",
+        "path": "נתיב בקשה",
+        "provider": "ספק",
+        "providerId": "ID ספק",
+        "threatModel": "דגם איום",
+        "timestamp": "חותמת זמן",
+        "title": "רישום ביקורת",
+        "version": "גרסה",
+        "viewInContext": "צפה בהקשר"
+      },
+      "empty": "אין רישומים התואמים לסינונים אלה.",
+      "enums": {
+        "changeType": {
+          "created": "נוצר",
+          "deleted": "נמחק",
+          "patched": "תוקן",
+          "restored": "שוחזר",
+          "rolled_back": "חזר לגרסה קודמת",
+          "updated": "עודכן"
+        },
+        "objectType": {
+          "asset": "נכס",
+          "diagram": "דיאגרמה",
+          "document": "מסמך",
+          "note": "הערה",
+          "repository": "מחסן",
+          "threat": "איום",
+          "threat_model": "דגם איום"
+        }
+      },
+      "error": "שאילתת ביקורת נכשלה.",
+      "export": {
+        "csv": "CSV",
+        "error": "הייצוא נכשל",
+        "menu": "ייצוא",
+        "ndjson": "NDJSON"
+      },
+      "filters": {
+        "actor": "מבצע",
+        "actorPlaceholder": "חפש לפי דוא״ל",
+        "changeType": "סוג השינוי",
+        "clear": "נקה סינונים",
+        "createdAfter": "נוצר לאחר",
+        "createdBefore": "נוצר לפני",
+        "fieldPath": "נתיב שדה",
+        "httpMethod": "שיטת HTTP",
+        "objectType": "סוג אובייקט",
+        "pathPrefix": "קידומת נתיב",
+        "threatModelId": "ID דגם איום"
+      },
+      "pagination": {
+        "newer": "חדשים יותר",
+        "older": "ישנים יותר"
+      },
+      "retry": "נסה שוב",
+      "tabs": {
+        "system": "מערכת",
+        "threatModels": "דגמי איום"
+      },
+      "title": "יומני ביקורת",
+      "viewInAuditLog": "צפה ביומן הביקורת"
+    },
     "createAutomationUserDialog": {
       "email": "דוא\"ל (אופציונלי)",
       "emailHint": "אופציונלי — ברירת מחדל לכתובת @tmi.local שנוצרת אוטומטית",
@@ -176,6 +263,10 @@
       "addons": {
         "description": "התקן והגדר תוספי יישום.",
         "title": "תוספים"
+      },
+      "audit": {
+        "description": "צפה ביומני ביקורת של מערכת ודגמי איום.",
+        "title": "יומני ביקורת"
       },
       "groups": {
         "description": "הגדר קבוצות משתמשים וחברויות.",

--- a/src/assets/i18n/hi-IN.json
+++ b/src/assets/i18n/hi-IN.json
@@ -81,6 +81,93 @@
       "subtitle": "TMI कार्यक्षमता बढ़ाने के लिए ऐडऑन कॉन्फ़िगर करें",
       "title": "ऐडऑन प्रबंधित करें"
     },
+    "audit": {
+      "columns": {
+        "actor": "अभिनेता",
+        "changeSummary": "परिवर्तन सारांश",
+        "changeType": "परिवर्तन प्रकार",
+        "fieldPath": "फील्ड पथ",
+        "object": "वस्तु",
+        "request": "अनुरोध",
+        "threatModel": "खतरा मॉडल",
+        "timestamp": "समय मुहर"
+      },
+      "detail": {
+        "actor": "अभिनेता",
+        "changeSummary": "परिवर्तन सारांश",
+        "changeType": "परिवर्तन प्रकार",
+        "close": "बंद करें",
+        "copied": "कॉपी किया गया",
+        "copyPermalink": "स्थायी लिंक कॉपी करें",
+        "email": "ईमेल",
+        "fieldPath": "फील्ड पथ",
+        "method": "HTTP विधि",
+        "newValue": "नया मान",
+        "notFound": "ऑडिट प्रविष्टि नहीं मिली।",
+        "objectId": "वस्तु ID",
+        "objectType": "वस्तु प्रकार",
+        "oldValue": "पुराना मान",
+        "path": "अनुरोध पथ",
+        "provider": "प्रदाता",
+        "providerId": "प्रदाता ID",
+        "threatModel": "खतरा मॉडल",
+        "timestamp": "समय मुहर",
+        "title": "ऑडिट प्रविष्टि",
+        "version": "संस्करण",
+        "viewInContext": "संदर्भ में देखें"
+      },
+      "empty": "कोई प्रविष्टि इन फिल्टर से मेल नहीं खाती।",
+      "enums": {
+        "changeType": {
+          "created": "बनाया गया",
+          "deleted": "हटाया गया",
+          "patched": "पैच किया गया",
+          "restored": "पुनः स्थापित किया गया",
+          "rolled_back": "वापस किया गया",
+          "updated": "अपडेट किया गया"
+        },
+        "objectType": {
+          "asset": "संपत्ति",
+          "diagram": "आरेख",
+          "document": "दस्तावेज़",
+          "note": "नोट",
+          "repository": "रिपॉजिटरी",
+          "threat": "खतरा",
+          "threat_model": "खतरा मॉडल"
+        }
+      },
+      "error": "ऑडिट क्वेरी विफल रही।",
+      "export": {
+        "csv": "CSV",
+        "error": "निर्यात विफल",
+        "menu": "निर्यात",
+        "ndjson": "NDJSON"
+      },
+      "filters": {
+        "actor": "अभिनेता",
+        "actorPlaceholder": "ईमेल से खोजें",
+        "changeType": "परिवर्तन प्रकार",
+        "clear": "फिल्टर साफ़ करें",
+        "createdAfter": "इसके बाद बनाया गया",
+        "createdBefore": "इसके पहले बनाया गया",
+        "fieldPath": "फील्ड पथ",
+        "httpMethod": "HTTP विधि",
+        "objectType": "वस्तु प्रकार",
+        "pathPrefix": "पथ उपसर्ग",
+        "threatModelId": "खतरा मॉडल ID"
+      },
+      "pagination": {
+        "newer": "नई",
+        "older": "पुरानी"
+      },
+      "retry": "पुनः प्रयास करें",
+      "tabs": {
+        "system": "सिस्टम",
+        "threatModels": "खतरा मॉडल"
+      },
+      "title": "ऑडिट लॉग",
+      "viewInAuditLog": "ऑडिट लॉग में देखें"
+    },
     "createAutomationUserDialog": {
       "email": "ईमेल (वैकल्पिक)",
       "emailHint": "वैकल्पिक — स्वचालित रूप से उत्पन्न @tmi.local पते पर डिफ़ॉल्ट",
@@ -176,6 +263,10 @@
       "addons": {
         "description": "एप्लिकेशन ऐडऑन इंस्टॉल और कॉन्फ़िगर करें।",
         "title": "ऐडऑन"
+      },
+      "audit": {
+        "description": "सिस्टम और खतरा मॉडल ऑडिट लॉग देखें।",
+        "title": "ऑडिट लॉग"
       },
       "groups": {
         "description": "उपयोगकर्ता समूह और सदस्यता कॉन्फ़िगर करें।",

--- a/src/assets/i18n/id-ID.json
+++ b/src/assets/i18n/id-ID.json
@@ -81,6 +81,93 @@
       "subtitle": "Konfigurasikan addon untuk memperluas fungsionalitas TMI.",
       "title": "Kelola Addon"
     },
+    "audit": {
+      "columns": {
+        "actor": "Aktor",
+        "changeSummary": "Ringkasan perubahan",
+        "changeType": "Jenis perubahan",
+        "fieldPath": "Jalur field",
+        "object": "Objek",
+        "request": "Permintaan",
+        "threatModel": "Model ancaman",
+        "timestamp": "Waktu"
+      },
+      "detail": {
+        "actor": "Aktor",
+        "changeSummary": "Ringkasan perubahan",
+        "changeType": "Jenis perubahan",
+        "close": "Tutup",
+        "copied": "Disalin",
+        "copyPermalink": "Salin tautan permanen",
+        "email": "Email",
+        "fieldPath": "Jalur field",
+        "method": "Metode HTTP",
+        "newValue": "Nilai baru",
+        "notFound": "Entri audit tidak ditemukan.",
+        "objectId": "ID Objek",
+        "objectType": "Jenis objek",
+        "oldValue": "Nilai lama",
+        "path": "Jalur permintaan",
+        "provider": "Penyedia",
+        "providerId": "ID Penyedia",
+        "threatModel": "Model ancaman",
+        "timestamp": "Waktu",
+        "title": "Entri audit",
+        "version": "Versi",
+        "viewInContext": "Lihat dalam konteks"
+      },
+      "empty": "Tidak ada entri yang sesuai dengan filter ini.",
+      "enums": {
+        "changeType": {
+          "created": "Dibuat",
+          "deleted": "Dihapus",
+          "patched": "Dipatch",
+          "restored": "Dipulihkan",
+          "rolled_back": "Dikembalikan",
+          "updated": "Diperbarui"
+        },
+        "objectType": {
+          "asset": "Aset",
+          "diagram": "Diagram",
+          "document": "Dokumen",
+          "note": "Catatan",
+          "repository": "Repositori",
+          "threat": "Ancaman",
+          "threat_model": "Model ancaman"
+        }
+      },
+      "error": "Kueri audit gagal.",
+      "export": {
+        "csv": "CSV",
+        "error": "Ekspor gagal",
+        "menu": "Ekspor",
+        "ndjson": "NDJSON"
+      },
+      "filters": {
+        "actor": "Aktor",
+        "actorPlaceholder": "Cari berdasarkan email",
+        "changeType": "Jenis perubahan",
+        "clear": "Hapus filter",
+        "createdAfter": "Dibuat setelah",
+        "createdBefore": "Dibuat sebelum",
+        "fieldPath": "Jalur field",
+        "httpMethod": "Metode HTTP",
+        "objectType": "Jenis objek",
+        "pathPrefix": "Awalan jalur",
+        "threatModelId": "ID Model ancaman"
+      },
+      "pagination": {
+        "newer": "Lebih baru",
+        "older": "Lebih lama"
+      },
+      "retry": "Coba lagi",
+      "tabs": {
+        "system": "Sistem",
+        "threatModels": "Model ancaman"
+      },
+      "title": "Log audit",
+      "viewInAuditLog": "Lihat dalam log audit"
+    },
     "createAutomationUserDialog": {
       "email": "Email (Opsional)",
       "emailHint": "Opsional — default ke alamat @tmi.local yang dibuat otomatis",
@@ -176,6 +263,10 @@
       "addons": {
         "description": "Pasang dan konfigurasikan addon aplikasi.",
         "title": "Pengaya"
+      },
+      "audit": {
+        "description": "Lihat log audit sistem dan model ancaman.",
+        "title": "Log audit"
       },
       "groups": {
         "description": "Konfigurasikan grup pengguna dan keanggotaan.",

--- a/src/assets/i18n/ja-JP.json
+++ b/src/assets/i18n/ja-JP.json
@@ -81,6 +81,93 @@
       "subtitle": "TMI機能を拡張するためのアドオンを設定します。",
       "title": "アドオンの管理"
     },
+    "audit": {
+      "columns": {
+        "actor": "実行者",
+        "changeSummary": "変更内容",
+        "changeType": "変更種別",
+        "fieldPath": "フィールドパス",
+        "object": "オブジェクト",
+        "request": "リクエスト",
+        "threatModel": "脅威モデル",
+        "timestamp": "タイムスタンプ"
+      },
+      "detail": {
+        "actor": "実行者",
+        "changeSummary": "変更内容",
+        "changeType": "変更種別",
+        "close": "閉じる",
+        "copied": "コピーしました",
+        "copyPermalink": "パーマリンクをコピー",
+        "email": "メールアドレス",
+        "fieldPath": "フィールドパス",
+        "method": "HTTP メソッド",
+        "newValue": "新しい値",
+        "notFound": "監査エントリが見つかりません。",
+        "objectId": "オブジェクト ID",
+        "objectType": "オブジェクトタイプ",
+        "oldValue": "前の値",
+        "path": "リクエストパス",
+        "provider": "プロバイダー",
+        "providerId": "プロバイダー ID",
+        "threatModel": "脅威モデル",
+        "timestamp": "タイムスタンプ",
+        "title": "監査エントリ",
+        "version": "バージョン",
+        "viewInContext": "コンテキストで表示"
+      },
+      "empty": "フィルターに一致するエントリはありません。",
+      "enums": {
+        "changeType": {
+          "created": "作成",
+          "deleted": "削除",
+          "patched": "パッチ適用",
+          "restored": "復元",
+          "rolled_back": "ロールバック",
+          "updated": "更新"
+        },
+        "objectType": {
+          "asset": "アセット",
+          "diagram": "図",
+          "document": "ドキュメント",
+          "note": "ノート",
+          "repository": "リポジトリ",
+          "threat": "脅威",
+          "threat_model": "脅威モデル"
+        }
+      },
+      "error": "監査クエリが失敗しました。",
+      "export": {
+        "csv": "CSV",
+        "error": "エクスポートに失敗しました",
+        "menu": "エクスポート",
+        "ndjson": "NDJSON"
+      },
+      "filters": {
+        "actor": "実行者",
+        "actorPlaceholder": "メールアドレスで検索",
+        "changeType": "変更種別",
+        "clear": "フィルターをクリア",
+        "createdAfter": "作成日時（以降）",
+        "createdBefore": "作成日時（以前）",
+        "fieldPath": "フィールドパス",
+        "httpMethod": "HTTP メソッド",
+        "objectType": "オブジェクトタイプ",
+        "pathPrefix": "パスプレフィックス",
+        "threatModelId": "脅威モデル ID"
+      },
+      "pagination": {
+        "newer": "新しい順",
+        "older": "古い順"
+      },
+      "retry": "再試行",
+      "tabs": {
+        "system": "システム",
+        "threatModels": "脅威モデル"
+      },
+      "title": "監査ログ",
+      "viewInAuditLog": "監査ログで表示"
+    },
     "createAutomationUserDialog": {
       "email": "メール（任意）",
       "emailHint": "任意 — デフォルトは自動生成された @tmi.local アドレス",
@@ -176,6 +263,10 @@
       "addons": {
         "description": "アプリケーションアドオンをインストール・設定します。",
         "title": "アドオン"
+      },
+      "audit": {
+        "description": "システムおよび脅威モデルの監査ログを表示します。",
+        "title": "監査ログ"
       },
       "groups": {
         "description": "ユーザーグループとメンバーシップを設定します。",

--- a/src/assets/i18n/ko-KR.json
+++ b/src/assets/i18n/ko-KR.json
@@ -81,6 +81,93 @@
       "subtitle": "TMI 기능 확장을 위한 애드온을 구성합니다.",
       "title": "애드온 관리"
     },
+    "audit": {
+      "columns": {
+        "actor": "행위자",
+        "changeSummary": "변경 요약",
+        "changeType": "변경 유형",
+        "fieldPath": "필드 경로",
+        "object": "객체",
+        "request": "요청",
+        "threatModel": "위협 모델",
+        "timestamp": "타임스탬프"
+      },
+      "detail": {
+        "actor": "행위자",
+        "changeSummary": "변경 요약",
+        "changeType": "변경 유형",
+        "close": "닫기",
+        "copied": "복사됨",
+        "copyPermalink": "고유 링크 복사",
+        "email": "이메일",
+        "fieldPath": "필드 경로",
+        "method": "HTTP 메서드",
+        "newValue": "새 값",
+        "notFound": "감사 항목을 찾을 수 없습니다.",
+        "objectId": "객체 ID",
+        "objectType": "객체 유형",
+        "oldValue": "이전 값",
+        "path": "요청 경로",
+        "provider": "제공자",
+        "providerId": "제공자 ID",
+        "threatModel": "위협 모델",
+        "timestamp": "타임스탬프",
+        "title": "감사 항목",
+        "version": "버전",
+        "viewInContext": "컨텍스트에서 보기"
+      },
+      "empty": "필터와 일치하는 항목이 없습니다.",
+      "enums": {
+        "changeType": {
+          "created": "생성됨",
+          "deleted": "삭제됨",
+          "patched": "패치됨",
+          "restored": "복원됨",
+          "rolled_back": "롤백됨",
+          "updated": "업데이트됨"
+        },
+        "objectType": {
+          "asset": "자산",
+          "diagram": "다이어그램",
+          "document": "문서",
+          "note": "노트",
+          "repository": "저장소",
+          "threat": "위협",
+          "threat_model": "위협 모델"
+        }
+      },
+      "error": "감사 쿼리가 실패했습니다.",
+      "export": {
+        "csv": "CSV",
+        "error": "내보내기 실패",
+        "menu": "내보내기",
+        "ndjson": "NDJSON"
+      },
+      "filters": {
+        "actor": "행위자",
+        "actorPlaceholder": "이메일로 검색",
+        "changeType": "변경 유형",
+        "clear": "필터 지우기",
+        "createdAfter": "생성 이후",
+        "createdBefore": "생성 이전",
+        "fieldPath": "필드 경로",
+        "httpMethod": "HTTP 메서드",
+        "objectType": "객체 유형",
+        "pathPrefix": "경로 접두사",
+        "threatModelId": "위협 모델 ID"
+      },
+      "pagination": {
+        "newer": "최신",
+        "older": "이전"
+      },
+      "retry": "다시 시도",
+      "tabs": {
+        "system": "시스템",
+        "threatModels": "위협 모델"
+      },
+      "title": "감사 로그",
+      "viewInAuditLog": "감사 로그에서 보기"
+    },
     "createAutomationUserDialog": {
       "email": "이메일 (선택 사항)",
       "emailHint": "선택 사항 — 기본값은 자동 생성된 @tmi.local 주소",
@@ -176,6 +263,10 @@
       "addons": {
         "description": "애플리케이션 애드온을 설치하고 구성합니다.",
         "title": "애드온"
+      },
+      "audit": {
+        "description": "시스템 및 위협 모델 감사 로그를 봅니다.",
+        "title": "감사 로그"
       },
       "groups": {
         "description": "사용자 그룹 및 멤버십을 구성합니다.",

--- a/src/assets/i18n/pt-BR.json
+++ b/src/assets/i18n/pt-BR.json
@@ -81,6 +81,93 @@
       "subtitle": "Configure complementos para estender a funcionalidade do TMI.",
       "title": "Gerenciar complementos"
     },
+    "audit": {
+      "columns": {
+        "actor": "Ator",
+        "changeSummary": "Resumo das alterações",
+        "changeType": "Tipo de alteração",
+        "fieldPath": "Caminho do campo",
+        "object": "Objeto",
+        "request": "Solicitação",
+        "threatModel": "Modelo de ameaça",
+        "timestamp": "Timestamp"
+      },
+      "detail": {
+        "actor": "Ator",
+        "changeSummary": "Resumo das alterações",
+        "changeType": "Tipo de alteração",
+        "close": "Fechar",
+        "copied": "Copiado",
+        "copyPermalink": "Copiar permalink",
+        "email": "Email",
+        "fieldPath": "Caminho do campo",
+        "method": "Método HTTP",
+        "newValue": "Novo valor",
+        "notFound": "Entrada de auditoria não encontrada.",
+        "objectId": "ID do objeto",
+        "objectType": "Tipo de objeto",
+        "oldValue": "Valor anterior",
+        "path": "Caminho da solicitação",
+        "provider": "Provedor",
+        "providerId": "ID do provedor",
+        "threatModel": "Modelo de ameaça",
+        "timestamp": "Timestamp",
+        "title": "Entrada de auditoria",
+        "version": "Versão",
+        "viewInContext": "Visualizar no contexto"
+      },
+      "empty": "Nenhuma entrada corresponde a estes filtros.",
+      "enums": {
+        "changeType": {
+          "created": "Criado",
+          "deleted": "Deletado",
+          "patched": "Corrigido",
+          "restored": "Restaurado",
+          "rolled_back": "Revertido",
+          "updated": "Atualizado"
+        },
+        "objectType": {
+          "asset": "Ativo",
+          "diagram": "Diagrama",
+          "document": "Documento",
+          "note": "Nota",
+          "repository": "Repositório",
+          "threat": "Ameaça",
+          "threat_model": "Modelo de ameaça"
+        }
+      },
+      "error": "Falha na consulta de auditoria.",
+      "export": {
+        "csv": "CSV",
+        "error": "Falha na exportação",
+        "menu": "Exportar",
+        "ndjson": "NDJSON"
+      },
+      "filters": {
+        "actor": "Ator",
+        "actorPlaceholder": "Pesquisar por email",
+        "changeType": "Tipo de alteração",
+        "clear": "Limpar filtros",
+        "createdAfter": "Criado após",
+        "createdBefore": "Criado antes",
+        "fieldPath": "Caminho do campo",
+        "httpMethod": "Método HTTP",
+        "objectType": "Tipo de objeto",
+        "pathPrefix": "Prefixo do caminho",
+        "threatModelId": "ID do modelo de ameaça"
+      },
+      "pagination": {
+        "newer": "Mais recente",
+        "older": "Mais antigo"
+      },
+      "retry": "Tentar novamente",
+      "tabs": {
+        "system": "Sistema",
+        "threatModels": "Modelos de ameaça"
+      },
+      "title": "Logs de auditoria",
+      "viewInAuditLog": "Visualizar no log de auditoria"
+    },
     "createAutomationUserDialog": {
       "email": "E-mail (opcional)",
       "emailHint": "Opcional — padrão é um endereço @tmi.local gerado automaticamente",
@@ -176,6 +263,10 @@
       "addons": {
         "description": "Instale e configure complementos do aplicativo.",
         "title": "Complementos"
+      },
+      "audit": {
+        "description": "Visualizar logs de auditoria do sistema e modelos de ameaça.",
+        "title": "Logs de auditoria"
       },
       "groups": {
         "description": "Configure grupos de usuários e associações.",

--- a/src/assets/i18n/ru-RU.json
+++ b/src/assets/i18n/ru-RU.json
@@ -81,6 +81,93 @@
       "subtitle": "Настройка дополнений для расширения функциональности TMI.",
       "title": "Управление дополнениями"
     },
+    "audit": {
+      "columns": {
+        "actor": "Инициатор",
+        "changeSummary": "Описание изменения",
+        "changeType": "Тип изменения",
+        "fieldPath": "Путь поля",
+        "object": "Объект",
+        "request": "Запрос",
+        "threatModel": "Модель угроз",
+        "timestamp": "Время"
+      },
+      "detail": {
+        "actor": "Инициатор",
+        "changeSummary": "Описание изменения",
+        "changeType": "Тип изменения",
+        "close": "Закрыть",
+        "copied": "Скопировано",
+        "copyPermalink": "Копировать ссылку",
+        "email": "Электронная почта",
+        "fieldPath": "Путь поля",
+        "method": "Метод HTTP",
+        "newValue": "Новое значение",
+        "notFound": "Запись аудита не найдена.",
+        "objectId": "ID объекта",
+        "objectType": "Тип объекта",
+        "oldValue": "Старое значение",
+        "path": "Путь запроса",
+        "provider": "Поставщик",
+        "providerId": "ID поставщика",
+        "threatModel": "Модель угроз",
+        "timestamp": "Время",
+        "title": "Запись аудита",
+        "version": "Версия",
+        "viewInContext": "Просмотр в контексте"
+      },
+      "empty": "Нет записей, соответствующих этим фильтрам.",
+      "enums": {
+        "changeType": {
+          "created": "Создано",
+          "deleted": "Удалено",
+          "patched": "Применено исправление",
+          "restored": "Восстановлено",
+          "rolled_back": "Откачено",
+          "updated": "Обновлено"
+        },
+        "objectType": {
+          "asset": "Актив",
+          "diagram": "Диаграмма",
+          "document": "Документ",
+          "note": "Заметка",
+          "repository": "Репозиторий",
+          "threat": "Угроза",
+          "threat_model": "Модель угроз"
+        }
+      },
+      "error": "Ошибка при выполнении запроса аудита.",
+      "export": {
+        "csv": "CSV",
+        "error": "Экспорт не удался",
+        "menu": "Экспорт",
+        "ndjson": "NDJSON"
+      },
+      "filters": {
+        "actor": "Инициатор",
+        "actorPlaceholder": "Поиск по электронной почте",
+        "changeType": "Тип изменения",
+        "clear": "Очистить фильтры",
+        "createdAfter": "Создано после",
+        "createdBefore": "Создано до",
+        "fieldPath": "Путь поля",
+        "httpMethod": "Метод HTTP",
+        "objectType": "Тип объекта",
+        "pathPrefix": "Префикс пути",
+        "threatModelId": "ID модели угроз"
+      },
+      "pagination": {
+        "newer": "Новые",
+        "older": "Старые"
+      },
+      "retry": "Повторить",
+      "tabs": {
+        "system": "Система",
+        "threatModels": "Модели угроз"
+      },
+      "title": "Журналы аудита",
+      "viewInAuditLog": "Просмотр в журнале аудита"
+    },
     "createAutomationUserDialog": {
       "email": "Электронная почта (необязательно)",
       "emailHint": "Необязательно — по умолчанию используется автоматически сгенерированный адрес @tmi.local",
@@ -176,6 +263,10 @@
       "addons": {
         "description": "Установка и настройка дополнений приложения.",
         "title": "Дополнения"
+      },
+      "audit": {
+        "description": "Просмотр журналов аудита системы и моделей угроз.",
+        "title": "Журналы аудита"
       },
       "groups": {
         "description": "Настройка групп пользователей и членства.",

--- a/src/assets/i18n/th-TH.json
+++ b/src/assets/i18n/th-TH.json
@@ -81,6 +81,93 @@
       "subtitle": "กำหนดค่าส่วนเสริมสำหรับขยายฟังก์ชันของ TMI",
       "title": "จัดการส่วนเสริม"
     },
+    "audit": {
+      "columns": {
+        "actor": "ผู้กระทำการ",
+        "changeSummary": "สรุปการเปลี่ยนแปลง",
+        "changeType": "ประเภทการเปลี่ยนแปลง",
+        "fieldPath": "경로เขตข้อมูล",
+        "object": "วัตถุ",
+        "request": "คำขอ",
+        "threatModel": "แบบจำลองภัยคุกคาม",
+        "timestamp": "ประทับเวลา"
+      },
+      "detail": {
+        "actor": "ผู้กระทำการ",
+        "changeSummary": "สรุปการเปลี่ยนแปลง",
+        "changeType": "ประเภทการเปลี่ยนแปลง",
+        "close": "ปิด",
+        "copied": "คัดลอกแล้ว",
+        "copyPermalink": "คัดลอกลิงก์ถาวร",
+        "email": "อีเมล",
+        "fieldPath": "경로เขตข้อมูล",
+        "method": "เมธอด HTTP",
+        "newValue": "ค่าใหม่",
+        "notFound": "ไม่พบรายการตรวจสอบ",
+        "objectId": "ID วัตถุ",
+        "objectType": "ประเภทวัตถุ",
+        "oldValue": "ค่าเดิม",
+        "path": "경로คำขอ",
+        "provider": "ผู้ให้บริการ",
+        "providerId": "ID ผู้ให้บริการ",
+        "threatModel": "แบบจำลองภัยคุกคาม",
+        "timestamp": "ประทับเวลา",
+        "title": "รายการตรวจสอบ",
+        "version": "เวอร์ชัน",
+        "viewInContext": "ดูในบริบท"
+      },
+      "empty": "ไม่มีรายการที่ตรงกับตัวกรองเหล่านี้",
+      "enums": {
+        "changeType": {
+          "created": "สร้างแล้ว",
+          "deleted": "ลบแล้ว",
+          "patched": "แพตช์แล้ว",
+          "restored": "คืนสภาพแล้ว",
+          "rolled_back": "ย้อนกลับแล้ว",
+          "updated": "อัปเดตแล้ว"
+        },
+        "objectType": {
+          "asset": "สินทรัพย์",
+          "diagram": "แผนภาพ",
+          "document": "เอกสาร",
+          "note": "บันทึก",
+          "repository": "คลังเก็บ",
+          "threat": "ภัยคุกคาม",
+          "threat_model": "แบบจำลองภัยคุกคาม"
+        }
+      },
+      "error": "การค้นหาตรวจสอบล้มเหลว",
+      "export": {
+        "csv": "CSV",
+        "error": "ส่งออกล้มเหลว",
+        "menu": "ส่งออก",
+        "ndjson": "NDJSON"
+      },
+      "filters": {
+        "actor": "ผู้กระทำการ",
+        "actorPlaceholder": "ค้นหาตามอีเมล",
+        "changeType": "ประเภทการเปลี่ยนแปลง",
+        "clear": "ล้างตัวกรอง",
+        "createdAfter": "สร้างหลังจาก",
+        "createdBefore": "สร้างก่อน",
+        "fieldPath": "경로เขตข้อมูล",
+        "httpMethod": "เมธอด HTTP",
+        "objectType": "ประเภทวัตถุ",
+        "pathPrefix": "คำนำหน้า경로",
+        "threatModelId": "ID แบบจำลองภัยคุกคาม"
+      },
+      "pagination": {
+        "newer": "ใหม่กว่า",
+        "older": "เก่ากว่า"
+      },
+      "retry": "ลองอีกครั้ง",
+      "tabs": {
+        "system": "ระบบ",
+        "threatModels": "แบบจำลองภัยคุกคาม"
+      },
+      "title": "บันทึกการตรวจสอบ",
+      "viewInAuditLog": "ดูในบันทึกการตรวจสอบ"
+    },
     "createAutomationUserDialog": {
       "email": "อีเมล (ไม่บังคับ)",
       "emailHint": "ไม่บังคับ — ค่าเริ่มต้นคือที่อยู่ @tmi.local ที่สร้างอัตโนมัติ",
@@ -176,6 +263,10 @@
       "addons": {
         "description": "ติดตั้งและกำหนดค่าส่วนเสริมของแอปพลิเคชัน",
         "title": "{{common.addons}}"
+      },
+      "audit": {
+        "description": "ดูบันทึกการตรวจสอบระบบและแบบจำลองภัยคุกคาม",
+        "title": "บันทึกการตรวจสอบ"
       },
       "groups": {
         "description": "กำหนดค่ากลุ่มผู้ใช้และสมาชิกภาพ",

--- a/src/assets/i18n/ur-PK.json
+++ b/src/assets/i18n/ur-PK.json
@@ -81,6 +81,93 @@
       "subtitle": "TMI کی فعالیت بڑھانے کے لیے ایڈ آنز ترتیب دیں۔",
       "title": "ایڈ آنز کا انتظام"
     },
+    "audit": {
+      "columns": {
+        "actor": "ایکٹر",
+        "changeSummary": "تبدیلی کا خلاصہ",
+        "changeType": "تبدیلی کی قسم",
+        "fieldPath": "فیلڈ کا راستہ",
+        "object": "آبجیکٹ",
+        "request": "درخواست",
+        "threatModel": "Threat model",
+        "timestamp": "ٹائم سٹیمپ"
+      },
+      "detail": {
+        "actor": "ایکٹر",
+        "changeSummary": "تبدیلی کا خلاصہ",
+        "changeType": "تبدیلی کی قسم",
+        "close": "بند کریں",
+        "copied": "کاپی کر دیا گیا",
+        "copyPermalink": "Permalink کاپی کریں",
+        "email": "ای میل",
+        "fieldPath": "فیلڈ کا راستہ",
+        "method": "HTTP method",
+        "newValue": "نی قدر",
+        "notFound": "آڈٹ اندراج نہیں ملا۔",
+        "objectId": "Object ID",
+        "objectType": "آبجیکٹ کی قسم",
+        "oldValue": "پرانی قدر",
+        "path": "درخواست کا راستہ",
+        "provider": "فراہم کنندہ",
+        "providerId": "Provider ID",
+        "threatModel": "Threat model",
+        "timestamp": "ٹائم سٹیمپ",
+        "title": "آڈٹ اندراج",
+        "version": "ورژن",
+        "viewInContext": "تناظر میں دیکھیں"
+      },
+      "empty": "کوئی بھی اندراج ان فلٹرز سے مماثل نہیں۔",
+      "enums": {
+        "changeType": {
+          "created": "بنایا گیا",
+          "deleted": "حذف کر دیا گیا",
+          "patched": "ترمیم کر دی گئی",
+          "restored": "بحال کر دیا گیا",
+          "rolled_back": "واپس کر دیا گیا",
+          "updated": "اپ ڈیٹ کر دیا گیا"
+        },
+        "objectType": {
+          "asset": "ایسیٹ",
+          "diagram": "ڈائیاگرام",
+          "document": "دستاویز",
+          "note": "نوٹ",
+          "repository": "ذخیرہ",
+          "threat": "خطرہ",
+          "threat_model": "Threat model"
+        }
+      },
+      "error": "آڈٹ کویری ناکام۔",
+      "export": {
+        "csv": "CSV",
+        "error": "برآمد ناکام",
+        "menu": "برآمد کریں",
+        "ndjson": "NDJSON"
+      },
+      "filters": {
+        "actor": "ایکٹر",
+        "actorPlaceholder": "ای میل سے تلاش کریں",
+        "changeType": "تبدیلی کی قسم",
+        "clear": "فلٹرز صاف کریں",
+        "createdAfter": "بعد میں بنایا گیا",
+        "createdBefore": "پہلے بنایا گیا",
+        "fieldPath": "فیلڈ کا راستہ",
+        "httpMethod": "HTTP method",
+        "objectType": "آبجیکٹ کی قسم",
+        "pathPrefix": "راستے کا سابقہ",
+        "threatModelId": "Threat model ID"
+      },
+      "pagination": {
+        "newer": "نیا",
+        "older": "پرانا"
+      },
+      "retry": "دوبارہ کوشش کریں",
+      "tabs": {
+        "system": "نظام",
+        "threatModels": "Threat models"
+      },
+      "title": "آڈٹ لاگز",
+      "viewInAuditLog": "آڈٹ لاگ میں دیکھیں"
+    },
     "createAutomationUserDialog": {
       "email": "ای میل (اختیاری)",
       "emailHint": "اختیاری — ڈیفالٹ خودکار پیدا شدہ @tmi.local پتہ ہے",
@@ -176,6 +263,10 @@
       "addons": {
         "description": "ایپلیکیشن ایڈ آنز انسٹال اور ترتیب دیں۔",
         "title": "ایڈ آنز"
+      },
+      "audit": {
+        "description": "نظام اور Threat model آڈٹ لاگز دیکھیں۔",
+        "title": "آڈٹ لاگز"
       },
       "groups": {
         "description": "صارف گروپس اور رکنیتیں ترتیب دیں۔",

--- a/src/assets/i18n/zh-CN.json
+++ b/src/assets/i18n/zh-CN.json
@@ -81,6 +81,93 @@
       "subtitle": "配置插件以扩展 TMI 功能。",
       "title": "管理插件"
     },
+    "audit": {
+      "columns": {
+        "actor": "操作者",
+        "changeSummary": "变更摘要",
+        "changeType": "变更类型",
+        "fieldPath": "字段路径",
+        "object": "对象",
+        "request": "请求",
+        "threatModel": "威胁模型",
+        "timestamp": "时间戳"
+      },
+      "detail": {
+        "actor": "操作者",
+        "changeSummary": "变更摘要",
+        "changeType": "变更类型",
+        "close": "关闭",
+        "copied": "已复制",
+        "copyPermalink": "复制永久链接",
+        "email": "电子邮件",
+        "fieldPath": "字段路径",
+        "method": "HTTP 方法",
+        "newValue": "新值",
+        "notFound": "未找到审计条目。",
+        "objectId": "对象 ID",
+        "objectType": "对象类型",
+        "oldValue": "旧值",
+        "path": "请求路径",
+        "provider": "提供者",
+        "providerId": "提供者 ID",
+        "threatModel": "威胁模型",
+        "timestamp": "时间戳",
+        "title": "审计条目",
+        "version": "版本",
+        "viewInContext": "在上下文中查看"
+      },
+      "empty": "没有条目与这些筛选条件匹配。",
+      "enums": {
+        "changeType": {
+          "created": "已创建",
+          "deleted": "已删除",
+          "patched": "已修补",
+          "restored": "已恢复",
+          "rolled_back": "已回滚",
+          "updated": "已更新"
+        },
+        "objectType": {
+          "asset": "资产",
+          "diagram": "图表",
+          "document": "文档",
+          "note": "备注",
+          "repository": "存储库",
+          "threat": "威胁",
+          "threat_model": "威胁模型"
+        }
+      },
+      "error": "审计查询失败。",
+      "export": {
+        "csv": "CSV",
+        "error": "导出失败",
+        "menu": "导出",
+        "ndjson": "NDJSON"
+      },
+      "filters": {
+        "actor": "操作者",
+        "actorPlaceholder": "按电子邮件搜索",
+        "changeType": "变更类型",
+        "clear": "清除筛选条件",
+        "createdAfter": "创建于之后",
+        "createdBefore": "创建于之前",
+        "fieldPath": "字段路径",
+        "httpMethod": "HTTP 方法",
+        "objectType": "对象类型",
+        "pathPrefix": "路径前缀",
+        "threatModelId": "威胁模型 ID"
+      },
+      "pagination": {
+        "newer": "较新",
+        "older": "较旧"
+      },
+      "retry": "重试",
+      "tabs": {
+        "system": "系统",
+        "threatModels": "威胁模型"
+      },
+      "title": "审计日志",
+      "viewInAuditLog": "在审计日志中查看"
+    },
     "createAutomationUserDialog": {
       "email": "电子邮件（可选）",
       "emailHint": "可选 — 默认为自动生成的 @tmi.local 地址",
@@ -176,6 +263,10 @@
       "addons": {
         "description": "安装和配置应用程序插件。",
         "title": "附加组件"
+      },
+      "audit": {
+        "description": "查看系统和威胁模型审计日志。",
+        "title": "审计日志"
       },
       "groups": {
         "description": "配置用户组和成员资格。",


### PR DESCRIPTION
Implements the admin-only audit-log UI (tmi-ux#679) against the now fully-published server contract (tmi#398 + tmi#464 on tmi \`dev/1.4.0\`). Because tmi#464 has landed, this ships the **complete** feature in one pass — bidirectional cursor pagination, \`around\` permalink context, and CSV/NDJSON export — rather than the degraded forward-only first iteration suggested when only #398 was available.

## What's included

- **Two views** under \`/admin/audit\` (tabbed shell, \`adminGuard\`): system audit (\`/admin/audit/system\`) and cross-threat-model audit (\`/admin/audit/threat-models\`), each deep-linkable.
- **\`AdminAuditService\`** wrapping \`GET /admin/audit/system(/{entry_id})\`, \`GET /admin/audit/threat_models(/{entry_id})\`, and the streamed system export.
- **Config-driven filter bar** (actor autocomplete, date range, plus stream-specific filters); export menu (CSV/NDJSON) is system-only.
- **Cursor-paged table** with ‹ Newer / Older › (driven by \`prev_cursor\`/\`next_cursor\`), anchor-row highlight in \`around\` mode, and distinct empty vs. error states.
- **Route-driven detail panel** (child route \`:entryId\`, keeps the table alive) with copy-permalink and "view in context" (\`around={entry_id}\`).
- **CSV/NDJSON export** via \`ApiService.getBlob\` + a blob-download util (honors active filters).
- **Cross-reference affordance**: each admin Settings row links to the system audit view pre-filtered by \`field_path\`.
- **i18n**: new strings in \`en-US\` and backfilled across all 15 target locales.

## Notes / decisions

- Step-up auth (#680) is intentionally out of scope (audit reads don't require it, per server design).
- Audit types are hand-written (mirroring the existing \`audit-trail.model.ts\`) rather than regenerating \`api-types.d.ts\`, which is built from tmi \`main\` and would pull the entire 1.4.0 API diff.
- One incidental pre-existing fix: \`html2canvas\` (already in \`package.json\`) was not installed locally, which broke the build and the navbar spec; \`pnpm install\` resolves it (no dependency change).

## Verification

- \`pnpm run build\` ✓
- \`pnpm test\` ✓ (292 files, 5882 tests)
- \`pnpm run lint:all\` ✓ (0 errors; 3 pre-existing warnings unrelated to this change)
- Subagent code review performed; findings addressed (export subscription management, clearing \`around\` from the URL on cursor pagination, action-button \`aria-label\`s, position-preserving retry, chunk names).

Implements ericfitz/tmi-ux#679. Server-side counterpart: ericfitz/tmi#464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)