### PR TITLE
chore: point dev API URL at LAN host

### DIFF
--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -8,7 +8,7 @@ export const environment: Environment = {
   production: false,
   logLevel: 'DEBUG', // Most verbose logging in development
   debugComponents: ['websocket-api', 'websocket-adapter'], // Enable component-specific debug logging for WebSocket messages
-  apiUrl: 'http://localhost:8080',
+  apiUrl: 'http://192.168.1.2:8080',
   authTokenExpiryMinutes: 1440, // 24 hours for easier development
   operatorName: 'Local development',
   operatorContact: '',


### PR DESCRIPTION
Changes `environment.dev.ts` `apiUrl` from `http://localhost:8080` to `http://192.168.1.2:8080` so dev builds reach the TMI server over the LAN.

Validated: build, tests, and lint all passed with this change in the working tree (run during the #778 dependency bump validation).

Note: `src/environments/` changes are excluded from automatic version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016owDGDfY15y6SQB5vgS1nB