### PR TITLE
chore: call prettier binary directly in auto-format hook

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -56,7 +56,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd /Users/efitz/Projects/tmi-ux && jq -r '.tool_response.filePath // .tool_input.file_path' | { read -r f; case \"$f\" in /Users/efitz/Projects/tmi-ux/*) pnpm exec prettier --write --ignore-unknown \"$f\";; esac; } 2>/dev/null || true",
+            "command": "cd /Users/efitz/Projects/tmi-ux && jq -r '.tool_response.filePath // .tool_input.file_path' | { read -r f; case \"$f\" in /Users/efitz/Projects/tmi-ux/*) node_modules/.bin/prettier --write --ignore-unknown \"$f\";; esac; } 2>/dev/null || true",
             "statusMessage": "Auto-formatting..."
           }
         ]


### PR DESCRIPTION
## Summary
- The PostToolUse auto-format hook in `.claude/settings.local.json` invoked prettier via `pnpm exec`, whose corepack shim performs an npm-registry version check that stalls ~9s on every Edit/Write in the hook execution environment (measured: ~9.2s avg over 68 runs).
- Switch to calling `node_modules/.bin/prettier` directly — same single-file format, ~25ms.

## Testing
- Pipe-tested the hook command with a real payload (`src/app/app.component.ts`): formatted in 25ms, no spurious diff.
- `jq -e` schema check on the hooks config passes; `pnpm run lint:all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uJmUjWwNDyi3cVqMZfqEr