### PR TITLE
chore: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,9 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 .venv/
+
+# dedupe skill local DB
+.dedupe/
+
+# local-only settings
+.local/**


### PR DESCRIPTION
Adds local-only ignore entries to `.gitignore`:

- `.dedupe/` — dedupe skill local DB
- `.local/**` — local-only settings

`main` is protected (requires PR + status checks), so this change lands via PR rather than a direct push. The same change has been applied directly to `dev/1.4.0`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>