### PR TITLE
ci: fix deps-bump discover job failing on empty branch list

### DIFF
--- a/.github/workflows/deps-bump.yml
+++ b/.github/workflows/deps-bump.yml
@@ -62,7 +62,7 @@ jobs:
           else
             LIST="$(all_branches)"                            # weekly schedule, or dispatch with branch=all
           fi
-          BRANCHES="$(printf '%s\n' "$LIST" | grep -v '^$' | jq -R . | jq -cs .)"
+          BRANCHES="$(printf '%s\n' "$LIST" | jq -R . | jq -cs 'map(select(length > 0))')"
           echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
           echo "Discovered branches: $BRANCHES"
 


### PR DESCRIPTION
## Problem

The **Dependency Bump (Claude)** workflow has been failing every day. The daily cron (`0 13 * * *`) runs the `discover` job, which checks for open Dependabot alerts. When there are none — the normal outcome most days — the script logs `No open Dependabot alerts — nothing to do.`, sets `LIST=""`, then hits:

```bash
BRANCHES="$(printf '%s\n' "$LIST" | grep -v '^$' | jq -R . | jq -cs .)"
```

Under `set -euo pipefail`, `grep -v '^$'` matches no lines and **exits 1**; `pipefail` propagates the failure and `set -e` aborts the step. The healthy no-op path is reported as a ❌ failed run.

This is not an auth problem — the logs show the App token reads the alerts API successfully (count `0`, not the `ERR` fallback).

## Fix

Drop the fragile `grep` and let `jq` filter empty lines, which is robust under `pipefail`:

```bash
BRANCHES="$(printf '%s\n' "$LIST" | jq -R . | jq -cs 'map(select(length > 0))')"
```

- Empty `LIST` → `[]` (exit 0); the `bump` job skips cleanly via its existing `branches != '[]'` guard.
- Populated `LIST` → `["main","dev/1.4.0", ...]` (exit 0), unchanged behavior.

Verified both paths locally and confirmed the YAML still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)