### PR TITLE
fix: remove @angular/animations deprecation and resolve i18n ellipsis warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^22.0.4",
     "@angular/cdk": "^22.0.2",
     "@angular/common": "^22.0.4",
     "@angular/compiler": "^22.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,12 +41,9 @@ importers:
 
   .:
     dependencies:
-      '@angular/animations':
-        specifier: ^22.0.4
-        version: 22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
       '@angular/cdk':
         specifier: ^22.0.2
-        version: 22.0.3(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
+        version: 22.0.3(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
       '@angular/common':
         specifier: ^22.0.4
         version: 22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
@@ -58,19 +55,19 @@ importers:
         version: 22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)
       '@angular/forms':
         specifier: ^22.0.4
-        version: 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
+        version: 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
       '@angular/material':
         specifier: ^22.0.2
-        version: 22.0.3(bf3fec211aaac15f550b8d883286ac4c)
+        version: 22.0.3(6349ffe7d7c95371f4650cc9b38e6b6b)
       '@angular/platform-browser':
         specifier: ^22.0.4
-        version: 22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
+        version: 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
       '@angular/platform-browser-dynamic':
         specifier: ^22.0.4
-        version: 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))
+        version: 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))
       '@angular/router':
         specifier: ^22.0.4
-        version: 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
+        version: 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
       '@antv/x6':
         specifier: 2.19.2
         version: 2.19.2
@@ -127,7 +124,7 @@ importers:
         version: 11.16.0
       ngx-markdown:
         specifier: ^22.0.0
-        version: 22.0.0(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(clipboard@2.0.11)(katex@0.16.47)(marked@18.0.5)(mermaid@11.16.0)(prismjs@1.30.0)(rxjs@7.8.2)(zone.js@0.16.2)
+        version: 22.0.0(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(clipboard@2.0.11)(katex@0.16.47)(marked@18.0.5)(mermaid@11.16.0)(prismjs@1.30.0)(rxjs@7.8.2)(zone.js@0.16.2)
       pdf-lib:
         specifier: ^1.17.1
         version: 1.17.1
@@ -139,7 +136,7 @@ importers:
         version: 7.8.2
       survey-angular-ui:
         specifier: ^2.5.30
-        version: 2.5.32(57494dc71bc5be4a7e985d330bca0cff)
+        version: 2.5.32(@angular/cdk@22.0.3(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/forms@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2))(survey-core@2.5.32)
       survey-core:
         specifier: ^2.5.30
         version: 2.5.32
@@ -158,7 +155,7 @@ importers:
     devDependencies:
       '@analogjs/vite-plugin-angular':
         specifier: ^2.6.2
-        version: 2.6.2(@angular/build@22.0.5(@angular/compiler-cli@22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@26.1.0)(chokidar@5.0.0)(lightningcss@1.32.0)(postcss@8.5.16)(tslib@2.8.1)(tsx@4.23.0)(typescript@6.0.3)(vitest@4.1.10))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.99.0)(tsx@4.23.0))
+        version: 2.6.2(@angular/build@22.0.5(@angular/compiler-cli@22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@26.1.0)(chokidar@5.0.0)(lightningcss@1.32.0)(postcss@8.5.16)(tslib@2.8.1)(tsx@4.23.0)(typescript@6.0.3)(vitest@4.1.10))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.99.0)(tsx@4.23.0))
       '@angular-eslint/builder':
         specifier: ^22.0.0
         version: 22.0.0(@angular/cli@22.0.5(@types/node@26.1.0)(chokidar@5.0.0))(chokidar@5.0.0)(eslint@10.6.0)(typescript@6.0.3)
@@ -176,7 +173,7 @@ importers:
         version: 22.0.0(eslint@10.6.0)(typescript@6.0.3)
       '@angular/build':
         specifier: ^22.0.5
-        version: 22.0.5(@angular/compiler-cli@22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@26.1.0)(chokidar@5.0.0)(lightningcss@1.32.0)(postcss@8.5.16)(tslib@2.8.1)(tsx@4.23.0)(typescript@6.0.3)(vitest@4.1.10)
+        version: 22.0.5(@angular/compiler-cli@22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@26.1.0)(chokidar@5.0.0)(lightningcss@1.32.0)(postcss@8.5.16)(tslib@2.8.1)(tsx@4.23.0)(typescript@6.0.3)(vitest@4.1.10)
       '@angular/cli':
         specifier: ^22.0.4
         version: 22.0.5(@types/node@26.1.0)(chokidar@5.0.0)
@@ -200,7 +197,7 @@ importers:
         version: 1.61.1
       '@testing-library/angular':
         specifier: ^19.4.1
-        version: 19.4.1(4abadb3d7b0a26f4d10a8c31f77aa1b7)
+        version: 19.4.1(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/router@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2))(@testing-library/dom@10.4.1)
       '@types/jsdom':
         specifier: ^28.0.3
         version: 28.0.3
@@ -417,13 +414,6 @@ packages:
       '@typescript-eslint/utils': ^8.0.0
       eslint: ^9.0.0 || ^10.0.0
       typescript: '*'
-
-  '@angular/animations@22.0.5':
-    resolution: {integrity: sha512-c4qx3l/PUQIjJCVjc/t1zgdslgrOtwNJqaH313yMYcoPB+khLi46CW/94aeOkmiYS7AGzSIS6z0ZLVoq1IFryQ==}
-    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0}
-    deprecated: '@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.'
-    peerDependencies:
-      '@angular/core': 22.0.5
 
   '@angular/build@22.0.5':
     resolution: {integrity: sha512-uVXf1cSKTMDvpiP5x0X8h7D7dICHC2XsbmvRYtxdyTRy+zJduqtCdZTwnwmCrwIc5hOF+bmwa5p17P6XirYVfw==}
@@ -4965,7 +4955,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@analogjs/vite-plugin-angular@2.6.2(@angular/build@22.0.5(@angular/compiler-cli@22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@26.1.0)(chokidar@5.0.0)(lightningcss@1.32.0)(postcss@8.5.16)(tslib@2.8.1)(tsx@4.23.0)(typescript@6.0.3)(vitest@4.1.10))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.99.0)(tsx@4.23.0))':
+  '@analogjs/vite-plugin-angular@2.6.2(@angular/build@22.0.5(@angular/compiler-cli@22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@26.1.0)(chokidar@5.0.0)(lightningcss@1.32.0)(postcss@8.5.16)(tslib@2.8.1)(tsx@4.23.0)(typescript@6.0.3)(vitest@4.1.10))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.99.0)(tsx@4.23.0))':
     dependencies:
       magic-string: 0.30.21
       obug: 2.1.3
@@ -4973,7 +4963,7 @@ snapshots:
       tinyglobby: 0.2.17
       ts-morph: 21.0.1
     optionalDependencies:
-      '@angular/build': 22.0.5(@angular/compiler-cli@22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@26.1.0)(chokidar@5.0.0)(lightningcss@1.32.0)(postcss@8.5.16)(tslib@2.8.1)(tsx@4.23.0)(typescript@6.0.3)(vitest@4.1.10)
+      '@angular/build': 22.0.5(@angular/compiler-cli@22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@26.1.0)(chokidar@5.0.0)(lightningcss@1.32.0)(postcss@8.5.16)(tslib@2.8.1)(tsx@4.23.0)(typescript@6.0.3)(vitest@4.1.10)
       vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.99.0)(tsx@4.23.0)
     transitivePeerDependencies:
       - '@emnapi/core'
@@ -5072,12 +5062,7 @@ snapshots:
       eslint: 10.6.0
       typescript: 6.0.3
 
-  '@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))':
-    dependencies:
-      '@angular/core': 22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)
-      tslib: 2.8.1
-
-  '@angular/build@22.0.5(@angular/compiler-cli@22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@26.1.0)(chokidar@5.0.0)(lightningcss@1.32.0)(postcss@8.5.16)(tslib@2.8.1)(tsx@4.23.0)(typescript@6.0.3)(vitest@4.1.10)':
+  '@angular/build@22.0.5(@angular/compiler-cli@22.0.5(@angular/compiler@22.0.5)(typescript@6.0.3))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@types/node@26.1.0)(chokidar@5.0.0)(lightningcss@1.32.0)(postcss@8.5.16)(tslib@2.8.1)(tsx@4.23.0)(typescript@6.0.3)(vitest@4.1.10)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2200.5(chokidar@5.0.0)
@@ -5110,7 +5095,7 @@ snapshots:
       watchpack: 2.5.1
     optionalDependencies:
       '@angular/core': 22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)
-      '@angular/platform-browser': 22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
+      '@angular/platform-browser': 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
       lmdb: 3.5.4
       postcss: 8.5.16
       vitest: 4.1.10(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(sass@1.99.0)(tsx@4.23.0))
@@ -5127,11 +5112,11 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/cdk@22.0.3(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)':
+  '@angular/cdk@22.0.3(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)':
     dependencies:
       '@angular/common': 22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       '@angular/core': 22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)
-      '@angular/platform-browser': 22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
+      '@angular/platform-browser': 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
       parse5: 8.0.1
       rxjs: 7.8.2
       tslib: 2.8.1
@@ -5196,47 +5181,45 @@ snapshots:
       '@angular/compiler': 22.0.5
       zone.js: 0.16.2
 
-  '@angular/forms@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)':
+  '@angular/forms@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)':
     dependencies:
       '@angular/common': 22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       '@angular/core': 22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)
-      '@angular/platform-browser': 22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
+      '@angular/platform-browser': 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
       '@standard-schema/spec': 1.1.0
       rxjs: 7.8.2
       tslib: 2.8.1
       zod: 4.4.3
 
-  '@angular/material@22.0.3(bf3fec211aaac15f550b8d883286ac4c)':
+  '@angular/material@22.0.3(6349ffe7d7c95371f4650cc9b38e6b6b)':
     dependencies:
-      '@angular/cdk': 22.0.3(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
+      '@angular/cdk': 22.0.3(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
       '@angular/common': 22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       '@angular/core': 22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)
-      '@angular/forms': 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
-      '@angular/platform-browser': 22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
+      '@angular/forms': 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
+      '@angular/platform-browser': 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/platform-browser-dynamic@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))':
+  '@angular/platform-browser-dynamic@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/compiler@22.0.5)(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))':
     dependencies:
       '@angular/common': 22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       '@angular/compiler': 22.0.5
       '@angular/core': 22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)
-      '@angular/platform-browser': 22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
+      '@angular/platform-browser': 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
       tslib: 2.8.1
 
-  '@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))':
+  '@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))':
     dependencies:
       '@angular/common': 22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       '@angular/core': 22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)
       tslib: 2.8.1
-    optionalDependencies:
-      '@angular/animations': 22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
 
-  '@angular/router@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)':
+  '@angular/router@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)':
     dependencies:
       '@angular/common': 22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       '@angular/core': 22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)
-      '@angular/platform-browser': 22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
+      '@angular/platform-browser': 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
       rxjs: 7.8.2
       tslib: 2.8.1
 
@@ -6385,12 +6368,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@testing-library/angular@19.4.1(4abadb3d7b0a26f4d10a8c31f77aa1b7)':
+  '@testing-library/angular@19.4.1(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/router@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2))(@testing-library/dom@10.4.1)':
     dependencies:
       '@angular/common': 22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       '@angular/core': 22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)
-      '@angular/platform-browser': 22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
-      '@angular/router': 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
+      '@angular/platform-browser': 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
+      '@angular/router': 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
       '@testing-library/dom': 10.4.1
       tslib: 2.8.1
 
@@ -8297,11 +8280,11 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  ngx-markdown@22.0.0(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(clipboard@2.0.11)(katex@0.16.47)(marked@18.0.5)(mermaid@11.16.0)(prismjs@1.30.0)(rxjs@7.8.2)(zone.js@0.16.2):
+  ngx-markdown@22.0.0(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(clipboard@2.0.11)(katex@0.16.47)(marked@18.0.5)(mermaid@11.16.0)(prismjs@1.30.0)(rxjs@7.8.2)(zone.js@0.16.2):
     dependencies:
       '@angular/common': 22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       '@angular/core': 22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)
-      '@angular/platform-browser': 22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
+      '@angular/platform-browser': 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))
       marked: 18.0.5
       rxjs: 7.8.2
       tslib: 2.8.1
@@ -9062,11 +9045,11 @@ snapshots:
       has-flag: 5.0.1
       supports-color: 10.2.2
 
-  survey-angular-ui@2.5.32(57494dc71bc5be4a7e985d330bca0cff):
+  survey-angular-ui@2.5.32(@angular/cdk@22.0.3(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/forms@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2))(survey-core@2.5.32):
     dependencies:
-      '@angular/cdk': 22.0.3(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
+      '@angular/cdk': 22.0.3(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
       '@angular/core': 22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)
-      '@angular/forms': 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/animations@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
+      '@angular/forms': 22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.5(@angular/common@22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
       survey-core: 2.5.32
       tslib: 2.8.1
 

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -7,7 +7,6 @@
  * Key functionality:
  * - Configures routing with component input binding support
  * - Sets up HTTP client with fetch API and JWT interceptors
- * - Provides animations support for Angular Material components
  * - Configures internationalization with Transloco and locale support
  * - Sets up zone.js change detection with event coalescing for performance
  * - Determines locale from user preferences with fallback to English
@@ -27,7 +26,6 @@ import {
   importProvidersFrom,
   APP_INITIALIZER,
 } from '@angular/core';
-import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { BidiModule } from '@angular/cdk/bidi';
 import { MAT_DIALOG_DEFAULT_OPTIONS } from '@angular/material/dialog';
@@ -165,7 +163,6 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes, withComponentInputBinding()),
     provideHttpClient(withInterceptorsFromDi(), withFetch()),
-    provideAnimations(),
     // Add Bidi module for RTL/LTR support
     importProvidersFrom(BidiModule),
     // Configure Material Dialog to respect document direction

--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -138,7 +138,7 @@
 
   <!-- Advanced filters row (expandable) -->
   @if (showAdvancedFilters) {
-    <div class="advanced-filters-row" [@detailExpand]>
+    <div class="advanced-filters-row">
       <!-- Name filter -->
       <mat-form-field appearance="outline" class="text-filter">
         <mat-label>{{ 'dashboard.nameFilter' | transloco }}</mat-label>
@@ -573,7 +573,7 @@
           <ng-container matColumnDef="expandedDetail">
             <td mat-cell *matCellDef="let tm" [attr.colspan]="displayedColumns.length">
               @if (expandedTmId === tm.id && hasActiveSessions(tm.id)) {
-                <div class="expanded-session-detail" [@detailExpand]>
+                <div class="expanded-session-detail">
                   @for (session of getSessionsForTm(tm.id); track session.id; let last = $last) {
                     <div class="session-detail-content">
                       <p class="collab-detail">

--- a/src/app/pages/dashboard/dashboard.component.scss
+++ b/src/app/pages/dashboard/dashboard.component.scss
@@ -75,6 +75,9 @@
   margin-bottom: 16px;
   flex-wrap: wrap;
 
+  // Enter animation played when the row is added to the DOM (@if toggle).
+  animation: filters-row-expand 225ms cubic-bezier(0.4, 0, 0.2, 1);
+
   .text-filter {
     width: 200px;
   }
@@ -85,6 +88,20 @@
 
   mat-form-field ::ng-deep .mat-mdc-form-field-subscript-wrapper {
     display: none;
+  }
+}
+
+@keyframes filters-row-expand {
+  from {
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
+  }
+
+  to {
+    max-height: 600px;
+    opacity: 1;
+    overflow: hidden;
   }
 }
 
@@ -495,8 +512,23 @@ button.delete-button {
   overflow: hidden;
   padding: 8px 16px 16px 56px;
 
+  // Enter animation played when the detail row is added to the DOM (@if toggle).
+  animation: session-detail-expand 225ms cubic-bezier(0.4, 0, 0.2, 1);
+
   mat-divider {
     margin: 12px 0;
+  }
+}
+
+@keyframes session-detail-expand {
+  from {
+    max-height: 0;
+    opacity: 0;
+  }
+
+  to {
+    max-height: 600px;
+    opacity: 1;
   }
 }
 

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -26,7 +26,6 @@ import {
   OnInit,
   ViewChild,
 } from '@angular/core';
-import { trigger, state, style, transition, animate } from '@angular/animations';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import { Observable, Subject, Subscription } from 'rxjs';
@@ -116,13 +115,6 @@ import { getErrorMessage } from '@app/shared/utils/http-error.utils';
   styleUrl: './dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [{ provide: MatPaginatorIntl, useClass: PaginatorIntlService }],
-  animations: [
-    trigger('detailExpand', [
-      state('void', style({ height: '0', opacity: '0', overflow: 'hidden' })),
-      state('*', style({ height: '*', opacity: '1' })),
-      transition('void <=> *', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
-    ]),
-  ],
 })
 // SEM@e2fbc45e03d8471569c0ba4d4f2d8d25008f8a5d: list, filter, search, and manage threat models on the main dashboard
 export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {

--- a/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html
+++ b/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html
@@ -91,7 +91,7 @@
 
 <!-- Advanced filters row (expandable) -->
 @if (showAdvancedFilters) {
-  <div class="advanced-filters-row" [@detailExpand]>
+  <div class="advanced-filters-row">
     <!-- Owner filter -->
     <mat-form-field appearance="outline" class="text-filter">
       <mat-label>{{ 'dashboard.ownerFilter' | transloco }}</mat-label>

--- a/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.scss
+++ b/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.scss
@@ -71,6 +71,9 @@
   margin-bottom: 16px;
   flex-wrap: wrap;
 
+  // Enter animation played when the row is added to the DOM (@if toggle).
+  animation: filters-row-expand 225ms cubic-bezier(0.4, 0, 0.2, 1);
+
   .text-filter {
     width: 200px;
   }
@@ -81,6 +84,20 @@
 
   mat-form-field ::ng-deep .mat-mdc-form-field-subscript-wrapper {
     display: none;
+  }
+}
+
+@keyframes filters-row-expand {
+  from {
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
+  }
+
+  to {
+    max-height: 600px;
+    opacity: 1;
+    overflow: hidden;
   }
 }
 

--- a/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts
+++ b/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts
@@ -10,7 +10,6 @@ import {
 import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
-import { trigger, state, style, transition, animate } from '@angular/animations';
 import { PageEvent } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatDialog } from '@angular/material/dialog';
@@ -65,13 +64,6 @@ interface ReviewerFilters {
   templateUrl: './reviewer-assignment-list.component.html',
   styleUrl: './reviewer-assignment-list.component.scss',
   changeDetection: ChangeDetectionStrategy.Eager,
-  animations: [
-    trigger('detailExpand', [
-      state('void', style({ height: '0', opacity: '0', overflow: 'hidden' })),
-      state('*', style({ height: '*', opacity: '1' })),
-      transition('void <=> *', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
-    ]),
-  ],
 })
 // SEM@18b5b056436f5b56f58815b0bb5bfe9b18b41346: list and assign security reviewers to unreviewed threat models (reads DB)
 export class ReviewerAssignmentListComponent implements OnInit, OnDestroy {

--- a/src/assets/i18n/ar-SA.json
+++ b/src/assets/i18n/ar-SA.json
@@ -47,7 +47,7 @@
   },
   "admin": {
     "addons": {
-      "addButton": "{{admin.addons.addDialog.title}}",
+      "addButton": "{{admin.addons.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "ما هي وظيفة هذا الملحق؟",
@@ -183,7 +183,7 @@
       "title": "{{admin.createAutomationUserDialog.save}}"
     },
     "groups": {
-      "addButton": "{{admin.groups.addDialog.title}}",
+      "addButton": "{{admin.groups.addDialog.title}}...",
       "addDialog": {
         "description": "الوصف (اختياري)",
         "descriptionHint": "وصف اختياري لغرض المجموعة",
@@ -302,7 +302,7 @@
       }
     },
     "settings": {
-      "addButton": "{{admin.settings.addDialog.title}}",
+      "addButton": "{{admin.settings.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "وصف اختياري لهذا الإعداد",
@@ -360,7 +360,7 @@
         "threatModels": "TMs",
         "user": "{{common.subjectTypes.user}}"
       },
-      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}",
+      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}...",
       "deleteTooltip": "حذف حساب المستخدم",
       "filter": {
         "automationOnly": "عرض حسابات الأتمتة فقط."
@@ -388,7 +388,7 @@
       }
     },
     "webhooks": {
-      "addButton": "{{admin.webhooks.addDialog.title}}",
+      "addButton": "{{admin.webhooks.addDialog.title}}...",
       "addDialog": {
         "createAutomationUser": "إنشاء مستخدم أتمتة لهذا الـ Webhook.",
         "events": "أنواع الأحداث للاشتراك فيها",
@@ -870,7 +870,6 @@
     "openInNewTab": "فتح في علامة تبويب جديدة",
     "other": "أخرى",
     "paste": "لصق",
-    "permissions": "الأذونات",
     "priority": "الأولوية",
     "project": "مشروع",
     "provider": "المزود",
@@ -925,7 +924,8 @@
     "view": "عرض",
     "viewMetadata": "عرض البيانات الوصفية",
     "viewPermissions": "عرض الأذونات",
-    "viewThreat": "عرض التهديد"
+    "viewThreat": "عرض التهديد",
+    "permissions": "الأذونات..."
   },
   "contextMenu": {
     "addInverseConnection": "إضافة اتصال عكسي",
@@ -1008,7 +1008,7 @@
   "cwePicker": {
     "addCwe": "إضافة CWE",
     "addCweReference": "إضافة مرجع CWE إلى التهديد",
-    "chooseCwe": "{{cwePicker.title}}",
+    "chooseCwe": "{{cwePicker.title}}...",
     "extendedDescription": "الوصف الموسَّع",
     "loading": "جارٍ تحميل الثغرات...",
     "matchingWeaknesses": "الثغرات المطابقة",
@@ -1615,10 +1615,10 @@
     "filterStatusLabel": "{{projects.statusFilterLabel}}",
     "filterTeamLabel": "{{projects.teamFilterLabel}}",
     "kebab": {
-      "delete": "{{common.delete}}",
-      "metadata": "{{common.metadata}}",
-      "relatedProjects": "{{projects.relatedProjectsDialog.title}}",
-      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}"
+      "delete": "{{common.delete}}...",
+      "metadata": "{{common.metadata}}...",
+      "relatedProjects": "{{projects.relatedProjectsDialog.title}}...",
+      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.projects.title}}",
     "noProjects": "لم يتم العثور على مشاريع.",
@@ -1854,11 +1854,11 @@
     },
     "filterLabel": "تصفية الفرق",
     "kebab": {
-      "delete": "{{common.delete}}",
+      "delete": "{{common.delete}}...",
       "members": "أعضاء الفريق...",
-      "metadata": "{{common.metadata}}",
-      "relatedTeams": "{{teams.relatedTeamsDialog.title}}",
-      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}"
+      "metadata": "{{common.metadata}}...",
+      "relatedTeams": "{{teams.relatedTeamsDialog.title}}...",
+      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.teams.title}}",
     "membersDialog": {
@@ -1947,14 +1947,14 @@
     "selectDiagramFirst": "اختر مخططاً أولاً",
     "threatPriority": {
       "0": "Immediate (P0)",
-      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
       "1": "High (P1)",
-      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
       "2": "Medium (P2)",
-      "2.description": "Address within standard development cycles; moderate exposure.",
       "3": "Low (P3)",
-      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4": "Deferred (P4)",
+      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
+      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
+      "2.description": "Address within standard development cycles; moderate exposure.",
+      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4.description": "Postponed with documented business approval; tracked but not scheduled.",
       "deferred": "مؤجل (P4)",
       "deferred.description": "مؤجل بموافقة تجارية موثقة؛ متتبع لكن غير مجدول.",
@@ -1968,11 +1968,11 @@
       "medium.description": "المعالجة ضمن دورات التطوير القياسية؛ تعرض معتدل."
     },
     "threatSeverity": {
+      "4": "Informational",
       "0.description": "Exploitable vulnerability enables complete system compromise, data breach, or safety impact; requires immediate action.",
       "1.description": "Significant impact or high likelihood; enables major unauthorized access, privilege escalation, or service disruption.",
       "2.description": "Moderate impact or likelihood; limited data exposure, partial functionality impairment, or requires chained exploits.",
       "3.description": "Minimal impact or low likelihood; negligible business impact, requires specific conditions or user interaction.",
-      "4": "Informational",
       "4.description": "No direct exploitability; recommendation, best practice deviation, or configuration improvement.",
       "5.description": "Threat severity has not yet been assessed.",
       "critical": "حرج",
@@ -1990,24 +1990,24 @@
     },
     "threatStatus": {
       "0": "Open",
-      "0.description": "The finding has been identified and documented but no action has been initiated.",
       "1": "Confirmed",
-      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
       "2": "Mitigation Planned",
-      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
       "3": "Mitigation In Progress",
-      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
       "4": "Verification Pending",
-      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
       "5": "Resolved",
-      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
       "6": "Accepted",
-      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
       "7": "False Positive",
-      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
       "8": "Deferred",
-      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9": "Closed",
+      "0.description": "The finding has been identified and documented but no action has been initiated.",
+      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
+      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
+      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
+      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
+      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
+      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
+      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
+      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9.description": "The finding is archived after resolution, acceptance, or invalidation, with audit trail.",
       "accepted": "مقبول",
       "accepted.description": "التهديد معترف به لكن لم يتم تخفيفه عمداً (مثل: بسبب مبرر تجاري)؛ يتطلب قبول المخاطر الرسمي.",
@@ -2129,24 +2129,24 @@
     "sourcesCount": "مستودعات",
     "status": {
       "0": "Not Started",
-      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
       "1": "In Progress",
-      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
       "2": "Pending Review",
-      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
       "3": "Remediation Required",
-      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
       "4": "Remediation In Progress",
-      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
       "5": "Verification Pending",
-      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
       "6": "Approved",
-      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
       "7": "Rejected",
-      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
       "8": "Deferred",
-      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9": "Closed",
+      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
+      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
+      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
+      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
+      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
+      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
+      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
+      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
+      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9.tooltip": "The review is fully completed and archived, with no further action needed.",
       "active": "نشط",
       "active.tooltip": "يجري العمل على نموذج التهديد بشكل نشط.",
@@ -2179,7 +2179,7 @@
       "addAsset": "إضافة أصل...",
       "addDiagram": "إضافة مخطط...",
       "addDocument": "إضافة وثيقة...",
-      "addNote": "{{triage.detail.addNote}}",
+      "addNote": "{{triage.detail.addNote}}...",
       "assetsCardTitle": "الأصول هي موارد قيمة داخل النظام تتطلب الحماية، مثل البيانات والأجهزة والبرامج والبنية التحتية والخدمات أو الموظفين",
       "diagramsCardTitle": "المخططات في TMI هي تمثيلات قابلة للقراءة آلياً لحركة البيانات والعمليات داخل النظام، مما يتيح التحليل الأمني اليدوي والآلي",
       "documentsCardTitle": "مراجع الوثائق هي روابط للوثائق المخزنة خارج TMI. الوثائق ذات الصلة تصف النظام المراد تحليله، ويمكن استخدامها من قبل محللي الأمن وعمليات التحليل الآلي",

--- a/src/assets/i18n/bn-BD.json
+++ b/src/assets/i18n/bn-BD.json
@@ -69,7 +69,7 @@
   "addons.invokeDialog.valueTooLong": "মান সর্বোচ্চ দৈর্ঘ্য অতিক্রম করেছে।",
   "admin": {
     "addons": {
-      "addButton": "{{admin.addons.addDialog.title}}",
+      "addButton": "{{admin.addons.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "এই অ্যাডঅন কী করে?",
@@ -205,7 +205,7 @@
       "title": "{{admin.createAutomationUserDialog.save}}"
     },
     "groups": {
-      "addButton": "{{admin.groups.addDialog.title}}",
+      "addButton": "{{admin.groups.addDialog.title}}...",
       "addDialog": {
         "description": "বিবরণ (ঐচ্ছিক)",
         "descriptionHint": "গ্রুপের উদ্দেশ্যের ঐচ্ছিক বিবরণ",
@@ -324,7 +324,7 @@
       }
     },
     "settings": {
-      "addButton": "{{admin.settings.addDialog.title}}",
+      "addButton": "{{admin.settings.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "এই সেটিংয়ের ঐচ্ছিক বিবরণ",
@@ -382,7 +382,7 @@
         "threatModels": "TMs",
         "user": "{{common.subjectTypes.user}}"
       },
-      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}",
+      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}...",
       "deleteTooltip": "ব্যবহারকারী অ্যাকাউন্ট মুছুন",
       "filter": {
         "automationOnly": "শুধুমাত্র অটোমেশন অ্যাকাউন্ট দেখান"
@@ -410,7 +410,7 @@
       }
     },
     "webhooks": {
-      "addButton": "{{admin.webhooks.addDialog.title}}",
+      "addButton": "{{admin.webhooks.addDialog.title}}...",
       "addDialog": {
         "createAutomationUser": "এই ওয়েবহুকের জন্য অটোমেশন ব্যবহারকারী তৈরি করুন",
         "events": "সাবস্ক্রাইব করার জন্য ইভেন্ট প্রকার",
@@ -1074,7 +1074,6 @@
     "openInNewTab": "নতুন ট্যাবে খুলুন",
     "other": "অন্যান্য",
     "paste": "পেস্ট",
-    "permissions": "অনুমতি",
     "priority": "অগ্রাধিকার",
     "project": "প্রকল্প",
     "provider": "প্রদানকারী",
@@ -1129,7 +1128,8 @@
     "view": "দেখুন",
     "viewMetadata": "মেটাডেটা দেখুন",
     "viewPermissions": "অনুমতি দেখুন",
-    "viewThreat": "হুমকি দেখুন"
+    "viewThreat": "হুমকি দেখুন",
+    "permissions": "অনুমতি..."
   },
   "common.addMetadata": "মেটাডেটা যুক্ত করুন",
   "common.addThreat": "হুমকি যুক্ত করুন",
@@ -1276,7 +1276,7 @@
   "cwePicker": {
     "addCwe": "CWE যোগ করুন",
     "addCweReference": "হুমকিতে CWE রেফারেন্স যোগ করুন",
-    "chooseCwe": "{{cwePicker.title}}",
+    "chooseCwe": "{{cwePicker.title}}...",
     "extendedDescription": "বিস্তারিত বিবরণ",
     "loading": "দুর্বলতাগুলো লোড হচ্ছে...",
     "matchingWeaknesses": "মিলে যাওয়া দুর্বলতাসমূহ",
@@ -2057,10 +2057,10 @@
     "filterStatusLabel": "{{projects.statusFilterLabel}}",
     "filterTeamLabel": "{{projects.teamFilterLabel}}",
     "kebab": {
-      "delete": "{{common.delete}}",
-      "metadata": "{{common.metadata}}",
-      "relatedProjects": "{{projects.relatedProjectsDialog.title}}",
-      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}"
+      "delete": "{{common.delete}}...",
+      "metadata": "{{common.metadata}}...",
+      "relatedProjects": "{{projects.relatedProjectsDialog.title}}...",
+      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.projects.title}}",
     "noProjects": "কোন প্রকল্প পাওয়া যায়নি",
@@ -2363,11 +2363,11 @@
     },
     "filterLabel": "দল ফিল্টার করুন",
     "kebab": {
-      "delete": "{{common.delete}}",
+      "delete": "{{common.delete}}...",
       "members": "সদস্য",
-      "metadata": "{{common.metadata}}",
-      "relatedTeams": "{{teams.relatedTeamsDialog.title}}",
-      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}"
+      "metadata": "{{common.metadata}}...",
+      "relatedTeams": "{{teams.relatedTeamsDialog.title}}...",
+      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.teams.title}}",
     "membersDialog": {
@@ -2487,14 +2487,14 @@
     "selectDiagramFirst": "প্রথমে একটি ডায়াগ্রাম নির্বাচন করুন",
     "threatPriority": {
       "0": "Immediate (P0)",
-      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
       "1": "High (P1)",
-      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
       "2": "Medium (P2)",
-      "2.description": "Address within standard development cycles; moderate exposure.",
       "3": "Low (P3)",
-      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4": "Deferred (P4)",
+      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
+      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
+      "2.description": "Address within standard development cycles; moderate exposure.",
+      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4.description": "Postponed with documented business approval; tracked but not scheduled.",
       "deferred.description": "নথিভুক্ত ব্যবসায়িক অনুমোদনসহ স্থগিত; ট্র্যাক করা হচ্ছে কিন্তু নির্ধারিত নয়।",
       "high.description": "দ্রুত সমাধান প্রয়োজন; উচ্চ-ঝুঁকির এক্সপোজার বা আসন্ন রিলিজ ডেডলাইন।",
@@ -2503,11 +2503,11 @@
       "medium.description": "স্বাভাবিক ডেভেলপমেন্ট চক্রের মধ্যে সমাধান করুন; মাঝারি ঝুঁকি।"
     },
     "threatSeverity": {
+      "4": "Informational",
       "0.description": "Exploitable vulnerability enables complete system compromise, data breach, or safety impact; requires immediate action.",
       "1.description": "Significant impact or high likelihood; enables major unauthorized access, privilege escalation, or service disruption.",
       "2.description": "Moderate impact or likelihood; limited data exposure, partial functionality impairment, or requires chained exploits.",
       "3.description": "Minimal impact or low likelihood; negligible business impact, requires specific conditions or user interaction.",
-      "4": "Informational",
       "4.description": "No direct exploitability; recommendation, best practice deviation, or configuration improvement.",
       "5.description": "Threat severity has not yet been assessed.",
       "critical": "গুরুতর",
@@ -2525,24 +2525,24 @@
     },
     "threatStatus": {
       "0": "Open",
-      "0.description": "The finding has been identified and documented but no action has been initiated.",
       "1": "Confirmed",
-      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
       "2": "Mitigation Planned",
-      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
       "3": "Mitigation In Progress",
-      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
       "4": "Verification Pending",
-      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
       "5": "Resolved",
-      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
       "6": "Accepted",
-      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
       "7": "False Positive",
-      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
       "8": "Deferred",
-      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9": "Closed",
+      "0.description": "The finding has been identified and documented but no action has been initiated.",
+      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
+      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
+      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
+      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
+      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
+      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
+      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
+      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9.description": "The finding is archived after resolution, acceptance, or invalidation, with audit trail.",
       "accepted": "গৃহীত",
       "accepted.description": "হুমকিটি স্বীকৃত কিন্তু ইচ্ছাকৃতভাবে প্রশমিত নয় (যেমন, ব্যবসায়িক যুক্তির কারণে); আনুষ্ঠানিক ঝুঁকি গ্রহণযোগ্যতা প্রয়োজন।",
@@ -2683,24 +2683,24 @@
     "sourcesCount": "রিপো",
     "status": {
       "0": "Not Started",
-      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
       "1": "In Progress",
-      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
       "2": "Pending Review",
-      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
       "3": "Remediation Required",
-      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
       "4": "Remediation In Progress",
-      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
       "5": "Verification Pending",
-      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
       "6": "Approved",
-      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
       "7": "Rejected",
-      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
       "8": "Deferred",
-      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9": "Closed",
+      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
+      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
+      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
+      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
+      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
+      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
+      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
+      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
+      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9.tooltip": "The review is fully completed and archived, with no further action needed.",
       "active": "সক্রিয়",
       "active.tooltip": "থ্রেট মডেলটি সক্রিয়ভাবে কাজ করা হচ্ছে।",
@@ -2727,7 +2727,7 @@
       "addAsset": "অ্যাসেট যোগ করুন",
       "addDiagram": "ডায়াগ্রাম যোগ করুন",
       "addDocument": "ডকুমেন্ট যোগ করুন",
-      "addNote": "{{triage.detail.addNote}}",
+      "addNote": "{{triage.detail.addNote}}...",
       "assetsCardTitle": "অ্যাসেট হল সিস্টেমের মধ্যে মূল্যবান সম্পদ যা সুরক্ষা প্রয়োজন, যেমন ডেটা, হার্ডওয়্যার, সফটওয়্যার, অবকাঠামো, সেবা বা কর্মী।",
       "diagramsCardTitle": "TMI-তে ডায়াগ্রাম হল একটি সিস্টেমের মধ্যে ডেটা চলাচল এবং প্রক্রিয়াগুলির মেশিন-পাঠযোগ্য উপস্থাপনা, যা ম্যানুয়াল এবং স্বয়ংক্রিয় নিরাপত্তা বিশ্লেষণ উভয়ই সক্ষম করে।",
       "documentsCardTitle": "ডকুমেন্ট রেফারেন্স হল TMI-র বাইরে সংরক্ষিত ডকুমেন্টের লিংক। প্রাসঙ্গিক ডকুমেন্ট বিশ্লেষণ করা সিস্টেম বর্ণনা করে এবং নিরাপত্তা বিশ্লেষক এবং স্বয়ংক্রিয় বিশ্লেষণ প্রক্রিয়া উভয় দ্বারা ব্যবহার করা যেতে পারে।",

--- a/src/assets/i18n/de-DE.json
+++ b/src/assets/i18n/de-DE.json
@@ -47,7 +47,7 @@
   },
   "admin": {
     "addons": {
-      "addButton": "{{admin.addons.addDialog.title}}",
+      "addButton": "{{admin.addons.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "Was macht diese Erweiterung?",
@@ -183,7 +183,7 @@
       "title": "{{admin.createAutomationUserDialog.save}}"
     },
     "groups": {
-      "addButton": "{{admin.groups.addDialog.title}}",
+      "addButton": "{{admin.groups.addDialog.title}}...",
       "addDialog": {
         "description": "Beschreibung (optional)",
         "descriptionHint": "Optionale Beschreibung des Gruppenzwecks",
@@ -302,7 +302,7 @@
       }
     },
     "settings": {
-      "addButton": "{{admin.settings.addDialog.title}}",
+      "addButton": "{{admin.settings.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "Optionale Beschreibung dieser Einstellung",
@@ -360,7 +360,7 @@
         "threatModels": "TMs",
         "user": "{{common.subjectTypes.user}}"
       },
-      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}",
+      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}...",
       "deleteTooltip": "Benutzerkonto löschen",
       "filter": {
         "automationOnly": "Nur Automatisierungskonten anzeigen."
@@ -388,7 +388,7 @@
       }
     },
     "webhooks": {
-      "addButton": "{{admin.webhooks.addDialog.title}}",
+      "addButton": "{{admin.webhooks.addDialog.title}}...",
       "addDialog": {
         "createAutomationUser": "Automatisierungsbenutzer für diesen Webhook erstellen.",
         "events": "Zu abonnierende Ereignistypen",
@@ -870,7 +870,6 @@
     "openInNewTab": "In neuem Tab öffnen",
     "other": "Andere",
     "paste": "Einfügen",
-    "permissions": "Berechtigungen",
     "priority": "Priorität",
     "project": "Projekt",
     "provider": "Anbieter",
@@ -925,7 +924,8 @@
     "view": "Ansicht",
     "viewMetadata": "Metadaten anzeigen",
     "viewPermissions": "Berechtigungen anzeigen",
-    "viewThreat": "Bedrohung anzeigen"
+    "viewThreat": "Bedrohung anzeigen",
+    "permissions": "Berechtigungen..."
   },
   "contextMenu": {
     "addInverseConnection": "Umgekehrte Verbindung hinzufügen",
@@ -1008,7 +1008,7 @@
   "cwePicker": {
     "addCwe": "CWE hinzufügen",
     "addCweReference": "CWE-Referenz zur Bedrohung hinzufügen",
-    "chooseCwe": "{{cwePicker.title}}",
+    "chooseCwe": "{{cwePicker.title}}...",
     "extendedDescription": "Erweiterte Beschreibung",
     "loading": "Schwachstellen werden geladen...",
     "matchingWeaknesses": "Übereinstimmende Schwachstellen",
@@ -1613,10 +1613,10 @@
     "filterStatusLabel": "{{projects.statusFilterLabel}}",
     "filterTeamLabel": "{{projects.teamFilterLabel}}",
     "kebab": {
-      "delete": "{{common.delete}}",
-      "metadata": "{{common.metadata}}",
-      "relatedProjects": "{{projects.relatedProjectsDialog.title}}",
-      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}"
+      "delete": "{{common.delete}}...",
+      "metadata": "{{common.metadata}}...",
+      "relatedProjects": "{{projects.relatedProjectsDialog.title}}...",
+      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.projects.title}}",
     "noProjects": "Keine Projekte gefunden.",
@@ -1852,11 +1852,11 @@
     },
     "filterLabel": "Teams filtern",
     "kebab": {
-      "delete": "{{common.delete}}",
+      "delete": "{{common.delete}}...",
       "members": "Mitglieder...",
-      "metadata": "{{common.metadata}}",
-      "relatedTeams": "{{teams.relatedTeamsDialog.title}}",
-      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}"
+      "metadata": "{{common.metadata}}...",
+      "relatedTeams": "{{teams.relatedTeamsDialog.title}}...",
+      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.teams.title}}",
     "membersDialog": {
@@ -1945,14 +1945,14 @@
     "selectDiagramFirst": "Zuerst ein Diagramm auswählen",
     "threatPriority": {
       "0": "Immediate (P0)",
-      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
       "1": "High (P1)",
-      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
       "2": "Medium (P2)",
-      "2.description": "Address within standard development cycles; moderate exposure.",
       "3": "Low (P3)",
-      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4": "Deferred (P4)",
+      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
+      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
+      "2.description": "Address within standard development cycles; moderate exposure.",
+      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4.description": "Postponed with documented business approval; tracked but not scheduled.",
       "deferred": "Zurückgestellt (P4)",
       "deferred.description": "Zurückgestellt mit dokumentierter Geschäftsgenehmigung; wird verfolgt, aber nicht eingeplant.",
@@ -1966,11 +1966,11 @@
       "medium.description": "Im Rahmen regulärer Entwicklungszyklen beheben; mittleres Risiko."
     },
     "threatSeverity": {
+      "4": "Informational",
       "0.description": "Exploitable vulnerability enables complete system compromise, data breach, or safety impact; requires immediate action.",
       "1.description": "Significant impact or high likelihood; enables major unauthorized access, privilege escalation, or service disruption.",
       "2.description": "Moderate impact or likelihood; limited data exposure, partial functionality impairment, or requires chained exploits.",
       "3.description": "Minimal impact or low likelihood; negligible business impact, requires specific conditions or user interaction.",
-      "4": "Informational",
       "4.description": "No direct exploitability; recommendation, best practice deviation, or configuration improvement.",
       "5.description": "Threat severity has not yet been assessed.",
       "critical": "Kritisch",
@@ -1988,24 +1988,24 @@
     },
     "threatStatus": {
       "0": "Open",
-      "0.description": "The finding has been identified and documented but no action has been initiated.",
       "1": "Confirmed",
-      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
       "2": "Mitigation Planned",
-      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
       "3": "Mitigation In Progress",
-      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
       "4": "Verification Pending",
-      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
       "5": "Resolved",
-      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
       "6": "Accepted",
-      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
       "7": "False Positive",
-      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
       "8": "Deferred",
-      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9": "Closed",
+      "0.description": "The finding has been identified and documented but no action has been initiated.",
+      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
+      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
+      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
+      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
+      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
+      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
+      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
+      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9.description": "The finding is archived after resolution, acceptance, or invalidation, with audit trail.",
       "accepted": "Akzeptiert",
       "accepted.description": "Die Bedrohung wird anerkannt, aber absichtlich nicht gemindert (z. B. aufgrund geschäftlicher Begründung); erfordert formale Risikoakzeptanz.",
@@ -2127,24 +2127,24 @@
     "sourcesCount": "Repos",
     "status": {
       "0": "Not Started",
-      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
       "1": "In Progress",
-      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
       "2": "Pending Review",
-      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
       "3": "Remediation Required",
-      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
       "4": "Remediation In Progress",
-      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
       "5": "Verification Pending",
-      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
       "6": "Approved",
-      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
       "7": "Rejected",
-      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
       "8": "Deferred",
-      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9": "Closed",
+      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
+      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
+      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
+      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
+      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
+      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
+      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
+      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
+      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9.tooltip": "The review is fully completed and archived, with no further action needed.",
       "active": "Aktiv",
       "active.tooltip": "Am Bedrohungsmodell wird aktiv gearbeitet.",
@@ -2177,7 +2177,7 @@
       "addAsset": "Asset hinzufügen...",
       "addDiagram": "Diagramm hinzufügen...",
       "addDocument": "Dokument hinzufügen...",
-      "addNote": "{{triage.detail.addNote}}",
+      "addNote": "{{triage.detail.addNote}}...",
       "assetsCardTitle": "Assets sind wertvolle Ressourcen innerhalb des Systems, die Schutz benötigen, wie Daten, Hardware, Software, Infrastruktur, Dienste oder Personal",
       "diagramsCardTitle": "Diagramme in TMI sind maschinenlesbare Darstellungen von Datenbewegungen und Prozessen innerhalb eines Systems, die sowohl manuelle als auch automatisierte Sicherheitsanalysen ermöglichen",
       "documentsCardTitle": "Dokumentreferenzen sind Links zu Dokumenten, die außerhalb von TMI gespeichert sind. Relevante Dokumente beschreiben das zu analysierende System und können sowohl von Sicherheitsanalysten als auch von automatisierten Analyseprozessen verwendet werden",

--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -55,7 +55,8 @@
   },
   "admin": {
     "addons": {
-      "addButton": "{{admin.addons.addDialog.title}}",
+      "addButton": "{{admin.addons.addDialog.title}}...",
+      "addButton.lint-skip": "Trailing ellipsis is intentional per style guide: button that opens a dialog.",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "What does this addon do?",
@@ -200,7 +201,8 @@
       "title": "{{admin.createAutomationUserDialog.save}}"
     },
     "groups": {
-      "addButton": "{{admin.groups.addDialog.title}}",
+      "addButton": "{{admin.groups.addDialog.title}}...",
+      "addButton.lint-skip": "Trailing ellipsis is intentional per style guide: button that opens a dialog.",
       "addDialog": {
         "description": "Description (optional)",
         "descriptionHint": "Optional description of the group's purpose",
@@ -334,7 +336,8 @@
       }
     },
     "settings": {
-      "addButton": "{{admin.settings.addDialog.title}}",
+      "addButton": "{{admin.settings.addDialog.title}}...",
+      "addButton.lint-skip": "Trailing ellipsis is intentional per style guide: button that opens a dialog.",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "Optional description of this setting",
@@ -399,7 +402,8 @@
         "threatModels": "TMs",
         "user": "{{common.subjectTypes.user}}"
       },
-      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}",
+      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}...",
+      "createAutomationUser.lint-skip": "Trailing ellipsis is intentional per style guide: button that opens a dialog.",
       "deleteTooltip": "Delete user account",
       "deleteTooltip.comment": "Verb (imperative). Used as a context-menu or dropdown action: 'Delete user account'.",
       "filter": {
@@ -431,7 +435,8 @@
       }
     },
     "webhooks": {
-      "addButton": "{{admin.webhooks.addDialog.title}}",
+      "addButton": "{{admin.webhooks.addDialog.title}}...",
+      "addButton.lint-skip": "Trailing ellipsis is intentional per style guide: button that opens a dialog.",
       "addDialog": {
         "createAutomationUser": "Create automation user for this webhook.",
         "events": "Event types to subscribe to",
@@ -727,9 +732,9 @@
   "auth": {
     "unauthorized": {
       "401": "401 unauthorized",
+      "403": "403 forbidden",
       "401.comment": "This is a standard error message and should not be translated.",
       "401.lint-skip": "HTTP status code label starting with numeric code, not a sentence.",
-      "403": "403 forbidden",
       "403.comment": "This is a standard error message and should not be translated.",
       "403.lint-skip": "HTTP status code label starting with numeric code, not a sentence.",
       "noPermission": "You do not have permission to access this page.",
@@ -853,6 +858,7 @@
   "common": {
     "about": "About",
     "actions": "Actions",
+    "actions.lint-skip": "Shared base label used across multiple surfaces (button/menu-item/tooltip); dedicated ellipsis-carrying wrapper keys exist where a dialog-opening affordance needs one, so this base key is intentionally not ellipsized.",
     "activate": "Activate",
     "active": "Active",
     "add": "Add",
@@ -887,6 +893,7 @@
     "copyToClipboard": "Copy to clipboard",
     "copyToClipboard.comment": "Verb (imperative). Used on a button that initiates the action: 'Copy to clipboard'.",
     "create": "Create",
+    "create.lint-skip": "Shared base label used across multiple surfaces (button/menu-item/tooltip); dedicated ellipsis-carrying wrapper keys exist where a dialog-opening affordance needs one, so this base key is intentionally not ellipsized.",
     "created": "Created",
     "createdBy": "Created by",
     "criticality": "Criticality",
@@ -894,6 +901,7 @@
     "cut": "Cut",
     "deactivate": "Deactivate",
     "delete": "Delete",
+    "delete.lint-skip": "Shared base label used across multiple surfaces (button/menu-item/tooltip); dedicated ellipsis-carrying wrapper keys exist where a dialog-opening affordance needs one, so this base key is intentionally not ellipsized.",
     "delete.comment": "Verb (imperative). Used on a button that initiates the action: 'Delete'.",
     "deleteConfirm": "Confirm deletion",
     "deleteFailed": "Delete failed",
@@ -914,6 +922,7 @@
     "done": "Done",
     "download": "Download",
     "edit": "Edit",
+    "edit.lint-skip": "Shared base label used across multiple surfaces (button/menu-item/tooltip); dedicated ellipsis-carrying wrapper keys exist where a dialog-opening affordance needs one, so this base key is intentionally not ellipsized.",
     "edit.comment": "Action description on a tooltip (typically for an icon button): 'Edit'.",
     "editThreat": "Edit threat",
     "editThreat.comment": "Verb (imperative form). Used as an action label: 'Edit threat'. Surface not identified in source scan.",
@@ -939,7 +948,9 @@
     "loading.lint-skip": "Ellipsis (...) is intentional for loading/in-progress states",
     "manage": "Manage",
     "manageMetadata": "Manage metadata",
+    "manageMetadata.lint-skip": "Shared with a dialog title (dialog-title surface); a trailing ellipsis would be wrong on the title, so the ellipsis convention does not apply to this key.",
     "manageThreats": "Manage threats",
+    "manageThreats.lint-skip": "Shared with a dialog title (dialog-title surface); a trailing ellipsis would be wrong on the title, so the ellipsis convention does not apply to this key.",
     "metadata": "Metadata",
     "metadataKey": "Key",
     "metadataValue": "Value",
@@ -988,7 +999,8 @@
     "openInNewTab": "Open in new tab",
     "other": "Other",
     "paste": "Paste",
-    "permissions": "Permissions",
+    "permissions": "Permissions...",
+    "permissions.lint-skip": "Trailing ellipsis is intentional per style guide: menu-item/tooltip/button that opens a dialog.",
     "priority": "Priority",
     "project": "Project",
     "provider": "Provider",
@@ -1048,6 +1060,7 @@
     "view": "View",
     "view.comment": "View is used as a verb here.",
     "viewMetadata": "View metadata",
+    "viewMetadata.lint-skip": "Shared with a dialog title (dialog-title surface); a trailing ellipsis would be wrong on the title, so the ellipsis convention does not apply to this key.",
     "viewMetadata.comment": "Verb (imperative). Used on a button that initiates the action: 'View metadata'.",
     "viewPermissions": "View permissions",
     "viewPermissions.comment": "Verb (imperative form). Used as an action label: 'View permissions'. Surface not identified in source scan.",
@@ -1198,7 +1211,8 @@
     "addCwe.comment": "Button label to open the CWE picker dialog. CWE = Common Weakness Enumeration, should not be translated.",
     "addCweReference": "Add CWE reference to threat",
     "addCweReference.comment": "Button label to add the selected CWE weakness to the threat. CWE = Common Weakness Enumeration.",
-    "chooseCwe": "{{cwePicker.title}}",
+    "chooseCwe": "{{cwePicker.title}}...",
+    "chooseCwe.lint-skip": "Trailing ellipsis is intentional per style guide: menu-item/tooltip/button that opens a dialog.",
     "chooseCwe.comment": "Tooltip for the action button that opens the CWE picker dialog. CWE = Common Weakness Enumeration.",
     "extendedDescription": "Extended description",
     "extendedDescription.comment": "Label for the extended description field shown when a CWE weakness is selected.",
@@ -1880,10 +1894,14 @@
     "filterStatusLabel": "{{projects.statusFilterLabel}}",
     "filterTeamLabel": "{{projects.teamFilterLabel}}",
     "kebab": {
-      "delete": "{{common.delete}}",
-      "metadata": "{{common.metadata}}",
-      "relatedProjects": "{{projects.relatedProjectsDialog.title}}",
-      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}"
+      "delete": "{{common.delete}}...",
+      "delete.lint-skip": "Trailing ellipsis is intentional per style guide: menu-item/tooltip/button that opens a dialog.",
+      "metadata": "{{common.metadata}}...",
+      "metadata.lint-skip": "Trailing ellipsis is intentional per style guide: menu-item/tooltip/button that opens a dialog.",
+      "relatedProjects": "{{projects.relatedProjectsDialog.title}}...",
+      "relatedProjects.lint-skip": "Trailing ellipsis is intentional per style guide: menu-item/tooltip/button that opens a dialog.",
+      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}...",
+      "responsibleParties.lint-skip": "Trailing ellipsis is intentional per style guide: menu-item/tooltip/button that opens a dialog."
     },
     "listTitle": "{{admin.sections.projects.title}}",
     "noProjects": "No projects found.",
@@ -2199,12 +2217,16 @@
     "filterLabel": "Filter teams",
     "filterLabel.comment": "Noun. Labels a form field or UI section: 'Filter teams'.",
     "kebab": {
-      "delete": "{{common.delete}}",
+      "delete": "{{common.delete}}...",
+      "delete.lint-skip": "Trailing ellipsis is intentional per style guide: menu-item/tooltip/button that opens a dialog.",
       "members": "Members...",
       "members.lint-skip": "Trailing ... is intentional per style guide: button/tooltip that opens a dialog",
-      "metadata": "{{common.metadata}}",
-      "relatedTeams": "{{teams.relatedTeamsDialog.title}}",
-      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}"
+      "metadata": "{{common.metadata}}...",
+      "metadata.lint-skip": "Trailing ellipsis is intentional per style guide: menu-item/tooltip/button that opens a dialog.",
+      "relatedTeams": "{{teams.relatedTeamsDialog.title}}...",
+      "relatedTeams.lint-skip": "Trailing ellipsis is intentional per style guide: menu-item/tooltip/button that opens a dialog.",
+      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}...",
+      "responsibleParties.lint-skip": "Trailing ellipsis is intentional per style guide: menu-item/tooltip/button that opens a dialog."
     },
     "listTitle": "{{admin.sections.teams.title}}",
     "membersDialog": {
@@ -2519,7 +2541,8 @@
       "addDocument": "Add document...",
       "addDocument.comment": "Action description on a tooltip (typically for an icon button): 'Add document'.",
       "addDocument.lint-skip": "Trailing ... is intentional per style guide: button/tooltip that opens a dialog",
-      "addNote": "{{triage.detail.addNote}}",
+      "addNote": "{{triage.detail.addNote}}...",
+      "addNote.lint-skip": "Trailing ellipsis is intentional per style guide: menu-item/tooltip/button that opens a dialog.",
       "assetsCardTitle": "Assets are valuable resources within the system that require protection, such as data, hardware, software, infrastructure, services, or personnel",
       "diagramsCardTitle": "Diagrams in TMI are machine-readable representations of data movement and processes within a system, enabling both manual and automated security analysis",
       "documentsCardTitle": "Document references are links to documents stored outside TMI. Relevant documents describe the system to be analyzed, and can be used by both security analysts and automated analysis processes",

--- a/src/assets/i18n/es-ES.json
+++ b/src/assets/i18n/es-ES.json
@@ -47,7 +47,7 @@
   },
   "admin": {
     "addons": {
-      "addButton": "{{admin.addons.addDialog.title}}",
+      "addButton": "{{admin.addons.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "¿Qué hace este complemento?",
@@ -183,7 +183,7 @@
       "title": "{{admin.createAutomationUserDialog.save}}"
     },
     "groups": {
-      "addButton": "{{admin.groups.addDialog.title}}",
+      "addButton": "{{admin.groups.addDialog.title}}...",
       "addDialog": {
         "description": "Descripción (opcional)",
         "descriptionHint": "Descripción opcional del propósito del grupo",
@@ -302,7 +302,7 @@
       }
     },
     "settings": {
-      "addButton": "{{admin.settings.addDialog.title}}",
+      "addButton": "{{admin.settings.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "Descripción opcional de esta configuración",
@@ -360,7 +360,7 @@
         "threatModels": "TMs",
         "user": "{{common.subjectTypes.user}}"
       },
-      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}",
+      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}...",
       "deleteTooltip": "Eliminar cuenta de usuario",
       "filter": {
         "automationOnly": "Mostrar solo cuentas de automatización."
@@ -388,7 +388,7 @@
       }
     },
     "webhooks": {
-      "addButton": "{{admin.webhooks.addDialog.title}}",
+      "addButton": "{{admin.webhooks.addDialog.title}}...",
       "addDialog": {
         "createAutomationUser": "Crear usuario de automatización para este webhook.",
         "events": "Tipos de evento a suscribir",
@@ -870,7 +870,6 @@
     "openInNewTab": "Abrir en nueva pestaña",
     "other": "Otro",
     "paste": "Pegar",
-    "permissions": "Permisos",
     "priority": "Prioridad",
     "project": "Proyecto",
     "provider": "Proveedor",
@@ -925,7 +924,8 @@
     "view": "Ver",
     "viewMetadata": "Ver metadatos",
     "viewPermissions": "Ver permisos",
-    "viewThreat": "Ver amenaza"
+    "viewThreat": "Ver amenaza",
+    "permissions": "Permisos..."
   },
   "contextMenu": {
     "addInverseConnection": "Agregar conexión inversa",
@@ -1008,7 +1008,7 @@
   "cwePicker": {
     "addCwe": "Agregar CWE",
     "addCweReference": "Agregar referencia CWE a la amenaza",
-    "chooseCwe": "{{cwePicker.title}}",
+    "chooseCwe": "{{cwePicker.title}}...",
     "extendedDescription": "Descripción extendida",
     "loading": "Cargando debilidades...",
     "matchingWeaknesses": "Debilidades coincidentes",
@@ -1613,10 +1613,10 @@
     "filterStatusLabel": "{{projects.statusFilterLabel}}",
     "filterTeamLabel": "{{projects.teamFilterLabel}}",
     "kebab": {
-      "delete": "{{common.delete}}",
-      "metadata": "{{common.metadata}}",
-      "relatedProjects": "{{projects.relatedProjectsDialog.title}}",
-      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}"
+      "delete": "{{common.delete}}...",
+      "metadata": "{{common.metadata}}...",
+      "relatedProjects": "{{projects.relatedProjectsDialog.title}}...",
+      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.projects.title}}",
     "noProjects": "No se encontraron proyectos.",
@@ -1852,11 +1852,11 @@
     },
     "filterLabel": "Filtrar equipos",
     "kebab": {
-      "delete": "{{common.delete}}",
+      "delete": "{{common.delete}}...",
       "members": "Miembros...",
-      "metadata": "{{common.metadata}}",
-      "relatedTeams": "{{teams.relatedTeamsDialog.title}}",
-      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}"
+      "metadata": "{{common.metadata}}...",
+      "relatedTeams": "{{teams.relatedTeamsDialog.title}}...",
+      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.teams.title}}",
     "membersDialog": {
@@ -1945,14 +1945,14 @@
     "selectDiagramFirst": "Seleccione primero un diagrama",
     "threatPriority": {
       "0": "Immediate (P0)",
-      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
       "1": "High (P1)",
-      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
       "2": "Medium (P2)",
-      "2.description": "Address within standard development cycles; moderate exposure.",
       "3": "Low (P3)",
-      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4": "Deferred (P4)",
+      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
+      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
+      "2.description": "Address within standard development cycles; moderate exposure.",
+      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4.description": "Postponed with documented business approval; tracked but not scheduled.",
       "deferred": "Diferido (P4)",
       "deferred.description": "Pospuesto con aprobación empresarial documentada; en seguimiento pero sin programar.",
@@ -1966,11 +1966,11 @@
       "medium.description": "Abordar dentro de los ciclos de desarrollo estándar; exposición moderada."
     },
     "threatSeverity": {
+      "4": "Informational",
       "0.description": "Exploitable vulnerability enables complete system compromise, data breach, or safety impact; requires immediate action.",
       "1.description": "Significant impact or high likelihood; enables major unauthorized access, privilege escalation, or service disruption.",
       "2.description": "Moderate impact or likelihood; limited data exposure, partial functionality impairment, or requires chained exploits.",
       "3.description": "Minimal impact or low likelihood; negligible business impact, requires specific conditions or user interaction.",
-      "4": "Informational",
       "4.description": "No direct exploitability; recommendation, best practice deviation, or configuration improvement.",
       "5.description": "Threat severity has not yet been assessed.",
       "critical": "Crítica",
@@ -1988,24 +1988,24 @@
     },
     "threatStatus": {
       "0": "Open",
-      "0.description": "The finding has been identified and documented but no action has been initiated.",
       "1": "Confirmed",
-      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
       "2": "Mitigation Planned",
-      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
       "3": "Mitigation In Progress",
-      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
       "4": "Verification Pending",
-      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
       "5": "Resolved",
-      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
       "6": "Accepted",
-      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
       "7": "False Positive",
-      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
       "8": "Deferred",
-      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9": "Closed",
+      "0.description": "The finding has been identified and documented but no action has been initiated.",
+      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
+      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
+      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
+      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
+      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
+      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
+      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
+      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9.description": "The finding is archived after resolution, acceptance, or invalidation, with audit trail.",
       "accepted": "Aceptado",
       "accepted.description": "La amenaza es reconocida pero intencionalmente no mitigada (p. ej., por justificación empresarial); requiere aceptación formal del riesgo.",
@@ -2127,24 +2127,24 @@
     "sourcesCount": "Repositorios",
     "status": {
       "0": "Not Started",
-      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
       "1": "In Progress",
-      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
       "2": "Pending Review",
-      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
       "3": "Remediation Required",
-      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
       "4": "Remediation In Progress",
-      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
       "5": "Verification Pending",
-      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
       "6": "Approved",
-      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
       "7": "Rejected",
-      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
       "8": "Deferred",
-      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9": "Closed",
+      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
+      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
+      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
+      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
+      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
+      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
+      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
+      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
+      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9.tooltip": "The review is fully completed and archived, with no further action needed.",
       "active": "Activo",
       "active.tooltip": "El modelo de amenazas está siendo trabajado activamente.",
@@ -2177,7 +2177,7 @@
       "addAsset": "Agregar activo...",
       "addDiagram": "Agregar diagrama...",
       "addDocument": "Agregar documento...",
-      "addNote": "{{triage.detail.addNote}}",
+      "addNote": "{{triage.detail.addNote}}...",
       "assetsCardTitle": "Los activos son recursos valiosos dentro del sistema que requieren protección, como datos, hardware, software, infraestructura, servicios o personal",
       "diagramsCardTitle": "Los diagramas en TMI son representaciones legibles por máquina del movimiento de datos y procesos dentro de un sistema, permitiendo análisis de seguridad tanto manual como automatizado",
       "documentsCardTitle": "Las referencias de documentos son enlaces a documentos almacenados fuera de TMI. Los documentos relevantes describen el sistema a analizar y pueden ser utilizados tanto por analistas de seguridad como por procesos de análisis automatizados",

--- a/src/assets/i18n/fr-FR.json
+++ b/src/assets/i18n/fr-FR.json
@@ -47,7 +47,7 @@
   },
   "admin": {
     "addons": {
-      "addButton": "{{admin.addons.addDialog.title}}",
+      "addButton": "{{admin.addons.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "Que fait cet addon ?",
@@ -183,7 +183,7 @@
       "title": "{{admin.createAutomationUserDialog.save}}"
     },
     "groups": {
-      "addButton": "{{admin.groups.addDialog.title}}",
+      "addButton": "{{admin.groups.addDialog.title}}...",
       "addDialog": {
         "description": "Description (optionnelle)",
         "descriptionHint": "Description optionnelle de l'objectif du groupe",
@@ -302,7 +302,7 @@
       }
     },
     "settings": {
-      "addButton": "{{admin.settings.addDialog.title}}",
+      "addButton": "{{admin.settings.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "Description optionnelle de ce paramètre",
@@ -360,7 +360,7 @@
         "threatModels": "TMs",
         "user": "{{common.subjectTypes.user}}"
       },
-      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}",
+      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}...",
       "deleteTooltip": "Supprimer le compte utilisateur",
       "filter": {
         "automationOnly": "Afficher uniquement les comptes d'automatisation."
@@ -388,7 +388,7 @@
       }
     },
     "webhooks": {
-      "addButton": "{{admin.webhooks.addDialog.title}}",
+      "addButton": "{{admin.webhooks.addDialog.title}}...",
       "addDialog": {
         "createAutomationUser": "Créer un utilisateur d'automatisation pour ce webhook.",
         "events": "Types d'événements auxquels s'abonner",
@@ -870,7 +870,6 @@
     "openInNewTab": "Ouvrir dans un nouvel onglet",
     "other": "Autre",
     "paste": "Coller",
-    "permissions": "Permissions",
     "priority": "Priorite",
     "project": "Projet",
     "provider": "Fournisseur",
@@ -925,7 +924,8 @@
     "view": "Voir",
     "viewMetadata": "Afficher les métadonnées",
     "viewPermissions": "Afficher les autorisations",
-    "viewThreat": "Afficher la menace"
+    "viewThreat": "Afficher la menace",
+    "permissions": "Permissions..."
   },
   "contextMenu": {
     "addInverseConnection": "Ajouter une connexion inverse",
@@ -1008,7 +1008,7 @@
   "cwePicker": {
     "addCwe": "Ajouter un CWE",
     "addCweReference": "Ajouter une référence CWE à la menace",
-    "chooseCwe": "{{cwePicker.title}}",
+    "chooseCwe": "{{cwePicker.title}}...",
     "extendedDescription": "Description étendue",
     "loading": "Chargement des faiblesses...",
     "matchingWeaknesses": "Faiblesses correspondantes",
@@ -1613,10 +1613,10 @@
     "filterStatusLabel": "{{projects.statusFilterLabel}}",
     "filterTeamLabel": "{{projects.teamFilterLabel}}",
     "kebab": {
-      "delete": "{{common.delete}}",
-      "metadata": "{{common.metadata}}",
-      "relatedProjects": "{{projects.relatedProjectsDialog.title}}",
-      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}"
+      "delete": "{{common.delete}}...",
+      "metadata": "{{common.metadata}}...",
+      "relatedProjects": "{{projects.relatedProjectsDialog.title}}...",
+      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.projects.title}}",
     "noProjects": "Aucun projet trouvé.",
@@ -1852,11 +1852,11 @@
     },
     "filterLabel": "Filtrer les équipes",
     "kebab": {
-      "delete": "{{common.delete}}",
+      "delete": "{{common.delete}}...",
       "members": "Membres...",
-      "metadata": "{{common.metadata}}",
-      "relatedTeams": "{{teams.relatedTeamsDialog.title}}",
-      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}"
+      "metadata": "{{common.metadata}}...",
+      "relatedTeams": "{{teams.relatedTeamsDialog.title}}...",
+      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.teams.title}}",
     "membersDialog": {
@@ -1945,14 +1945,14 @@
     "selectDiagramFirst": "Sélectionnez d'abord un diagramme",
     "threatPriority": {
       "0": "Immediate (P0)",
-      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
       "1": "High (P1)",
-      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
       "2": "Medium (P2)",
-      "2.description": "Address within standard development cycles; moderate exposure.",
       "3": "Low (P3)",
-      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4": "Deferred (P4)",
+      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
+      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
+      "2.description": "Address within standard development cycles; moderate exposure.",
+      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4.description": "Postponed with documented business approval; tracked but not scheduled.",
       "deferred": "Différé (p4)",
       "deferred.description": "Reporté avec approbation commerciale documentée ; suivi mais non planifié.",
@@ -1966,11 +1966,11 @@
       "medium.description": "À traiter dans les cycles de développement standard ; exposition modérée."
     },
     "threatSeverity": {
+      "4": "Informational",
       "0.description": "Exploitable vulnerability enables complete system compromise, data breach, or safety impact; requires immediate action.",
       "1.description": "Significant impact or high likelihood; enables major unauthorized access, privilege escalation, or service disruption.",
       "2.description": "Moderate impact or likelihood; limited data exposure, partial functionality impairment, or requires chained exploits.",
       "3.description": "Minimal impact or low likelihood; negligible business impact, requires specific conditions or user interaction.",
-      "4": "Informational",
       "4.description": "No direct exploitability; recommendation, best practice deviation, or configuration improvement.",
       "5.description": "Threat severity has not yet been assessed.",
       "critical": "Critique",
@@ -1988,24 +1988,24 @@
     },
     "threatStatus": {
       "0": "Open",
-      "0.description": "The finding has been identified and documented but no action has been initiated.",
       "1": "Confirmed",
-      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
       "2": "Mitigation Planned",
-      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
       "3": "Mitigation In Progress",
-      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
       "4": "Verification Pending",
-      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
       "5": "Resolved",
-      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
       "6": "Accepted",
-      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
       "7": "False Positive",
-      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
       "8": "Deferred",
-      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9": "Closed",
+      "0.description": "The finding has been identified and documented but no action has been initiated.",
+      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
+      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
+      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
+      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
+      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
+      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
+      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
+      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9.description": "The finding is archived after resolution, acceptance, or invalidation, with audit trail.",
       "accepted": "Accepté",
       "accepted.description": "La menace est reconnue mais intentionnellement non atténuée (par ex., en raison d'une justification commerciale) ; nécessite une acceptation formelle du risque.",
@@ -2127,24 +2127,24 @@
     "sourcesCount": "Depots",
     "status": {
       "0": "Not Started",
-      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
       "1": "In Progress",
-      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
       "2": "Pending Review",
-      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
       "3": "Remediation Required",
-      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
       "4": "Remediation In Progress",
-      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
       "5": "Verification Pending",
-      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
       "6": "Approved",
-      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
       "7": "Rejected",
-      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
       "8": "Deferred",
-      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9": "Closed",
+      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
+      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
+      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
+      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
+      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
+      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
+      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
+      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
+      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9.tooltip": "The review is fully completed and archived, with no further action needed.",
       "active": "Actif",
       "active.tooltip": "Le modèle de menace est en cours de traitement.",
@@ -2177,7 +2177,7 @@
       "addAsset": "Ajouter un actif...",
       "addDiagram": "Ajouter un diagramme...",
       "addDocument": "Ajouter un document...",
-      "addNote": "{{triage.detail.addNote}}",
+      "addNote": "{{triage.detail.addNote}}...",
       "assetsCardTitle": "Les actifs sont des ressources précieuses du système qui nécessitent une protection, telles que les données, le matériel, les logiciels, l'infrastructure, les services ou le personnel",
       "diagramsCardTitle": "Les diagrammes dans TMI sont des représentations lisibles par machine des mouvements de données et des processus au sein d'un système, permettant à la fois une analyse de sécurité manuelle et automatisée",
       "documentsCardTitle": "Les références de documents sont des liens vers des documents stockés en dehors de TMI. Les documents pertinents décrivent le système à analyser et peuvent être utilisés par les analystes de sécurité et les processus d'analyse automatisés",

--- a/src/assets/i18n/he-IL.json
+++ b/src/assets/i18n/he-IL.json
@@ -47,7 +47,7 @@
   },
   "admin": {
     "addons": {
-      "addButton": "{{admin.addons.addDialog.title}}",
+      "addButton": "{{admin.addons.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "מה התוסף הזה עושה?",
@@ -183,7 +183,7 @@
       "title": "{{admin.createAutomationUserDialog.save}}"
     },
     "groups": {
-      "addButton": "{{admin.groups.addDialog.title}}",
+      "addButton": "{{admin.groups.addDialog.title}}...",
       "addDialog": {
         "description": "תיאור (אופציונלי)",
         "descriptionHint": "תיאור אופציונלי של מטרת הקבוצה",
@@ -302,7 +302,7 @@
       }
     },
     "settings": {
-      "addButton": "{{admin.settings.addDialog.title}}",
+      "addButton": "{{admin.settings.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "תיאור אופציונלי של הגדרה זו",
@@ -360,7 +360,7 @@
         "threatModels": "TMs",
         "user": "{{common.subjectTypes.user}}"
       },
-      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}",
+      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}...",
       "deleteTooltip": "מחק חשבון משתמש",
       "filter": {
         "automationOnly": "הצג רק חשבונות אוטומציה."
@@ -388,7 +388,7 @@
       }
     },
     "webhooks": {
-      "addButton": "{{admin.webhooks.addDialog.title}}",
+      "addButton": "{{admin.webhooks.addDialog.title}}...",
       "addDialog": {
         "createAutomationUser": "צור משתמש אוטומציה עבור webhook זה.",
         "events": "סוגי אירועים להרשמה",
@@ -870,7 +870,6 @@
     "openInNewTab": "פתח בכרטיסייה חדשה",
     "other": "אחר",
     "paste": "הדבק",
-    "permissions": "הרשאות",
     "priority": "עדיפות",
     "project": "פרויקט",
     "provider": "ספק",
@@ -925,7 +924,8 @@
     "view": "צפה",
     "viewMetadata": "צפה במטא-נתונים",
     "viewPermissions": "צפה בהרשאות",
-    "viewThreat": "צפה באיום"
+    "viewThreat": "צפה באיום",
+    "permissions": "הרשאות..."
   },
   "contextMenu": {
     "addInverseConnection": "הוסף חיבור הפוך",
@@ -1008,7 +1008,7 @@
   "cwePicker": {
     "addCwe": "הוסף CWE",
     "addCweReference": "הוסף הפניית CWE לאיום",
-    "chooseCwe": "{{cwePicker.title}}",
+    "chooseCwe": "{{cwePicker.title}}...",
     "extendedDescription": "תיאור מורחב",
     "loading": "טוען חולשות...",
     "matchingWeaknesses": "חולשות תואמות",
@@ -1611,10 +1611,10 @@
     "filterStatusLabel": "{{projects.statusFilterLabel}}",
     "filterTeamLabel": "{{projects.teamFilterLabel}}",
     "kebab": {
-      "delete": "{{common.delete}}",
-      "metadata": "{{common.metadata}}",
-      "relatedProjects": "{{projects.relatedProjectsDialog.title}}",
-      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}"
+      "delete": "{{common.delete}}...",
+      "metadata": "{{common.metadata}}...",
+      "relatedProjects": "{{projects.relatedProjectsDialog.title}}...",
+      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.projects.title}}",
     "noProjects": "לא נמצאו פרויקטים.",
@@ -1850,11 +1850,11 @@
     },
     "filterLabel": "סנן צוותות",
     "kebab": {
-      "delete": "{{common.delete}}",
+      "delete": "{{common.delete}}...",
       "members": "חברים...",
-      "metadata": "{{common.metadata}}",
-      "relatedTeams": "{{teams.relatedTeamsDialog.title}}",
-      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}"
+      "metadata": "{{common.metadata}}...",
+      "relatedTeams": "{{teams.relatedTeamsDialog.title}}...",
+      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.teams.title}}",
     "membersDialog": {
@@ -1943,14 +1943,14 @@
     "selectDiagramFirst": "בחר תחילה דיאגרמה",
     "threatPriority": {
       "0": "Immediate (P0)",
-      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
       "1": "High (P1)",
-      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
       "2": "Medium (P2)",
-      "2.description": "Address within standard development cycles; moderate exposure.",
       "3": "Low (P3)",
-      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4": "Deferred (P4)",
+      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
+      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
+      "2.description": "Address within standard development cycles; moderate exposure.",
+      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4.description": "Postponed with documented business approval; tracked but not scheduled.",
       "deferred": "נדחה (p4)",
       "deferred.description": "נדחה עם אישור עסקי מתועד; במעקב אך לא מתוזמן.",
@@ -1964,11 +1964,11 @@
       "medium.description": "טפל במסגרת מחזורי הפיתוח הרגילים; חשיפה מתונה."
     },
     "threatSeverity": {
+      "4": "Informational",
       "0.description": "Exploitable vulnerability enables complete system compromise, data breach, or safety impact; requires immediate action.",
       "1.description": "Significant impact or high likelihood; enables major unauthorized access, privilege escalation, or service disruption.",
       "2.description": "Moderate impact or likelihood; limited data exposure, partial functionality impairment, or requires chained exploits.",
       "3.description": "Minimal impact or low likelihood; negligible business impact, requires specific conditions or user interaction.",
-      "4": "Informational",
       "4.description": "No direct exploitability; recommendation, best practice deviation, or configuration improvement.",
       "5.description": "Threat severity has not yet been assessed.",
       "critical": "קריטי",
@@ -1986,24 +1986,24 @@
     },
     "threatStatus": {
       "0": "Open",
-      "0.description": "The finding has been identified and documented but no action has been initiated.",
       "1": "Confirmed",
-      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
       "2": "Mitigation Planned",
-      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
       "3": "Mitigation In Progress",
-      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
       "4": "Verification Pending",
-      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
       "5": "Resolved",
-      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
       "6": "Accepted",
-      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
       "7": "False Positive",
-      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
       "8": "Deferred",
-      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9": "Closed",
+      "0.description": "The finding has been identified and documented but no action has been initiated.",
+      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
+      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
+      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
+      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
+      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
+      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
+      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
+      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9.description": "The finding is archived after resolution, acceptance, or invalidation, with audit trail.",
       "accepted": "מקובל",
       "accepted.description": "האיום מוכר אך אינו מופחת בכוונה (למשל, עקב הצדקה עסקית); דורש קבלת סיכון רשמית.",
@@ -2125,24 +2125,24 @@
     "sourcesCount": "מאגרים",
     "status": {
       "0": "Not Started",
-      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
       "1": "In Progress",
-      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
       "2": "Pending Review",
-      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
       "3": "Remediation Required",
-      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
       "4": "Remediation In Progress",
-      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
       "5": "Verification Pending",
-      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
       "6": "Approved",
-      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
       "7": "Rejected",
-      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
       "8": "Deferred",
-      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9": "Closed",
+      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
+      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
+      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
+      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
+      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
+      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
+      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
+      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
+      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9.tooltip": "The review is fully completed and archived, with no further action needed.",
       "active": "פעיל",
       "active.tooltip": "מודל האיומים נמצא בעבודה פעילה.",
@@ -2175,7 +2175,7 @@
       "addAsset": "הוסף נכס...",
       "addDiagram": "הוסף דיאגרמה...",
       "addDocument": "הוסף מסמך...",
-      "addNote": "{{triage.detail.addNote}}",
+      "addNote": "{{triage.detail.addNote}}...",
       "assetsCardTitle": "נכסים הם משאבים בעלי ערך במערכת הדורשים הגנה, כגון נתונים, חומרה, תוכנה, תשתיות, שירותים או כוח אדם",
       "diagramsCardTitle": "דיאגרמות ב-TMI הן ייצוגים קריאים-מכונה של תנועת נתונים ותהליכים במערכת, המאפשרים ניתוח אבטחה ידני ואוטומטי",
       "documentsCardTitle": "הפניות מסמכים הן קישורים למסמכים המאוחסנים מחוץ ל-TMI. מסמכים רלוונטיים מתארים את המערכת לניתוח, וניתן להשתמש בהם על ידי אנליסטי אבטחה ותהליכי ניתוח אוטומטיים",

--- a/src/assets/i18n/hi-IN.json
+++ b/src/assets/i18n/hi-IN.json
@@ -47,7 +47,7 @@
   },
   "admin": {
     "addons": {
-      "addButton": "{{admin.addons.addDialog.title}}",
+      "addButton": "{{admin.addons.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "यह ऐडऑन क्या करता है?",
@@ -183,7 +183,7 @@
       "title": "{{admin.createAutomationUserDialog.save}}"
     },
     "groups": {
-      "addButton": "{{admin.groups.addDialog.title}}",
+      "addButton": "{{admin.groups.addDialog.title}}...",
       "addDialog": {
         "description": "विवरण (वैकल्पिक)",
         "descriptionHint": "समूह के उद्देश्य का वैकल्पिक विवरण",
@@ -302,7 +302,7 @@
       }
     },
     "settings": {
-      "addButton": "{{admin.settings.addDialog.title}}",
+      "addButton": "{{admin.settings.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "इस सेटिंग का वैकल्पिक विवरण",
@@ -360,7 +360,7 @@
         "threatModels": "TMs",
         "user": "{{common.subjectTypes.user}}"
       },
-      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}",
+      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}...",
       "deleteTooltip": "उपयोगकर्ता खाता हटाएं",
       "filter": {
         "automationOnly": "केवल ऑटोमेशन खाते दिखाएं।"
@@ -388,7 +388,7 @@
       }
     },
     "webhooks": {
-      "addButton": "{{admin.webhooks.addDialog.title}}",
+      "addButton": "{{admin.webhooks.addDialog.title}}...",
       "addDialog": {
         "createAutomationUser": "इस webhook के लिए ऑटोमेशन उपयोगकर्ता बनाएं।",
         "events": "सदस्यता लेने के लिए इवेंट प्रकार",
@@ -870,7 +870,6 @@
     "openInNewTab": "नए टैब में खोलें",
     "other": "अन्य",
     "paste": "पेस्ट करें",
-    "permissions": "अनुमतियां",
     "priority": "प्राथमिकता",
     "project": "प्रोजेक्ट",
     "provider": "प्रदाता",
@@ -925,7 +924,8 @@
     "view": "देखें",
     "viewMetadata": "मेटाडेटा देखें",
     "viewPermissions": "अनुमतियाँ देखें",
-    "viewThreat": "खतरा देखें"
+    "viewThreat": "खतरा देखें",
+    "permissions": "अनुमतियां..."
   },
   "contextMenu": {
     "addInverseConnection": "व्युत्क्रम कनेक्शन जोड़ें",
@@ -1008,7 +1008,7 @@
   "cwePicker": {
     "addCwe": "CWE जोड़ें",
     "addCweReference": "खतरे में CWE संदर्भ जोड़ें",
-    "chooseCwe": "{{cwePicker.title}}",
+    "chooseCwe": "{{cwePicker.title}}...",
     "extendedDescription": "विस्तारित विवरण",
     "loading": "कमज़ोरियाँ लोड हो रही हैं...",
     "matchingWeaknesses": "मिलान करने वाली कमज़ोरियाँ",
@@ -1615,10 +1615,10 @@
     "filterStatusLabel": "{{projects.statusFilterLabel}}",
     "filterTeamLabel": "{{projects.teamFilterLabel}}",
     "kebab": {
-      "delete": "{{common.delete}}",
-      "metadata": "{{common.metadata}}",
-      "relatedProjects": "{{projects.relatedProjectsDialog.title}}",
-      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}"
+      "delete": "{{common.delete}}...",
+      "metadata": "{{common.metadata}}...",
+      "relatedProjects": "{{projects.relatedProjectsDialog.title}}...",
+      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.projects.title}}",
     "noProjects": "कोई प्रोजेक्ट नहीं मिला",
@@ -1854,11 +1854,11 @@
     },
     "filterLabel": "टीमें फ़िल्टर करें",
     "kebab": {
-      "delete": "{{common.delete}}",
+      "delete": "{{common.delete}}...",
       "members": "सदस्य...",
-      "metadata": "{{common.metadata}}",
-      "relatedTeams": "{{teams.relatedTeamsDialog.title}}",
-      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}"
+      "metadata": "{{common.metadata}}...",
+      "relatedTeams": "{{teams.relatedTeamsDialog.title}}...",
+      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.teams.title}}",
     "membersDialog": {
@@ -1947,14 +1947,14 @@
     "selectDiagramFirst": "पहले एक आरेख चुनें",
     "threatPriority": {
       "0": "Immediate (P0)",
-      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
       "1": "High (P1)",
-      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
       "2": "Medium (P2)",
-      "2.description": "Address within standard development cycles; moderate exposure.",
       "3": "Low (P3)",
-      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4": "Deferred (P4)",
+      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
+      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
+      "2.description": "Address within standard development cycles; moderate exposure.",
+      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4.description": "Postponed with documented business approval; tracked but not scheduled.",
       "deferred": "स्थगित (p4)",
       "deferred.description": "प्रलेखित व्यावसायिक अनुमोदन के साथ स्थगित; ट्रैक किया गया लेकिन अनुसूचित नहीं।",
@@ -1968,11 +1968,11 @@
       "medium.description": "मानक विकास चक्रों के भीतर समाधान करें; मध्यम जोखिम।"
     },
     "threatSeverity": {
+      "4": "Informational",
       "0.description": "Exploitable vulnerability enables complete system compromise, data breach, or safety impact; requires immediate action.",
       "1.description": "Significant impact or high likelihood; enables major unauthorized access, privilege escalation, or service disruption.",
       "2.description": "Moderate impact or likelihood; limited data exposure, partial functionality impairment, or requires chained exploits.",
       "3.description": "Minimal impact or low likelihood; negligible business impact, requires specific conditions or user interaction.",
-      "4": "Informational",
       "4.description": "No direct exploitability; recommendation, best practice deviation, or configuration improvement.",
       "5.description": "Threat severity has not yet been assessed.",
       "critical": "गंभीर",
@@ -1990,24 +1990,24 @@
     },
     "threatStatus": {
       "0": "Open",
-      "0.description": "The finding has been identified and documented but no action has been initiated.",
       "1": "Confirmed",
-      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
       "2": "Mitigation Planned",
-      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
       "3": "Mitigation In Progress",
-      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
       "4": "Verification Pending",
-      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
       "5": "Resolved",
-      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
       "6": "Accepted",
-      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
       "7": "False Positive",
-      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
       "8": "Deferred",
-      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9": "Closed",
+      "0.description": "The finding has been identified and documented but no action has been initiated.",
+      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
+      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
+      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
+      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
+      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
+      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
+      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
+      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9.description": "The finding is archived after resolution, acceptance, or invalidation, with audit trail.",
       "accepted": "स्वीकृत",
       "accepted.description": "खतरे को स्वीकार किया गया है लेकिन जानबूझकर शमन नहीं किया गया है (जैसे, व्यावसायिक औचित्य के कारण); औपचारिक जोखिम स्वीकृति की आवश्यकता है।",
@@ -2129,24 +2129,24 @@
     "sourcesCount": "रिपोज़",
     "status": {
       "0": "Not Started",
-      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
       "1": "In Progress",
-      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
       "2": "Pending Review",
-      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
       "3": "Remediation Required",
-      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
       "4": "Remediation In Progress",
-      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
       "5": "Verification Pending",
-      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
       "6": "Approved",
-      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
       "7": "Rejected",
-      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
       "8": "Deferred",
-      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9": "Closed",
+      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
+      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
+      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
+      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
+      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
+      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
+      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
+      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
+      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9.tooltip": "The review is fully completed and archived, with no further action needed.",
       "active": "सक्रिय",
       "active.tooltip": "थ्रेट मॉडल पर सक्रिय रूप से काम किया जा रहा है।",
@@ -2179,7 +2179,7 @@
       "addAsset": "संपत्ति जोड़ें...",
       "addDiagram": "आरेख जोड़ें...",
       "addDocument": "दस्तावेज़ जोड़ें...",
-      "addNote": "{{triage.detail.addNote}}",
+      "addNote": "{{triage.detail.addNote}}...",
       "assetsCardTitle": "संपत्तियाँ सिस्टम के भीतर मूल्यवान संसाधन हैं जिन्हें सुरक्षा की आवश्यकता है, जैसे डेटा, हार्डवेयर, सॉफ़्टवेयर, इन्फ्रास्ट्रक्चर, सेवाएं, या कर्मी",
       "diagramsCardTitle": "TMI में आरेख किसी सिस्टम के भीतर डेटा आंदोलन और प्रक्रियाओं के मशीन-पठनीय प्रतिनिधित्व हैं, जो मैनुअल और स्वचालित दोनों सुरक्षा विश्लेषण को सक्षम करते हैं",
       "documentsCardTitle": "दस्तावेज़ संदर्भ TMI के बाहर संग्रहीत दस्तावेज़ों के लिंक हैं। प्रासंगिक दस्तावेज़ विश्लेषण किए जाने वाले सिस्टम का वर्णन करते हैं और सुरक्षा विश्लेषकों और स्वचालित विश्लेषण प्रक्रियाओं दोनों द्वारा उपयोग किए जा सकते हैं",

--- a/src/assets/i18n/id-ID.json
+++ b/src/assets/i18n/id-ID.json
@@ -47,7 +47,7 @@
   },
   "admin": {
     "addons": {
-      "addButton": "{{admin.addons.addDialog.title}}",
+      "addButton": "{{admin.addons.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "Apa fungsi addon ini?",
@@ -183,7 +183,7 @@
       "title": "{{admin.createAutomationUserDialog.save}}"
     },
     "groups": {
-      "addButton": "{{admin.groups.addDialog.title}}",
+      "addButton": "{{admin.groups.addDialog.title}}...",
       "addDialog": {
         "description": "Deskripsi (Opsional)",
         "descriptionHint": "Deskripsi opsional tentang tujuan grup",
@@ -302,7 +302,7 @@
       }
     },
     "settings": {
-      "addButton": "{{admin.settings.addDialog.title}}",
+      "addButton": "{{admin.settings.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "Deskripsi opsional dari pengaturan ini",
@@ -360,7 +360,7 @@
         "threatModels": "TMs",
         "user": "{{common.subjectTypes.user}}"
       },
-      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}",
+      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}...",
       "deleteTooltip": "Hapus akun pengguna",
       "filter": {
         "automationOnly": "Tampilkan hanya akun otomasi."
@@ -388,7 +388,7 @@
       }
     },
     "webhooks": {
-      "addButton": "{{admin.webhooks.addDialog.title}}",
+      "addButton": "{{admin.webhooks.addDialog.title}}...",
       "addDialog": {
         "createAutomationUser": "Buat pengguna otomasi untuk webhook ini.",
         "events": "Jenis peristiwa untuk berlangganan",
@@ -870,7 +870,6 @@
     "openInNewTab": "Buka di Tab Baru",
     "other": "Lainnya",
     "paste": "Tempel",
-    "permissions": "Izin",
     "priority": "Prioritas",
     "project": "Proyek",
     "provider": "Penyedia",
@@ -925,7 +924,8 @@
     "view": "Lihat",
     "viewMetadata": "Lihat Metadata",
     "viewPermissions": "Lihat Izin",
-    "viewThreat": "Lihat Ancaman"
+    "viewThreat": "Lihat Ancaman",
+    "permissions": "Izin..."
   },
   "contextMenu": {
     "addInverseConnection": "Tambah Koneksi Terbalik",
@@ -1008,7 +1008,7 @@
   "cwePicker": {
     "addCwe": "Tambah CWE",
     "addCweReference": "Tambahkan Referensi CWE ke Ancaman",
-    "chooseCwe": "{{cwePicker.title}}",
+    "chooseCwe": "{{cwePicker.title}}...",
     "extendedDescription": "Deskripsi Lengkap",
     "loading": "Memuat kelemahan...",
     "matchingWeaknesses": "Kelemahan yang Cocok",
@@ -1613,10 +1613,10 @@
     "filterStatusLabel": "{{projects.statusFilterLabel}}",
     "filterTeamLabel": "{{projects.teamFilterLabel}}",
     "kebab": {
-      "delete": "{{common.delete}}",
-      "metadata": "{{common.metadata}}",
-      "relatedProjects": "{{projects.relatedProjectsDialog.title}}",
-      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}"
+      "delete": "{{common.delete}}...",
+      "metadata": "{{common.metadata}}...",
+      "relatedProjects": "{{projects.relatedProjectsDialog.title}}...",
+      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.projects.title}}",
     "noProjects": "Tidak ada proyek yang ditemukan.",
@@ -1852,11 +1852,11 @@
     },
     "filterLabel": "Filter Tim",
     "kebab": {
-      "delete": "{{common.delete}}",
+      "delete": "{{common.delete}}...",
       "members": "Anggota...",
-      "metadata": "{{common.metadata}}",
-      "relatedTeams": "{{teams.relatedTeamsDialog.title}}",
-      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}"
+      "metadata": "{{common.metadata}}...",
+      "relatedTeams": "{{teams.relatedTeamsDialog.title}}...",
+      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.teams.title}}",
     "membersDialog": {
@@ -1945,14 +1945,14 @@
     "selectDiagramFirst": "Pilih diagram terlebih dahulu",
     "threatPriority": {
       "0": "Immediate (P0)",
-      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
       "1": "High (P1)",
-      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
       "2": "Medium (P2)",
-      "2.description": "Address within standard development cycles; moderate exposure.",
       "3": "Low (P3)",
-      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4": "Deferred (P4)",
+      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
+      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
+      "2.description": "Address within standard development cycles; moderate exposure.",
+      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4.description": "Postponed with documented business approval; tracked but not scheduled.",
       "deferred": "Ditunda (P4)",
       "deferred.description": "Ditunda dengan persetujuan bisnis yang terdokumentasi; dilacak tetapi tidak dijadwalkan.",
@@ -1966,11 +1966,11 @@
       "medium.description": "Tangani dalam siklus pengembangan standar; paparan sedang."
     },
     "threatSeverity": {
+      "4": "Informational",
       "0.description": "Exploitable vulnerability enables complete system compromise, data breach, or safety impact; requires immediate action.",
       "1.description": "Significant impact or high likelihood; enables major unauthorized access, privilege escalation, or service disruption.",
       "2.description": "Moderate impact or likelihood; limited data exposure, partial functionality impairment, or requires chained exploits.",
       "3.description": "Minimal impact or low likelihood; negligible business impact, requires specific conditions or user interaction.",
-      "4": "Informational",
       "4.description": "No direct exploitability; recommendation, best practice deviation, or configuration improvement.",
       "5.description": "Threat severity has not yet been assessed.",
       "critical": "Kritis",
@@ -1988,24 +1988,24 @@
     },
     "threatStatus": {
       "0": "Open",
-      "0.description": "The finding has been identified and documented but no action has been initiated.",
       "1": "Confirmed",
-      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
       "2": "Mitigation Planned",
-      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
       "3": "Mitigation In Progress",
-      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
       "4": "Verification Pending",
-      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
       "5": "Resolved",
-      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
       "6": "Accepted",
-      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
       "7": "False Positive",
-      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
       "8": "Deferred",
-      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9": "Closed",
+      "0.description": "The finding has been identified and documented but no action has been initiated.",
+      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
+      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
+      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
+      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
+      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
+      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
+      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
+      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9.description": "The finding is archived after resolution, acceptance, or invalidation, with audit trail.",
       "accepted": "Diterima",
       "accepted.description": "Ancaman diakui tetapi sengaja tidak dimitigasi (mis., karena justifikasi bisnis); memerlukan penerimaan risiko formal.",
@@ -2127,24 +2127,24 @@
     "sourcesCount": "Repo",
     "status": {
       "0": "Not Started",
-      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
       "1": "In Progress",
-      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
       "2": "Pending Review",
-      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
       "3": "Remediation Required",
-      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
       "4": "Remediation In Progress",
-      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
       "5": "Verification Pending",
-      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
       "6": "Approved",
-      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
       "7": "Rejected",
-      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
       "8": "Deferred",
-      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9": "Closed",
+      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
+      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
+      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
+      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
+      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
+      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
+      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
+      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
+      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9.tooltip": "The review is fully completed and archived, with no further action needed.",
       "active": "Aktif",
       "active.tooltip": "Model ancaman sedang aktif dikerjakan.",
@@ -2177,7 +2177,7 @@
       "addAsset": "Tambah Aset...",
       "addDiagram": "Tambah Diagram...",
       "addDocument": "Tambah Dokumen...",
-      "addNote": "{{triage.detail.addNote}}",
+      "addNote": "{{triage.detail.addNote}}...",
       "assetsCardTitle": "Aset adalah sumber daya berharga dalam sistem yang memerlukan perlindungan, seperti data, perangkat keras, perangkat lunak, infrastruktur, layanan, atau personel",
       "diagramsCardTitle": "Diagram di TMI adalah representasi yang dapat dibaca mesin dari pergerakan data dan proses dalam sistem, memungkinkan analisis keamanan manual dan otomatis",
       "documentsCardTitle": "Referensi dokumen adalah tautan ke dokumen yang disimpan di luar TMI. Dokumen yang relevan menjelaskan sistem yang akan dianalisis, dan dapat digunakan oleh analis keamanan dan proses analisis otomatis",

--- a/src/assets/i18n/ja-JP.json
+++ b/src/assets/i18n/ja-JP.json
@@ -47,7 +47,7 @@
   },
   "admin": {
     "addons": {
-      "addButton": "{{admin.addons.addDialog.title}}",
+      "addButton": "{{admin.addons.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "このアドオンは何をしますか？",
@@ -183,7 +183,7 @@
       "title": "{{admin.createAutomationUserDialog.save}}"
     },
     "groups": {
-      "addButton": "{{admin.groups.addDialog.title}}",
+      "addButton": "{{admin.groups.addDialog.title}}...",
       "addDialog": {
         "description": "説明（任意）",
         "descriptionHint": "グループの目的の説明（任意）",
@@ -302,7 +302,7 @@
       }
     },
     "settings": {
-      "addButton": "{{admin.settings.addDialog.title}}",
+      "addButton": "{{admin.settings.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "この設定の説明（任意）",
@@ -360,7 +360,7 @@
         "threatModels": "TMs",
         "user": "{{common.subjectTypes.user}}"
       },
-      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}",
+      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}...",
       "deleteTooltip": "ユーザーアカウントを削除",
       "filter": {
         "automationOnly": "自動化アカウントのみ表示する。"
@@ -388,7 +388,7 @@
       }
     },
     "webhooks": {
-      "addButton": "{{admin.webhooks.addDialog.title}}",
+      "addButton": "{{admin.webhooks.addDialog.title}}...",
       "addDialog": {
         "createAutomationUser": "このWebhook用の自動化ユーザーを作成する。",
         "events": "サブスクライブするイベントタイプ",
@@ -870,7 +870,6 @@
     "openInNewTab": "新しいタブで開く",
     "other": "その他",
     "paste": "貼り付け",
-    "permissions": "権限",
     "priority": "優先度",
     "project": "プロジェクト",
     "provider": "プロバイダー",
@@ -925,7 +924,8 @@
     "view": "表示",
     "viewMetadata": "メタデータを表示",
     "viewPermissions": "権限を表示",
-    "viewThreat": "脅威を表示"
+    "viewThreat": "脅威を表示",
+    "permissions": "権限..."
   },
   "contextMenu": {
     "addInverseConnection": "逆接続を追加",
@@ -1008,7 +1008,7 @@
   "cwePicker": {
     "addCwe": "CWEを追加",
     "addCweReference": "CWE参照を脅威に追加",
-    "chooseCwe": "{{cwePicker.title}}",
+    "chooseCwe": "{{cwePicker.title}}...",
     "extendedDescription": "拡張説明",
     "loading": "脆弱性を読み込み中...",
     "matchingWeaknesses": "一致する脆弱性",
@@ -1615,10 +1615,10 @@
     "filterStatusLabel": "{{projects.statusFilterLabel}}",
     "filterTeamLabel": "{{projects.teamFilterLabel}}",
     "kebab": {
-      "delete": "{{common.delete}}",
-      "metadata": "{{common.metadata}}",
-      "relatedProjects": "{{projects.relatedProjectsDialog.title}}",
-      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}"
+      "delete": "{{common.delete}}...",
+      "metadata": "{{common.metadata}}...",
+      "relatedProjects": "{{projects.relatedProjectsDialog.title}}...",
+      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.projects.title}}",
     "noProjects": "プロジェクトが見つかりません。",
@@ -1854,11 +1854,11 @@
     },
     "filterLabel": "チームを絞り込む",
     "kebab": {
-      "delete": "{{common.delete}}",
+      "delete": "{{common.delete}}...",
       "members": "メンバー...",
-      "metadata": "{{common.metadata}}",
-      "relatedTeams": "{{teams.relatedTeamsDialog.title}}",
-      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}"
+      "metadata": "{{common.metadata}}...",
+      "relatedTeams": "{{teams.relatedTeamsDialog.title}}...",
+      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.teams.title}}",
     "membersDialog": {
@@ -1947,14 +1947,14 @@
     "selectDiagramFirst": "最初にダイアグラムを選択してください",
     "threatPriority": {
       "0": "Immediate (P0)",
-      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
       "1": "High (P1)",
-      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
       "2": "Medium (P2)",
-      "2.description": "Address within standard development cycles; moderate exposure.",
       "3": "Low (P3)",
-      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4": "Deferred (P4)",
+      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
+      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
+      "2.description": "Address within standard development cycles; moderate exposure.",
+      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4.description": "Postponed with documented business approval; tracked but not scheduled.",
       "deferred": "延期済み（p4）",
       "deferred.description": "文書化されたビジネス承認のもと延期済み。追跡されているがスケジュールは未定。",
@@ -1968,11 +1968,11 @@
       "medium.description": "標準的な開発サイクル内で対処する。中程度のリスク露出。"
     },
     "threatSeverity": {
+      "4": "Informational",
       "0.description": "Exploitable vulnerability enables complete system compromise, data breach, or safety impact; requires immediate action.",
       "1.description": "Significant impact or high likelihood; enables major unauthorized access, privilege escalation, or service disruption.",
       "2.description": "Moderate impact or likelihood; limited data exposure, partial functionality impairment, or requires chained exploits.",
       "3.description": "Minimal impact or low likelihood; negligible business impact, requires specific conditions or user interaction.",
-      "4": "Informational",
       "4.description": "No direct exploitability; recommendation, best practice deviation, or configuration improvement.",
       "5.description": "Threat severity has not yet been assessed.",
       "critical": "クリティカル",
@@ -1990,24 +1990,24 @@
     },
     "threatStatus": {
       "0": "Open",
-      "0.description": "The finding has been identified and documented but no action has been initiated.",
       "1": "Confirmed",
-      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
       "2": "Mitigation Planned",
-      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
       "3": "Mitigation In Progress",
-      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
       "4": "Verification Pending",
-      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
       "5": "Resolved",
-      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
       "6": "Accepted",
-      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
       "7": "False Positive",
-      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
       "8": "Deferred",
-      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9": "Closed",
+      "0.description": "The finding has been identified and documented but no action has been initiated.",
+      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
+      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
+      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
+      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
+      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
+      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
+      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
+      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9.description": "The finding is archived after resolution, acceptance, or invalidation, with audit trail.",
       "accepted": "受け入れ済み",
       "accepted.description": "脅威は認識されていますが、意図的に緩和されていません（例：ビジネス上の理由による）。正式なリスク受け入れが必要です。",
@@ -2129,24 +2129,24 @@
     "sourcesCount": "リポジトリ",
     "status": {
       "0": "Not Started",
-      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
       "1": "In Progress",
-      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
       "2": "Pending Review",
-      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
       "3": "Remediation Required",
-      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
       "4": "Remediation In Progress",
-      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
       "5": "Verification Pending",
-      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
       "6": "Approved",
-      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
       "7": "Rejected",
-      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
       "8": "Deferred",
-      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9": "Closed",
+      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
+      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
+      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
+      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
+      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
+      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
+      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
+      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
+      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9.tooltip": "The review is fully completed and archived, with no further action needed.",
       "active": "進行中",
       "active.tooltip": "脅威モデルは現在作業中です。",
@@ -2179,7 +2179,7 @@
       "addAsset": "アセットを追加...",
       "addDiagram": "ダイアグラムを追加...",
       "addDocument": "ドキュメントを追加...",
-      "addNote": "{{triage.detail.addNote}}",
+      "addNote": "{{triage.detail.addNote}}...",
       "assetsCardTitle": "アセットとは、データ、ハードウェア、ソフトウェア、インフラ、サービス、人員などの保護が必要なシステム内の重要なリソースです",
       "diagramsCardTitle": "TMIにおけるダイアグラムは、システム内のデータの動きとプロセスを機械可読な形式で表現したものであり、手動および自動のセキュリティ分析を可能にします",
       "documentsCardTitle": "ドキュメント参照はTMI外に保存されたドキュメントへのリンクです。関連ドキュメントは分析対象システムを説明するもので、セキュリティアナリストと自動分析プロセスの両方が使用できます",

--- a/src/assets/i18n/ko-KR.json
+++ b/src/assets/i18n/ko-KR.json
@@ -47,7 +47,7 @@
   },
   "admin": {
     "addons": {
-      "addButton": "{{admin.addons.addDialog.title}}",
+      "addButton": "{{admin.addons.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "이 애드온은 무엇을 하나요?",
@@ -183,7 +183,7 @@
       "title": "{{admin.createAutomationUserDialog.save}}"
     },
     "groups": {
-      "addButton": "{{admin.groups.addDialog.title}}",
+      "addButton": "{{admin.groups.addDialog.title}}...",
       "addDialog": {
         "description": "설명 (선택 사항)",
         "descriptionHint": "그룹 목적에 대한 선택적 설명",
@@ -302,7 +302,7 @@
       }
     },
     "settings": {
-      "addButton": "{{admin.settings.addDialog.title}}",
+      "addButton": "{{admin.settings.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "이 설정에 대한 선택적 설명",
@@ -360,7 +360,7 @@
         "threatModels": "TMs",
         "user": "{{common.subjectTypes.user}}"
       },
-      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}",
+      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}...",
       "deleteTooltip": "사용자 계정 삭제",
       "filter": {
         "automationOnly": "자동화 계정만 표시합니다."
@@ -388,7 +388,7 @@
       }
     },
     "webhooks": {
-      "addButton": "{{admin.webhooks.addDialog.title}}",
+      "addButton": "{{admin.webhooks.addDialog.title}}...",
       "addDialog": {
         "createAutomationUser": "이 웹훅을 위한 자동화 사용자 생성.",
         "events": "구독할 이벤트 유형",
@@ -870,7 +870,6 @@
     "openInNewTab": "새 탭에서 열기",
     "other": "기타",
     "paste": "붙여넣기",
-    "permissions": "권한",
     "priority": "우선순위",
     "project": "프로젝트",
     "provider": "공급자",
@@ -925,7 +924,8 @@
     "view": "보기",
     "viewMetadata": "메타데이터 보기",
     "viewPermissions": "권한 보기",
-    "viewThreat": "위협 보기"
+    "viewThreat": "위협 보기",
+    "permissions": "권한..."
   },
   "contextMenu": {
     "addInverseConnection": "역방향 연결 추가",
@@ -1008,7 +1008,7 @@
   "cwePicker": {
     "addCwe": "CWE 추가",
     "addCweReference": "위협에 CWE 참조 추가",
-    "chooseCwe": "{{cwePicker.title}}",
+    "chooseCwe": "{{cwePicker.title}}...",
     "extendedDescription": "확장 설명",
     "loading": "취약점 로드 중...",
     "matchingWeaknesses": "일치하는 취약점",
@@ -1611,10 +1611,10 @@
     "filterStatusLabel": "{{projects.statusFilterLabel}}",
     "filterTeamLabel": "{{projects.teamFilterLabel}}",
     "kebab": {
-      "delete": "{{common.delete}}",
-      "metadata": "{{common.metadata}}",
-      "relatedProjects": "{{projects.relatedProjectsDialog.title}}",
-      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}"
+      "delete": "{{common.delete}}...",
+      "metadata": "{{common.metadata}}...",
+      "relatedProjects": "{{projects.relatedProjectsDialog.title}}...",
+      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.projects.title}}",
     "noProjects": "프로젝트를 찾을 수 없음.",
@@ -1850,11 +1850,11 @@
     },
     "filterLabel": "팀 필터",
     "kebab": {
-      "delete": "{{common.delete}}",
+      "delete": "{{common.delete}}...",
       "members": "멤버...",
-      "metadata": "{{common.metadata}}",
-      "relatedTeams": "{{teams.relatedTeamsDialog.title}}",
-      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}"
+      "metadata": "{{common.metadata}}...",
+      "relatedTeams": "{{teams.relatedTeamsDialog.title}}...",
+      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.teams.title}}",
     "membersDialog": {
@@ -1943,14 +1943,14 @@
     "selectDiagramFirst": "다이어그램을 먼저 선택하세요",
     "threatPriority": {
       "0": "Immediate (P0)",
-      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
       "1": "High (P1)",
-      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
       "2": "Medium (P2)",
-      "2.description": "Address within standard development cycles; moderate exposure.",
       "3": "Low (P3)",
-      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4": "Deferred (P4)",
+      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
+      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
+      "2.description": "Address within standard development cycles; moderate exposure.",
+      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4.description": "Postponed with documented business approval; tracked but not scheduled.",
       "deferred": "연기됨 (P4)",
       "deferred.description": "문서화된 비즈니스 승인에 따라 연기됨; 추적 중이나 예정 없음.",
@@ -1964,11 +1964,11 @@
       "medium.description": "표준 개발 주기 내에 처리; 중간 수준의 노출."
     },
     "threatSeverity": {
+      "4": "Informational",
       "0.description": "Exploitable vulnerability enables complete system compromise, data breach, or safety impact; requires immediate action.",
       "1.description": "Significant impact or high likelihood; enables major unauthorized access, privilege escalation, or service disruption.",
       "2.description": "Moderate impact or likelihood; limited data exposure, partial functionality impairment, or requires chained exploits.",
       "3.description": "Minimal impact or low likelihood; negligible business impact, requires specific conditions or user interaction.",
-      "4": "Informational",
       "4.description": "No direct exploitability; recommendation, best practice deviation, or configuration improvement.",
       "5.description": "Threat severity has not yet been assessed.",
       "critical": "치명적",
@@ -1986,24 +1986,24 @@
     },
     "threatStatus": {
       "0": "Open",
-      "0.description": "The finding has been identified and documented but no action has been initiated.",
       "1": "Confirmed",
-      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
       "2": "Mitigation Planned",
-      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
       "3": "Mitigation In Progress",
-      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
       "4": "Verification Pending",
-      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
       "5": "Resolved",
-      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
       "6": "Accepted",
-      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
       "7": "False Positive",
-      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
       "8": "Deferred",
-      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9": "Closed",
+      "0.description": "The finding has been identified and documented but no action has been initiated.",
+      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
+      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
+      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
+      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
+      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
+      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
+      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
+      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9.description": "The finding is archived after resolution, acceptance, or invalidation, with audit trail.",
       "accepted": "수용됨",
       "accepted.description": "위협이 인식되었으나 의도적으로 완화하지 않습니다 (예: 비즈니스 정당성으로 인해); 공식적인 위험 수용이 필요합니다.",
@@ -2125,24 +2125,24 @@
     "sourcesCount": "저장소",
     "status": {
       "0": "Not Started",
-      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
       "1": "In Progress",
-      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
       "2": "Pending Review",
-      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
       "3": "Remediation Required",
-      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
       "4": "Remediation In Progress",
-      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
       "5": "Verification Pending",
-      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
       "6": "Approved",
-      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
       "7": "Rejected",
-      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
       "8": "Deferred",
-      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9": "Closed",
+      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
+      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
+      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
+      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
+      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
+      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
+      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
+      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
+      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9.tooltip": "The review is fully completed and archived, with no further action needed.",
       "active": "활성",
       "active.tooltip": "위협 모델이 현재 작업 중입니다.",
@@ -2175,7 +2175,7 @@
       "addAsset": "자산 추가...",
       "addDiagram": "다이어그램 추가...",
       "addDocument": "문서 추가...",
-      "addNote": "{{triage.detail.addNote}}",
+      "addNote": "{{triage.detail.addNote}}...",
       "assetsCardTitle": "자산은 데이터, 하드웨어, 소프트웨어, 인프라, 서비스 또는 인력과 같이 보호가 필요한 시스템 내의 가치 있는 리소스입니다",
       "diagramsCardTitle": "TMI의 다이어그램은 시스템 내 데이터 이동 및 프로세스를 기계가 읽을 수 있는 형태로 표현하여 수동 및 자동 보안 분석을 모두 가능하게 합니다",
       "documentsCardTitle": "문서 참조는 TMI 외부에 저장된 문서에 대한 링크입니다. 관련 문서는 분석할 시스템을 설명하며 보안 분석가와 자동화된 분석 프로세스 모두에서 사용할 수 있습니다",

--- a/src/assets/i18n/pt-BR.json
+++ b/src/assets/i18n/pt-BR.json
@@ -47,7 +47,7 @@
   },
   "admin": {
     "addons": {
-      "addButton": "{{admin.addons.addDialog.title}}",
+      "addButton": "{{admin.addons.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "O que este complemento faz?",
@@ -183,7 +183,7 @@
       "title": "{{admin.createAutomationUserDialog.save}}"
     },
     "groups": {
-      "addButton": "{{admin.groups.addDialog.title}}",
+      "addButton": "{{admin.groups.addDialog.title}}...",
       "addDialog": {
         "description": "Descrição (opcional)",
         "descriptionHint": "Descricao opcional do proposito do grupo",
@@ -302,7 +302,7 @@
       }
     },
     "settings": {
-      "addButton": "{{admin.settings.addDialog.title}}",
+      "addButton": "{{admin.settings.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "Descrição opcional desta configuração",
@@ -360,7 +360,7 @@
         "threatModels": "TMs",
         "user": "{{common.subjectTypes.user}}"
       },
-      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}",
+      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}...",
       "deleteTooltip": "Excluir conta de usuario",
       "filter": {
         "automationOnly": "Exibir apenas contas de automação."
@@ -388,7 +388,7 @@
       }
     },
     "webhooks": {
-      "addButton": "{{admin.webhooks.addDialog.title}}",
+      "addButton": "{{admin.webhooks.addDialog.title}}...",
       "addDialog": {
         "createAutomationUser": "Criar usuário de automação para este webhook.",
         "events": "Tipos de evento para assinar",
@@ -870,7 +870,6 @@
     "openInNewTab": "Abrir em nova aba",
     "other": "Outro",
     "paste": "Colar",
-    "permissions": "Permissoes",
     "priority": "Prioridade",
     "project": "Projeto",
     "provider": "Provedor",
@@ -925,7 +924,8 @@
     "view": "Visualizar",
     "viewMetadata": "Visualizar metadados",
     "viewPermissions": "Visualizar permissões",
-    "viewThreat": "Visualizar ameaça"
+    "viewThreat": "Visualizar ameaça",
+    "permissions": "Permissões..."
   },
   "contextMenu": {
     "addInverseConnection": "Adicionar conexão inversa",
@@ -1008,7 +1008,7 @@
   "cwePicker": {
     "addCwe": "Adicionar CWE",
     "addCweReference": "Adicionar referência CWE à ameaça",
-    "chooseCwe": "{{cwePicker.title}}",
+    "chooseCwe": "{{cwePicker.title}}...",
     "extendedDescription": "Descrição estendida",
     "loading": "Carregando fraquezas...",
     "matchingWeaknesses": "Fraquezas correspondentes",
@@ -1615,10 +1615,10 @@
     "filterStatusLabel": "{{projects.statusFilterLabel}}",
     "filterTeamLabel": "{{projects.teamFilterLabel}}",
     "kebab": {
-      "delete": "{{common.delete}}",
-      "metadata": "{{common.metadata}}",
-      "relatedProjects": "{{projects.relatedProjectsDialog.title}}",
-      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}"
+      "delete": "{{common.delete}}...",
+      "metadata": "{{common.metadata}}...",
+      "relatedProjects": "{{projects.relatedProjectsDialog.title}}...",
+      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.projects.title}}",
     "noProjects": "Nenhum projeto encontrado.",
@@ -1856,11 +1856,11 @@
     "editDialog.title": "Editar Equipe",
     "filterLabel": "Filtrar equipes",
     "kebab": {
-      "delete": "{{common.delete}}",
+      "delete": "{{common.delete}}...",
       "members": "Membros...",
-      "metadata": "{{common.metadata}}",
-      "relatedTeams": "{{teams.relatedTeamsDialog.title}}",
-      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}"
+      "metadata": "{{common.metadata}}...",
+      "relatedTeams": "{{teams.relatedTeamsDialog.title}}...",
+      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}..."
     },
     "kebab.members": "Membros",
     "listTitle": "{{admin.sections.teams.title}}",
@@ -1974,14 +1974,14 @@
     "selectDiagramFirst": "Selecione um diagrama primeiro",
     "threatPriority": {
       "0": "Immediate (P0)",
-      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
       "1": "High (P1)",
-      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
       "2": "Medium (P2)",
-      "2.description": "Address within standard development cycles; moderate exposure.",
       "3": "Low (P3)",
-      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4": "Deferred (P4)",
+      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
+      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
+      "2.description": "Address within standard development cycles; moderate exposure.",
+      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4.description": "Postponed with documented business approval; tracked but not scheduled.",
       "deferred": "Adiada (p4)",
       "deferred.description": "Adiada com aprovação empresarial documentada; rastreada, mas não agendada.",
@@ -1995,11 +1995,11 @@
       "medium.description": "Tratar dentro dos ciclos de desenvolvimento padrão; exposição moderada."
     },
     "threatSeverity": {
+      "4": "Informational",
       "0.description": "Exploitable vulnerability enables complete system compromise, data breach, or safety impact; requires immediate action.",
       "1.description": "Significant impact or high likelihood; enables major unauthorized access, privilege escalation, or service disruption.",
       "2.description": "Moderate impact or likelihood; limited data exposure, partial functionality impairment, or requires chained exploits.",
       "3.description": "Minimal impact or low likelihood; negligible business impact, requires specific conditions or user interaction.",
-      "4": "Informational",
       "4.description": "No direct exploitability; recommendation, best practice deviation, or configuration improvement.",
       "5.description": "Threat severity has not yet been assessed.",
       "critical": "Critica",
@@ -2017,24 +2017,24 @@
     },
     "threatStatus": {
       "0": "Open",
-      "0.description": "The finding has been identified and documented but no action has been initiated.",
       "1": "Confirmed",
-      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
       "2": "Mitigation Planned",
-      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
       "3": "Mitigation In Progress",
-      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
       "4": "Verification Pending",
-      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
       "5": "Resolved",
-      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
       "6": "Accepted",
-      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
       "7": "False Positive",
-      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
       "8": "Deferred",
-      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9": "Closed",
+      "0.description": "The finding has been identified and documented but no action has been initiated.",
+      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
+      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
+      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
+      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
+      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
+      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
+      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
+      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9.description": "The finding is archived after resolution, acceptance, or invalidation, with audit trail.",
       "accepted": "Aceita",
       "accepted.description": "A ameaça é reconhecida, mas intencionalmente não mitigada (ex.: por justificativa empresarial); requer aceitação formal do risco.",
@@ -2156,24 +2156,24 @@
     "sourcesCount": "Repositorios",
     "status": {
       "0": "Not Started",
-      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
       "1": "In Progress",
-      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
       "2": "Pending Review",
-      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
       "3": "Remediation Required",
-      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
       "4": "Remediation In Progress",
-      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
       "5": "Verification Pending",
-      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
       "6": "Approved",
-      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
       "7": "Rejected",
-      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
       "8": "Deferred",
-      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9": "Closed",
+      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
+      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
+      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
+      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
+      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
+      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
+      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
+      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
+      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9.tooltip": "The review is fully completed and archived, with no further action needed.",
       "active": "Ativo",
       "active.tooltip": "O modelo de ameaças está sendo ativamente trabalhado.",
@@ -2206,7 +2206,7 @@
       "addAsset": "Adicionar ativo...",
       "addDiagram": "Adicionar diagrama...",
       "addDocument": "Adicionar documento...",
-      "addNote": "{{triage.detail.addNote}}",
+      "addNote": "{{triage.detail.addNote}}...",
       "assetsCardTitle": "Ativos são recursos valiosos dentro do sistema que requerem proteção, como dados, hardware, software, infraestrutura, serviços ou pessoal",
       "diagramsCardTitle": "Diagramas no TMI são representações legíveis por máquina do movimento de dados e processos dentro de um sistema, habilitando análise de segurança manual e automatizada",
       "documentsCardTitle": "Referências de documentos são links para documentos armazenados fora do TMI. Documentos relevantes descrevem o sistema a ser analisado e podem ser usados por analistas de segurança e processos de análise automatizados",

--- a/src/assets/i18n/ru-RU.json
+++ b/src/assets/i18n/ru-RU.json
@@ -47,7 +47,7 @@
   },
   "admin": {
     "addons": {
-      "addButton": "{{admin.addons.addDialog.title}}",
+      "addButton": "{{admin.addons.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "Что делает это дополнение?",
@@ -183,7 +183,7 @@
       "title": "{{admin.createAutomationUserDialog.save}}"
     },
     "groups": {
-      "addButton": "{{admin.groups.addDialog.title}}",
+      "addButton": "{{admin.groups.addDialog.title}}...",
       "addDialog": {
         "description": "Описание (необязательно)",
         "descriptionHint": "Необязательное описание назначения группы",
@@ -302,7 +302,7 @@
       }
     },
     "settings": {
-      "addButton": "{{admin.settings.addDialog.title}}",
+      "addButton": "{{admin.settings.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "Необязательное описание этой настройки",
@@ -360,7 +360,7 @@
         "threatModels": "TMs",
         "user": "{{common.subjectTypes.user}}"
       },
-      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}",
+      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}...",
       "deleteTooltip": "Удалить учётную запись пользователя",
       "filter": {
         "automationOnly": "Показать только учётные записи автоматизации."
@@ -388,7 +388,7 @@
       }
     },
     "webhooks": {
-      "addButton": "{{admin.webhooks.addDialog.title}}",
+      "addButton": "{{admin.webhooks.addDialog.title}}...",
       "addDialog": {
         "createAutomationUser": "Создать пользователя автоматизации для этого вебхука.",
         "events": "Типы событий для подписки",
@@ -870,7 +870,6 @@
     "openInNewTab": "Открыть в новой вкладке",
     "other": "Другое",
     "paste": "Вставить",
-    "permissions": "Разрешения",
     "priority": "Приоритет",
     "project": "Проект",
     "provider": "Поставщик",
@@ -925,7 +924,8 @@
     "view": "Просмотр",
     "viewMetadata": "Просмотр метаданных",
     "viewPermissions": "Просмотр разрешений",
-    "viewThreat": "Просмотр угрозы"
+    "viewThreat": "Просмотр угрозы",
+    "permissions": "Разрешения..."
   },
   "contextMenu": {
     "addInverseConnection": "Добавить обратное соединение",
@@ -1008,7 +1008,7 @@
   "cwePicker": {
     "addCwe": "Добавить CWE",
     "addCweReference": "Добавить ссылку CWE к угрозе",
-    "chooseCwe": "{{cwePicker.title}}",
+    "chooseCwe": "{{cwePicker.title}}...",
     "extendedDescription": "Расширенное описание",
     "loading": "Загрузка уязвимостей...",
     "matchingWeaknesses": "Совпадающие уязвимости",
@@ -1613,10 +1613,10 @@
     "filterStatusLabel": "{{projects.statusFilterLabel}}",
     "filterTeamLabel": "{{projects.teamFilterLabel}}",
     "kebab": {
-      "delete": "{{common.delete}}",
-      "metadata": "{{common.metadata}}",
-      "relatedProjects": "{{projects.relatedProjectsDialog.title}}",
-      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}"
+      "delete": "{{common.delete}}...",
+      "metadata": "{{common.metadata}}...",
+      "relatedProjects": "{{projects.relatedProjectsDialog.title}}...",
+      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.projects.title}}",
     "noProjects": "Проектов не найдено.",
@@ -1852,11 +1852,11 @@
     },
     "filterLabel": "Фильтр команд",
     "kebab": {
-      "delete": "{{common.delete}}",
+      "delete": "{{common.delete}}...",
       "members": "Участники...",
-      "metadata": "{{common.metadata}}",
-      "relatedTeams": "{{teams.relatedTeamsDialog.title}}",
-      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}"
+      "metadata": "{{common.metadata}}...",
+      "relatedTeams": "{{teams.relatedTeamsDialog.title}}...",
+      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.teams.title}}",
     "membersDialog": {
@@ -1945,14 +1945,14 @@
     "selectDiagramFirst": "Сначала выберите диаграмму",
     "threatPriority": {
       "0": "Immediate (P0)",
-      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
       "1": "High (P1)",
-      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
       "2": "Medium (P2)",
-      "2.description": "Address within standard development cycles; moderate exposure.",
       "3": "Low (P3)",
-      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4": "Deferred (P4)",
+      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
+      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
+      "2.description": "Address within standard development cycles; moderate exposure.",
+      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4.description": "Postponed with documented business approval; tracked but not scheduled.",
       "deferred": "Отложено (P4)",
       "deferred.description": "Отложено с задокументированным согласованием с бизнесом; отслеживается, но не запланировано.",
@@ -1966,11 +1966,11 @@
       "medium.description": "Устранить в рамках стандартных циклов разработки; умеренная степень воздействия."
     },
     "threatSeverity": {
+      "4": "Informational",
       "0.description": "Exploitable vulnerability enables complete system compromise, data breach, or safety impact; requires immediate action.",
       "1.description": "Significant impact or high likelihood; enables major unauthorized access, privilege escalation, or service disruption.",
       "2.description": "Moderate impact or likelihood; limited data exposure, partial functionality impairment, or requires chained exploits.",
       "3.description": "Minimal impact or low likelihood; negligible business impact, requires specific conditions or user interaction.",
-      "4": "Informational",
       "4.description": "No direct exploitability; recommendation, best practice deviation, or configuration improvement.",
       "5.description": "Threat severity has not yet been assessed.",
       "critical": "Критический",
@@ -1988,24 +1988,24 @@
     },
     "threatStatus": {
       "0": "Open",
-      "0.description": "The finding has been identified and documented but no action has been initiated.",
       "1": "Confirmed",
-      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
       "2": "Mitigation Planned",
-      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
       "3": "Mitigation In Progress",
-      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
       "4": "Verification Pending",
-      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
       "5": "Resolved",
-      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
       "6": "Accepted",
-      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
       "7": "False Positive",
-      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
       "8": "Deferred",
-      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9": "Closed",
+      "0.description": "The finding has been identified and documented but no action has been initiated.",
+      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
+      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
+      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
+      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
+      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
+      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
+      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
+      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9.description": "The finding is archived after resolution, acceptance, or invalidation, with audit trail.",
       "accepted": "Принято",
       "accepted.description": "Угроза признана, но намеренно не устранена (например, по соображениям бизнеса); требует официального принятия риска.",
@@ -2127,24 +2127,24 @@
     "sourcesCount": "Репозитории",
     "status": {
       "0": "Not Started",
-      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
       "1": "In Progress",
-      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
       "2": "Pending Review",
-      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
       "3": "Remediation Required",
-      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
       "4": "Remediation In Progress",
-      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
       "5": "Verification Pending",
-      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
       "6": "Approved",
-      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
       "7": "Rejected",
-      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
       "8": "Deferred",
-      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9": "Closed",
+      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
+      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
+      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
+      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
+      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
+      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
+      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
+      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
+      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9.tooltip": "The review is fully completed and archived, with no further action needed.",
       "active": "Активный",
       "active.tooltip": "Работа над моделью угроз активно ведётся.",
@@ -2177,7 +2177,7 @@
       "addAsset": "Добавить актив...",
       "addDiagram": "Добавить диаграмму...",
       "addDocument": "Добавить документ...",
-      "addNote": "{{triage.detail.addNote}}",
+      "addNote": "{{triage.detail.addNote}}...",
       "assetsCardTitle": "Активы — это ценные ресурсы в системе, которые требуют защиты, такие как данные, оборудование, программное обеспечение, инфраструктура, услуги или персонал",
       "diagramsCardTitle": "Диаграммы в TMI — это машиночитаемые представления движения данных и процессов в системе, позволяющие проводить как ручной, так и автоматизированный анализ безопасности",
       "documentsCardTitle": "Ссылки на документы — это ссылки на документы, хранящиеся вне TMI. Соответствующие документы описывают анализируемую систему и могут использоваться как аналитиками безопасности, так и автоматизированными процессами анализа",

--- a/src/assets/i18n/th-TH.json
+++ b/src/assets/i18n/th-TH.json
@@ -47,7 +47,7 @@
   },
   "admin": {
     "addons": {
-      "addButton": "{{admin.addons.addDialog.title}}",
+      "addButton": "{{admin.addons.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "ส่วนเสริมนี้ทำอะไร?",
@@ -183,7 +183,7 @@
       "title": "{{admin.createAutomationUserDialog.save}}"
     },
     "groups": {
-      "addButton": "{{admin.groups.addDialog.title}}",
+      "addButton": "{{admin.groups.addDialog.title}}...",
       "addDialog": {
         "description": "คำอธิบาย (ไม่บังคับ)",
         "descriptionHint": "คำอธิบายเพิ่มเติมเกี่ยวกับวัตถุประสงค์ของกลุ่ม",
@@ -302,7 +302,7 @@
       }
     },
     "settings": {
-      "addButton": "{{admin.settings.addDialog.title}}",
+      "addButton": "{{admin.settings.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "คำอธิบายเพิ่มเติมของการตั้งค่านี้",
@@ -360,7 +360,7 @@
         "threatModels": "TMs",
         "user": "{{common.subjectTypes.user}}"
       },
-      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}",
+      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}...",
       "deleteTooltip": "ลบบัญชีผู้ใช้",
       "filter": {
         "automationOnly": "แสดงเฉพาะบัญชีอัตโนมัติ"
@@ -388,7 +388,7 @@
       }
     },
     "webhooks": {
-      "addButton": "{{admin.webhooks.addDialog.title}}",
+      "addButton": "{{admin.webhooks.addDialog.title}}...",
       "addDialog": {
         "createAutomationUser": "สร้างผู้ใช้อัตโนมัติสำหรับ Webhook นี้",
         "events": "ประเภทเหตุการณ์ที่ต้องการรับ",
@@ -870,7 +870,6 @@
     "openInNewTab": "เปิดในแท็บใหม่",
     "other": "อื่นๆ",
     "paste": "วาง",
-    "permissions": "สิทธิ์การเข้าถึง",
     "priority": "ความสำคัญ",
     "project": "โปรเจกต์",
     "provider": "ผู้ให้บริการ",
@@ -925,7 +924,8 @@
     "view": "ดู",
     "viewMetadata": "ดูเมตาดาต้า",
     "viewPermissions": "ดูสิทธิ์",
-    "viewThreat": "ดูภัยคุกคาม"
+    "viewThreat": "ดูภัยคุกคาม",
+    "permissions": "สิทธิ์การเข้าถึง..."
   },
   "contextMenu": {
     "addInverseConnection": "เพิ่มการเชื่อมต่อย้อนกลับ",
@@ -1008,7 +1008,7 @@
   "cwePicker": {
     "addCwe": "เพิ่ม CWE",
     "addCweReference": "เพิ่มการอ้างอิง CWE ไปยังภัยคุกคาม",
-    "chooseCwe": "{{cwePicker.title}}",
+    "chooseCwe": "{{cwePicker.title}}...",
     "extendedDescription": "คำอธิบายเพิ่มเติม",
     "loading": "กำลังโหลดจุดอ่อน...",
     "matchingWeaknesses": "จุดอ่อนที่ตรงกัน",
@@ -1613,10 +1613,10 @@
     "filterStatusLabel": "{{projects.statusFilterLabel}}",
     "filterTeamLabel": "{{projects.teamFilterLabel}}",
     "kebab": {
-      "delete": "{{common.delete}}",
-      "metadata": "{{common.metadata}}",
-      "relatedProjects": "{{projects.relatedProjectsDialog.title}}",
-      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}"
+      "delete": "{{common.delete}}...",
+      "metadata": "{{common.metadata}}...",
+      "relatedProjects": "{{projects.relatedProjectsDialog.title}}...",
+      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.projects.title}}",
     "noProjects": "ไม่พบโครงการ",
@@ -1852,11 +1852,11 @@
     },
     "filterLabel": "กรองทีม",
     "kebab": {
-      "delete": "{{common.delete}}",
+      "delete": "{{common.delete}}...",
       "members": "สมาชิก...",
-      "metadata": "{{common.metadata}}",
-      "relatedTeams": "{{teams.relatedTeamsDialog.title}}",
-      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}"
+      "metadata": "{{common.metadata}}...",
+      "relatedTeams": "{{teams.relatedTeamsDialog.title}}...",
+      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.teams.title}}",
     "membersDialog": {
@@ -1945,14 +1945,14 @@
     "selectDiagramFirst": "เลือกแผนภาพก่อน",
     "threatPriority": {
       "0": "Immediate (P0)",
-      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
       "1": "High (P1)",
-      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
       "2": "Medium (P2)",
-      "2.description": "Address within standard development cycles; moderate exposure.",
       "3": "Low (P3)",
-      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4": "Deferred (P4)",
+      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
+      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
+      "2.description": "Address within standard development cycles; moderate exposure.",
+      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4.description": "Postponed with documented business approval; tracked but not scheduled.",
       "deferred": "เลื่อนออกไป (p4)",
       "deferred.description": "เลื่อนออกไปพร้อมการอนุมัติทางธุรกิจที่บันทึกไว้ ติดตามแต่ยังไม่ได้กำหนดการ",
@@ -1966,11 +1966,11 @@
       "medium.description": "ดำเนินการภายในรอบการพัฒนามาตรฐาน ความเสี่ยงในระดับปานกลาง"
     },
     "threatSeverity": {
+      "4": "Informational",
       "0.description": "Exploitable vulnerability enables complete system compromise, data breach, or safety impact; requires immediate action.",
       "1.description": "Significant impact or high likelihood; enables major unauthorized access, privilege escalation, or service disruption.",
       "2.description": "Moderate impact or likelihood; limited data exposure, partial functionality impairment, or requires chained exploits.",
       "3.description": "Minimal impact or low likelihood; negligible business impact, requires specific conditions or user interaction.",
-      "4": "Informational",
       "4.description": "No direct exploitability; recommendation, best practice deviation, or configuration improvement.",
       "5.description": "Threat severity has not yet been assessed.",
       "critical": "วิกฤต",
@@ -1988,24 +1988,24 @@
     },
     "threatStatus": {
       "0": "Open",
-      "0.description": "The finding has been identified and documented but no action has been initiated.",
       "1": "Confirmed",
-      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
       "2": "Mitigation Planned",
-      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
       "3": "Mitigation In Progress",
-      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
       "4": "Verification Pending",
-      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
       "5": "Resolved",
-      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
       "6": "Accepted",
-      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
       "7": "False Positive",
-      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
       "8": "Deferred",
-      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9": "Closed",
+      "0.description": "The finding has been identified and documented but no action has been initiated.",
+      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
+      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
+      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
+      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
+      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
+      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
+      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
+      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9.description": "The finding is archived after resolution, acceptance, or invalidation, with audit trail.",
       "accepted": "ยอมรับแล้ว",
       "accepted.description": "ภัยคุกคามได้รับการรับทราบแต่ไม่ได้รับการลดผลกระทบโดยเจตนา (เช่น เนื่องจากเหตุผลทางธุรกิจ) ต้องมีการยอมรับความเสี่ยงอย่างเป็นทางการ",
@@ -2127,24 +2127,24 @@
     "sourcesCount": "ที่เก็บ",
     "status": {
       "0": "Not Started",
-      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
       "1": "In Progress",
-      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
       "2": "Pending Review",
-      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
       "3": "Remediation Required",
-      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
       "4": "Remediation In Progress",
-      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
       "5": "Verification Pending",
-      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
       "6": "Approved",
-      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
       "7": "Rejected",
-      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
       "8": "Deferred",
-      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9": "Closed",
+      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
+      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
+      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
+      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
+      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
+      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
+      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
+      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
+      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9.tooltip": "The review is fully completed and archived, with no further action needed.",
       "active": "ใช้งานอยู่",
       "active.tooltip": "กำลังดำเนินการกับ Threat Model อยู่",
@@ -2177,7 +2177,7 @@
       "addAsset": "เพิ่มทรัพย์สิน...",
       "addDiagram": "เพิ่มแผนภาพ...",
       "addDocument": "เพิ่มเอกสาร...",
-      "addNote": "{{triage.detail.addNote}}",
+      "addNote": "{{triage.detail.addNote}}...",
       "assetsCardTitle": "ทรัพย์สินคือทรัพยากรที่มีคุณค่าภายในระบบที่ต้องการการปกป้อง เช่น ข้อมูล ฮาร์ดแวร์ ซอฟต์แวร์ โครงสร้างพื้นฐาน บริการ หรือบุคลากร",
       "diagramsCardTitle": "แผนภาพใน TMI คือการแสดงแทนที่เครื่องอ่านได้ของการเคลื่อนไหวของข้อมูลและกระบวนการภายในระบบ ช่วยให้สามารถวิเคราะห์ความปลอดภัยทั้งแบบ manual และอัตโนมัติ",
       "documentsCardTitle": "การอ้างอิงเอกสารคือลิงก์ไปยังเอกสารที่จัดเก็บภายนอก TMI เอกสารที่เกี่ยวข้องอธิบายระบบที่จะวิเคราะห์ และสามารถใช้โดยนักวิเคราะห์ความปลอดภัยและกระบวนการวิเคราะห์อัตโนมัติ",

--- a/src/assets/i18n/ur-PK.json
+++ b/src/assets/i18n/ur-PK.json
@@ -47,7 +47,7 @@
   },
   "admin": {
     "addons": {
-      "addButton": "{{admin.addons.addDialog.title}}",
+      "addButton": "{{admin.addons.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "یہ ایڈ آن کیا کرتا ہے؟",
@@ -183,7 +183,7 @@
       "title": "{{admin.createAutomationUserDialog.save}}"
     },
     "groups": {
-      "addButton": "{{admin.groups.addDialog.title}}",
+      "addButton": "{{admin.groups.addDialog.title}}...",
       "addDialog": {
         "description": "تفصیل (اختیاری)",
         "descriptionHint": "گروپ کے مقصد کی اختیاری تفصیل",
@@ -302,7 +302,7 @@
       }
     },
     "settings": {
-      "addButton": "{{admin.settings.addDialog.title}}",
+      "addButton": "{{admin.settings.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "اس ترتیب کی اختیاری تفصیل",
@@ -360,7 +360,7 @@
         "threatModels": "TMs",
         "user": "{{common.subjectTypes.user}}"
       },
-      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}",
+      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}...",
       "deleteTooltip": "صارف اکاؤنٹ حذف کریں",
       "filter": {
         "automationOnly": "صرف آٹومیشن اکاؤنٹس دکھائیں۔"
@@ -388,7 +388,7 @@
       }
     },
     "webhooks": {
-      "addButton": "{{admin.webhooks.addDialog.title}}",
+      "addButton": "{{admin.webhooks.addDialog.title}}...",
       "addDialog": {
         "createAutomationUser": "اس webhook کے لیے آٹومیشن صارف بنائیں۔",
         "events": "سبسکرائب کرنے کے لیے ایونٹ کی اقسام",
@@ -870,7 +870,6 @@
     "openInNewTab": "نئی ٹیب میں کھولیں",
     "other": "دیگر",
     "paste": "پیسٹ کریں",
-    "permissions": "اجازتیں",
     "priority": "ترجیح",
     "project": "پروجیکٹ",
     "provider": "فراہم کنندہ",
@@ -925,7 +924,8 @@
     "view": "دیکھیں",
     "viewMetadata": "میٹا ڈیٹا دیکھیں",
     "viewPermissions": "اجازتیں دیکھیں",
-    "viewThreat": "خطرہ دیکھیں"
+    "viewThreat": "خطرہ دیکھیں",
+    "permissions": "اجازتیں..."
   },
   "contextMenu": {
     "addInverseConnection": "الٹا کنکشن شامل کریں",
@@ -1008,7 +1008,7 @@
   "cwePicker": {
     "addCwe": "CWE شامل کریں",
     "addCweReference": "خطرے میں CWE حوالہ شامل کریں",
-    "chooseCwe": "{{cwePicker.title}}",
+    "chooseCwe": "{{cwePicker.title}}...",
     "extendedDescription": "توسیعی تفصیل",
     "loading": "کمزوریاں لوڈ ہو رہی ہیں...",
     "matchingWeaknesses": "مماثل کمزوریاں",
@@ -1613,10 +1613,10 @@
     "filterStatusLabel": "{{projects.statusFilterLabel}}",
     "filterTeamLabel": "{{projects.teamFilterLabel}}",
     "kebab": {
-      "delete": "{{common.delete}}",
-      "metadata": "{{common.metadata}}",
-      "relatedProjects": "{{projects.relatedProjectsDialog.title}}",
-      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}"
+      "delete": "{{common.delete}}...",
+      "metadata": "{{common.metadata}}...",
+      "relatedProjects": "{{projects.relatedProjectsDialog.title}}...",
+      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.projects.title}}",
     "noProjects": "کوئی منصوبے نہیں ملے۔",
@@ -1852,11 +1852,11 @@
     },
     "filterLabel": "ٹیموں کو فلٹر کریں",
     "kebab": {
-      "delete": "{{common.delete}}",
+      "delete": "{{common.delete}}...",
       "members": "اراکین...",
-      "metadata": "{{common.metadata}}",
-      "relatedTeams": "{{teams.relatedTeamsDialog.title}}",
-      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}"
+      "metadata": "{{common.metadata}}...",
+      "relatedTeams": "{{teams.relatedTeamsDialog.title}}...",
+      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.teams.title}}",
     "membersDialog": {
@@ -1945,14 +1945,14 @@
     "selectDiagramFirst": "پہلے ایک خاکہ منتخب کریں",
     "threatPriority": {
       "0": "Immediate (P0)",
-      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
       "1": "High (P1)",
-      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
       "2": "Medium (P2)",
-      "2.description": "Address within standard development cycles; moderate exposure.",
       "3": "Low (P3)",
-      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4": "Deferred (P4)",
+      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
+      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
+      "2.description": "Address within standard development cycles; moderate exposure.",
+      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4.description": "Postponed with documented business approval; tracked but not scheduled.",
       "deferred": "ملتوی (p4)",
       "deferred.description": "دستاویزی کاروباری منظوری کے ساتھ ملتوی؛ ٹریک کیا گیا لیکن شیڈول نہیں۔",
@@ -1966,11 +1966,11 @@
       "medium.description": "معیاری ترقیاتی چکروں میں حل کریں؛ معتدل خطرہ۔"
     },
     "threatSeverity": {
+      "4": "Informational",
       "0.description": "Exploitable vulnerability enables complete system compromise, data breach, or safety impact; requires immediate action.",
       "1.description": "Significant impact or high likelihood; enables major unauthorized access, privilege escalation, or service disruption.",
       "2.description": "Moderate impact or likelihood; limited data exposure, partial functionality impairment, or requires chained exploits.",
       "3.description": "Minimal impact or low likelihood; negligible business impact, requires specific conditions or user interaction.",
-      "4": "Informational",
       "4.description": "No direct exploitability; recommendation, best practice deviation, or configuration improvement.",
       "5.description": "Threat severity has not yet been assessed.",
       "critical": "اہم",
@@ -1988,24 +1988,24 @@
     },
     "threatStatus": {
       "0": "Open",
-      "0.description": "The finding has been identified and documented but no action has been initiated.",
       "1": "Confirmed",
-      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
       "2": "Mitigation Planned",
-      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
       "3": "Mitigation In Progress",
-      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
       "4": "Verification Pending",
-      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
       "5": "Resolved",
-      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
       "6": "Accepted",
-      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
       "7": "False Positive",
-      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
       "8": "Deferred",
-      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9": "Closed",
+      "0.description": "The finding has been identified and documented but no action has been initiated.",
+      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
+      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
+      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
+      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
+      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
+      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
+      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
+      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9.description": "The finding is archived after resolution, acceptance, or invalidation, with audit trail.",
       "accepted": "قبول شدہ",
       "accepted.description": "خطرے کو تسلیم کیا گیا ہے لیکن جان بوجھ کر کم نہیں کیا گیا (مثلاً، کاروباری جواز کی وجہ سے)؛ باضابطہ خطرے کی قبولیت درکار ہے۔",
@@ -2127,24 +2127,24 @@
     "sourcesCount": "ریپوز",
     "status": {
       "0": "Not Started",
-      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
       "1": "In Progress",
-      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
       "2": "Pending Review",
-      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
       "3": "Remediation Required",
-      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
       "4": "Remediation In Progress",
-      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
       "5": "Verification Pending",
-      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
       "6": "Approved",
-      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
       "7": "Rejected",
-      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
       "8": "Deferred",
-      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9": "Closed",
+      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
+      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
+      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
+      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
+      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
+      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
+      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
+      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
+      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9.tooltip": "The review is fully completed and archived, with no further action needed.",
       "active": "فعال",
       "active.tooltip": "تھریٹ ماڈل پر فعال طور پر کام کیا جا رہا ہے۔",
@@ -2177,7 +2177,7 @@
       "addAsset": "اثاثہ شامل کریں...",
       "addDiagram": "خاکہ شامل کریں...",
       "addDocument": "دستاویز شامل کریں...",
-      "addNote": "{{triage.detail.addNote}}",
+      "addNote": "{{triage.detail.addNote}}...",
       "assetsCardTitle": "اثاثے سسٹم کے اندر قیمتی وسائل ہیں جن کو تحفظ کی ضرورت ہے، جیسے ڈیٹا، ہارڈ ویئر، سافٹ ویئر، انفراسٹرکچر، خدمات، یا اہلکار",
       "diagramsCardTitle": "TMI میں خاکے ڈیٹا کی حرکت اور سسٹم کے اندر عملوں کی مشین پڑھنے کے قابل نمائندگی ہیں، جو دستی اور خودکار سیکیورٹی تجزیے دونوں کو ممکن بناتے ہیں",
       "documentsCardTitle": "دستاویز حوالہ جات TMI سے باہر محفوظ دستاویزات کے لنکس ہیں۔ متعلقہ دستاویزات تجزیہ کیے جانے والے سسٹم کو بیان کرتی ہیں، اور سیکیورٹی تجزیہ کاروں اور خودکار تجزیاتی عمل دونوں استعمال کر سکتے ہیں",

--- a/src/assets/i18n/zh-CN.json
+++ b/src/assets/i18n/zh-CN.json
@@ -47,7 +47,7 @@
   },
   "admin": {
     "addons": {
-      "addButton": "{{admin.addons.addDialog.title}}",
+      "addButton": "{{admin.addons.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "此插件有什么功能？",
@@ -183,7 +183,7 @@
       "title": "{{admin.createAutomationUserDialog.save}}"
     },
     "groups": {
-      "addButton": "{{admin.groups.addDialog.title}}",
+      "addButton": "{{admin.groups.addDialog.title}}...",
       "addDialog": {
         "description": "描述（可选）",
         "descriptionHint": "用户组用途的可选描述",
@@ -302,7 +302,7 @@
       }
     },
     "settings": {
-      "addButton": "{{admin.settings.addDialog.title}}",
+      "addButton": "{{admin.settings.addDialog.title}}...",
       "addDialog": {
         "description": "{{common.description}}",
         "descriptionHint": "此设置的可选描述",
@@ -360,7 +360,7 @@
         "threatModels": "TMs",
         "user": "{{common.subjectTypes.user}}"
       },
-      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}",
+      "createAutomationUser": "{{admin.createAutomationUserDialog.save}}...",
       "deleteTooltip": "删除用户账户",
       "filter": {
         "automationOnly": "仅显示自动化账户。"
@@ -388,7 +388,7 @@
       }
     },
     "webhooks": {
-      "addButton": "{{admin.webhooks.addDialog.title}}",
+      "addButton": "{{admin.webhooks.addDialog.title}}...",
       "addDialog": {
         "createAutomationUser": "为此 webhook 创建自动化用户。",
         "events": "要订阅的事件类型",
@@ -870,7 +870,6 @@
     "openInNewTab": "在新标签页中打开",
     "other": "其他",
     "paste": "粘贴",
-    "permissions": "权限",
     "priority": "优先级",
     "project": "项目",
     "provider": "提供商",
@@ -925,7 +924,8 @@
     "view": "查看",
     "viewMetadata": "查看元数据",
     "viewPermissions": "查看权限",
-    "viewThreat": "查看威胁"
+    "viewThreat": "查看威胁",
+    "permissions": "权限..."
   },
   "contextMenu": {
     "addInverseConnection": "添加反向连接",
@@ -1008,7 +1008,7 @@
   "cwePicker": {
     "addCwe": "添加CWE",
     "addCweReference": "向威胁添加 CWE 参考",
-    "chooseCwe": "{{cwePicker.title}}",
+    "chooseCwe": "{{cwePicker.title}}...",
     "extendedDescription": "扩展描述",
     "loading": "正在加载弱点...",
     "matchingWeaknesses": "匹配的弱点",
@@ -1613,10 +1613,10 @@
     "filterStatusLabel": "{{projects.statusFilterLabel}}",
     "filterTeamLabel": "{{projects.teamFilterLabel}}",
     "kebab": {
-      "delete": "{{common.delete}}",
-      "metadata": "{{common.metadata}}",
-      "relatedProjects": "{{projects.relatedProjectsDialog.title}}",
-      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}"
+      "delete": "{{common.delete}}...",
+      "metadata": "{{common.metadata}}...",
+      "relatedProjects": "{{projects.relatedProjectsDialog.title}}...",
+      "responsibleParties": "{{projects.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.projects.title}}",
     "noProjects": "未找到项目。",
@@ -1852,11 +1852,11 @@
     },
     "filterLabel": "筛选团队",
     "kebab": {
-      "delete": "{{common.delete}}",
+      "delete": "{{common.delete}}...",
       "members": "成员...",
-      "metadata": "{{common.metadata}}",
-      "relatedTeams": "{{teams.relatedTeamsDialog.title}}",
-      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}"
+      "metadata": "{{common.metadata}}...",
+      "relatedTeams": "{{teams.relatedTeamsDialog.title}}...",
+      "responsibleParties": "{{teams.responsiblePartiesDialog.title}}..."
     },
     "listTitle": "{{admin.sections.teams.title}}",
     "membersDialog": {
@@ -1945,14 +1945,14 @@
     "selectDiagramFirst": "请先选择一个图表",
     "threatPriority": {
       "0": "Immediate (P0)",
-      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
       "1": "High (P1)",
-      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
       "2": "Medium (P2)",
-      "2.description": "Address within standard development cycles; moderate exposure.",
       "3": "Low (P3)",
-      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4": "Deferred (P4)",
+      "0.description": "Must be addressed urgently; active exploitation, regulatory violation, or critical business exposure.",
+      "1.description": "Requires prompt resolution; high-risk exposure or upcoming release deadline.",
+      "2.description": "Address within standard development cycles; moderate exposure.",
+      "3.description": "Include in backlog for future cycles; no immediate exposure.",
       "4.description": "Postponed with documented business approval; tracked but not scheduled.",
       "deferred": "已延迟（P4）",
       "deferred.description": "已通过有据可查的业务审批推迟；已跟踪但未排期。",
@@ -1966,11 +1966,11 @@
       "medium.description": "在标准开发周期内处理；中等风险暴露。"
     },
     "threatSeverity": {
+      "4": "Informational",
       "0.description": "Exploitable vulnerability enables complete system compromise, data breach, or safety impact; requires immediate action.",
       "1.description": "Significant impact or high likelihood; enables major unauthorized access, privilege escalation, or service disruption.",
       "2.description": "Moderate impact or likelihood; limited data exposure, partial functionality impairment, or requires chained exploits.",
       "3.description": "Minimal impact or low likelihood; negligible business impact, requires specific conditions or user interaction.",
-      "4": "Informational",
       "4.description": "No direct exploitability; recommendation, best practice deviation, or configuration improvement.",
       "5.description": "Threat severity has not yet been assessed.",
       "critical": "严重",
@@ -1988,24 +1988,24 @@
     },
     "threatStatus": {
       "0": "Open",
-      "0.description": "The finding has been identified and documented but no action has been initiated.",
       "1": "Confirmed",
-      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
       "2": "Mitigation Planned",
-      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
       "3": "Mitigation In Progress",
-      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
       "4": "Verification Pending",
-      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
       "5": "Resolved",
-      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
       "6": "Accepted",
-      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
       "7": "False Positive",
-      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
       "8": "Deferred",
-      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9": "Closed",
+      "0.description": "The finding has been identified and documented but no action has been initiated.",
+      "1.description": "The threat has been validated as legitimate through analysis or evidence.",
+      "2.description": "A remediation or mitigation strategy has been defined and assigned.",
+      "3.description": "Implementation of controls, code changes, or countermeasures is underway.",
+      "4.description": "Mitigation is complete; security team must test or review effectiveness.",
+      "5.description": "The threat is fully mitigated and verified; residual risk is acceptable.",
+      "6.description": "The threat is acknowledged but intentionally not mitigated (e.g., due to business justification); requires formal risk acceptance.",
+      "7.description": "Investigation determined the finding is not a valid threat; no further action required.",
+      "8.description": "Action is postponed with approval (e.g., for future sprints); includes rationale and due date.",
       "9.description": "The finding is archived after resolution, acceptance, or invalidation, with audit trail.",
       "accepted": "已接受",
       "accepted.description": "威胁已被认知但故意不予缓解（例如基于业务理由）；需要正式的风险接受。",
@@ -2127,24 +2127,24 @@
     "sourcesCount": "仓库",
     "status": {
       "0": "Not Started",
-      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
       "1": "In Progress",
-      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
       "2": "Pending Review",
-      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
       "3": "Remediation Required",
-      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
       "4": "Remediation In Progress",
-      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
       "5": "Verification Pending",
-      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
       "6": "Approved",
-      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
       "7": "Rejected",
-      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
       "8": "Deferred",
-      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9": "Closed",
+      "0.tooltip": "The security review has been initiated but no assessment activities have begun.",
+      "1.tooltip": "Active assessment is underway, including threat modeling, code review, or testing.",
+      "2.tooltip": "Assessment artifacts (e.g., reports, findings) await formal review by security leads or approvers.",
+      "3.tooltip": "Vulnerabilities or issues have been identified; development must address them.",
+      "4.tooltip": "Fixes for identified issues are being implemented by the development team.",
+      "5.tooltip": "Remediation is complete; security team must verify effectiveness.",
+      "6.tooltip": "All issues are resolved and verified; the application meets security criteria for release or deployment.",
+      "7.tooltip": "The review failed critical criteria; significant rework is required before re-submission.",
+      "8.tooltip": "The review is paused (e.g., due to resource constraints or application changes); resumption is planned.",
       "9.tooltip": "The review is fully completed and archived, with no further action needed.",
       "active": "活跃",
       "active.tooltip": "威胁模型正在被积极处理中。",
@@ -2177,7 +2177,7 @@
       "addAsset": "添加资产...",
       "addDiagram": "添加图表...",
       "addDocument": "添加文档...",
-      "addNote": "{{triage.detail.addNote}}",
+      "addNote": "{{triage.detail.addNote}}...",
       "assetsCardTitle": "资产是系统内需要保护的宝贵资源，例如数据、硬件、软件、基础设施、服务或人员",
       "diagramsCardTitle": "TMI 中的图表是系统内数据流动和处理过程的机器可读表示，支持手动和自动化安全分析",
       "documentsCardTitle": "文档引用是指向存储在 TMI 外部的文档的链接。相关文档描述要分析的系统，可供安全分析师和自动化分析流程使用",


### PR DESCRIPTION
Resolves two classes of warnings surfaced during the Dependabot cleanup.

## 1. `@angular/animations` deprecation (`refactor`)

`@angular/animations` is deprecated in Angular 22. It was in the tree **only because tmi-ux declared it directly** — it's an optional peer of `@angular/platform-browser` that nothing else requires (Angular Material v22 animates via CSS and does not depend on it).

- Migrated the two `detailExpand` triggers (`dashboard`, `reviewer-assignment-list`) to a pure-CSS enter animation (max-height + opacity keyframe, 225ms, same easing) on the existing classes.
- Removed the app-wide `provideAnimations()` and dropped `@angular/animations` from `package.json`; regenerated the lockfile → the optional peer is no longer resolved and the deprecation warning is gone.
- **Tradeoff:** the expandable rows animate on enter only; collapse is now instant (pure CSS cannot defer `@if` element removal). Verified zero synthetic animation properties remain anywhere.

## 2. i18n ellipsis lint warnings (`fix`)

The i18n style checker flags button/menu-item/tooltip keys whose click handler opens a `MatDialog` as needing a trailing ellipsis. All **23** candidates resolved using the project's established pattern (matching the existing `teams.kebab.members` convention):

- **Wrapper keys** — append `...` across all 16 locales + the en-US `<key>.lint-skip` sibling the period rule requires: `projects.kebab.*`, `teams.kebab.*`, `cwePicker.chooseCwe`, `threatModels.tooltips.addNote`, `admin.{addons,groups,settings,webhooks}.addButton`, `admin.users.createAutomationUser`. Most are `{{ref}}` interpolations, so the `...` is language-independent (no translation) and the referenced dialog-title keys stay clean.
- **`common.permissions`** (literal) — changed to `Permissions...`, deleted from the other 15 locales, and re-localized from the master. pt-BR also picked up a missing diacritic (`Permissoes` → `Permissões`).
- **Shared base keys** that cannot take a global ellipsis (dedicated wrappers carry it) get a `.lint-skip` marker instead: `common.{actions,create,delete,edit}` and the three metadata/threats labels that double as dialog titles (`common.{manageMetadata,manageThreats,viewMetadata}`).

`i18n style check: OK` (0 ellipsis warnings).

## Verification

- `pnpm run build` ✅
- `pnpm test` — 302 files, 5973 tests ✅
- `pnpm run lint:all` ✅ (i18n style check OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EW56ruGHRvag3UkgBXF7pc