### PR TITLE
feat: deploy tmi-ux to AWS (S3 + CloudFront) at app.aws.tmi.dev

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -205,6 +205,27 @@
                 }
               ]
             },
+            "aws": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "2.5MB",
+                  "maximumError": "3MB"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "20kB",
+                  "maximumError": "25kB"
+                }
+              ],
+              "outputHashing": "all",
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.aws.ts"
+                }
+              ]
+            },
             "oci": {
               "budgets": [
                 {

--- a/docs/reference/aws-deployment.md
+++ b/docs/reference/aws-deployment.md
@@ -15,8 +15,11 @@ All commands use the `tmi` AWS profile.
 
 ```bash
 pnpm run deploy:aws                 # build + deploy
-pnpm run deploy:aws -- --no-build   # deploy the existing dist/
+bash scripts/deploy-aws.sh --no-build   # deploy the existing dist/
 ```
+
+(Call the script directly to pass `--no-build`; `pnpm run deploy:aws -- --no-build`
+forwards the `--` to the script as a literal argument on this pnpm version.)
 
 ## Change infrastructure
 

--- a/docs/reference/aws-deployment.md
+++ b/docs/reference/aws-deployment.md
@@ -40,9 +40,36 @@ AWS_PROFILE=tmi terraform apply
 
 State lives at `tmi-ux/aws-public/terraform.tfstate` in
 `s3://tmi-tfstate-967218005408` — separate from the tmi server repo's state
-(`tmi/aws-public/…`), so this stack can be applied and destroyed independently.
+(`tmi/aws-public/…`), so this stack is applied independently of the server's.
 If a plan ever shows resources to **change or destroy** that you did not edit,
 stop: it means the backend key is resolving to the server's state.
+
+### Destroying the stack
+
+`terraform destroy` does **not** work on its own. The content bucket has no
+`force_destroy` and is versioned, so destroy fails with `BucketNotEmpty`. That
+is deliberate: versioning exists so a bad deploy can be rolled back, and an
+accidental destroy should not silently discard it. Empty it first — including
+noncurrent versions and delete markers:
+
+```bash
+BUCKET="$(cd terraform/aws && AWS_PROFILE=tmi terraform output -raw content_bucket)"
+AWS_PROFILE=tmi aws s3api delete-objects --bucket "$BUCKET" \
+  --delete "$(AWS_PROFILE=tmi aws s3api list-object-versions --bucket "$BUCKET" \
+    --output json --query '{Objects: Versions[].{Key:Key,VersionId:VersionId}}')"
+AWS_PROFILE=tmi aws s3api delete-objects --bucket "$BUCKET" \
+  --delete "$(AWS_PROFILE=tmi aws s3api list-object-versions --bucket "$BUCKET" \
+    --output json --query '{Objects: DeleteMarkers[].{Key:Key,VersionId:VersionId}}')"
+cd terraform/aws && AWS_PROFILE=tmi terraform destroy
+```
+
+(Repeat the two `delete-objects` calls if the bucket holds more than 1000
+versions; `list-object-versions` pages at 1000.) The log bucket sets
+`force_destroy = true` — access logs are disposable — so it needs no such step.
+
+Unbounded growth is bounded by lifecycle rules on the content bucket:
+noncurrent versions expire after 30 days and incomplete multipart uploads are
+aborted after 7.
 
 `terraform init` warns that the backend's `dynamodb_table` argument is
 deprecated in favour of S3 native locking (`use_lockfile = true`). The argument
@@ -52,10 +79,33 @@ not unilaterally here.
 ## Caching model
 
 `outputHashing: "all"` hashes only build-emitted files. `public/` and
-`src/assets/` ship under stable names, so the deploy script uses three passes:
+`src/assets/` ship under stable names, so the deploy script uploads in classes:
 stable names get one hour, hashed output gets a year `immutable`, and
 `index.html` / `config.json` get `no-store`. The `/*` invalidation exists for
 the stable-named assets.
+
+The pass **order** is load-bearing and must not be collapsed into a single
+`sync --delete`: new hashed bundles are uploaded first with no deletion, then
+`index.html` cuts over to them, and only then does a final pass prune keys the
+build no longer produces. Deleting first would leave the origin serving an
+`index.html` whose bundles are gone; CloudFront rewrites those 403s to
+`/index.html` with a 200, so the browser gets HTML where JavaScript is expected
+and fails with `Uncaught SyntaxError: Unexpected token '<'`.
+
+After invalidating, the script waits for the invalidation to complete and then
+asserts that `/` and one hashed bundle referenced by the new `index.html` both
+return 200 with the expected content type, so a broken deploy cannot exit 0.
+
+`config.json` is **rewritten to `{}` and re-uploaded on every deploy**. It
+exists only so the pre-bootstrap fetch in `src/main.ts` gets valid JSON instead
+of the SPA fallback's HTML. It is not a durable override hook — anything
+hand-edited into it in S3 is lost on the next deploy. Configure this deployment
+in `src/environments/environment.aws.ts` instead.
+
+`deploy-aws.sh` refuses to upload a `dist/` that does not reference
+`server.aws.tmi.dev`. Every build configuration emits to the same
+`dist/tmi-ux/browser`, so without that check `--no-build` would happily publish
+a `build:prod` or `build:test` output pointed at the wrong API.
 
 Verified behaviour of the bare domain `/`: it returns `cache-control: no-store`
 and CloudFront does not cache it at the edge (repeated requests report
@@ -76,8 +126,17 @@ directives to the CloudFront policy** — a directive narrower than the app's
 silently breaks the Google Drive and OneDrive pickers. `frame-ancestors` is the
 exception: meta-tag CSPs ignore it, so the edge is the only place it can be set.
 
-`environment.aws.ts`'s `securityConfig` block mirrors these headers and is
-guarded by `environment.aws.spec.ts`. If you change one, change both.
+`environment.aws.ts`'s `securityConfig` block is a hand-maintained copy of
+these headers. Nothing enforces it: it feeds only
+`generateRecommendedHeaders()` in
+`src/app/core/services/security-config.service.ts`, which publishes an advisory
+observable. Drift is a reporting inaccuracy, not a security regression.
+
+`environment.aws.spec.ts` compares that block against a literal in the same
+repo, so it catches edits to `environment.aws.ts` but is blind to edits of
+`cloudfront.tf` — which is the direction that actually changes what browsers
+receive. Treat it as a change-detector on the copy, not as verification of the
+edge. If you change either file, change both by hand.
 
 Known gap: the meta tag is injected during Angular bootstrap, so it does not
 cover the initial document parse (the Font Awesome and Google Fonts links in
@@ -116,7 +175,8 @@ can read it. A `200` would mean the bucket has gone public.
 
 ```bash
 AWS_PROFILE=tmi aws cloudfront get-invalidation \
-  --distribution-id EDFBI6U9CTWU7 --id <invalidation-id>
+  --distribution-id "$(cd terraform/aws && AWS_PROFILE=tmi terraform output -raw distribution_id)" \
+  --id <invalidation-id>
 ```
 
 **Login fails / callback rejected.** See "Server dependency" above.

--- a/docs/reference/aws-deployment.md
+++ b/docs/reference/aws-deployment.md
@@ -1,0 +1,129 @@
+# AWS deployment (app.aws.tmi.dev)
+
+The tmi-ux SPA is served from S3 + CloudFront in AWS account `967218005408`
+(`us-east-1`), against the TMI server at `https://server.aws.tmi.dev`.
+
+All commands use the `tmi` AWS profile.
+
+## Layout
+
+- `terraform/aws/` — S3 buckets, CloudFront, ACM, Route 53
+- `scripts/deploy-aws.sh` — build, sync, invalidate
+- `src/environments/environment.aws.ts` — compiled-in config
+
+## Deploy
+
+```bash
+pnpm run deploy:aws                 # build + deploy
+pnpm run deploy:aws -- --no-build   # deploy the existing dist/
+```
+
+## Change infrastructure
+
+`backend.hcl` is **not** in version control (matching the tmi repo's
+`**/backend.hcl` rule). Recreate `terraform/aws/backend.hcl` on a fresh clone:
+
+```hcl
+bucket         = "tmi-tfstate-967218005408"
+region         = "us-east-1"
+dynamodb_table = "tmi-tf-locks"
+```
+
+Then:
+
+```bash
+cd terraform/aws
+AWS_PROFILE=tmi terraform init -backend-config=backend.hcl   # first time only
+AWS_PROFILE=tmi terraform plan
+AWS_PROFILE=tmi terraform apply
+```
+
+State lives at `tmi-ux/aws-public/terraform.tfstate` in
+`s3://tmi-tfstate-967218005408` — separate from the tmi server repo's state
+(`tmi/aws-public/…`), so this stack can be applied and destroyed independently.
+If a plan ever shows resources to **change or destroy** that you did not edit,
+stop: it means the backend key is resolving to the server's state.
+
+`terraform init` warns that the backend's `dynamodb_table` argument is
+deprecated in favour of S3 native locking (`use_lockfile = true`). The argument
+still works; migrating is a deliberate decision to make alongside the tmi repo,
+not unilaterally here.
+
+## Caching model
+
+`outputHashing: "all"` hashes only build-emitted files. `public/` and
+`src/assets/` ship under stable names, so the deploy script uses three passes:
+stable names get one hour, hashed output gets a year `immutable`, and
+`index.html` / `config.json` get `no-store`. The `/*` invalidation exists for
+the stable-named assets.
+
+Verified behaviour of the bare domain `/`: it returns `cache-control: no-store`
+and CloudFront does not cache it at the edge (repeated requests report
+`x-cache: Miss from cloudfront`). This was checked explicitly because a request
+for `/` does not obviously match the ordered `/index.html` cache behaviour —
+the origin object's own `no-store` header governs, and `Managed-CachingOptimized`
+honours it.
+
+## Security headers
+
+CloudFront sends HSTS, `nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy`,
+`Permissions-Policy`, and a CSP of **`frame-ancestors 'none'` only**.
+
+The app injects its own complete CSP at runtime (`SecurityConfigService`),
+built from `environment.apiUrl` and the `CONTENT_PROVIDERS` registry. Two CSPs
+on one document are enforced as an intersection, so **do not add fetch
+directives to the CloudFront policy** — a directive narrower than the app's
+silently breaks the Google Drive and OneDrive pickers. `frame-ancestors` is the
+exception: meta-tag CSPs ignore it, so the edge is the only place it can be set.
+
+`environment.aws.ts`'s `securityConfig` block mirrors these headers and is
+guarded by `environment.aws.spec.ts`. If you change one, change both.
+
+Known gap: the meta tag is injected during Angular bootstrap, so it does not
+cover the initial document parse (the Font Awesome and Google Fonts links in
+`index.html`). Closing that means baking a static CSP into `index.html` at
+build time.
+
+## Server dependency
+
+The server must allowlist this origin's OAuth callbacks, via
+`TMI_OAUTH_CLIENT_CALLBACK_ALLOWLIST=https://app.aws.tmi.dev/*` in the
+`tmi-server-config` ConfigMap (namespace `tmi-platform`). The allowlist is
+fail-closed: unset means every callback is rejected and login fails. The
+ConfigMap is Terraform-owned in the tmi repo and consumed via `envFrom`, so it
+needs `kubectl -n tmi-platform rollout restart deployment/tmi-server`.
+
+Optional hardening: `TMI_CORS_ALLOWED_ORIGINS` is unset, so the server reflects
+any `Origin` back with `access-control-allow-credentials: true`. Setting it
+switches the server from reflect-all to allowlist-only, so it must list every
+origin in use, not just this one.
+
+## Troubleshooting
+
+**Blank app, HTTP 200.** The distribution maps origin 403/404 to `/index.html`
+with a 200 for SPA routing, which also masks a broken origin. Check the S3
+origin directly before trusting the CloudFront response:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' \
+  https://tmi-ux-app-967218005408.s3.amazonaws.com/index.html
+```
+
+`403` is correct and expected — the bucket is private and only the distribution
+can read it. A `200` would mean the bucket has gone public.
+
+**Stale assets after deploy.** Confirm the invalidation completed:
+
+```bash
+AWS_PROFILE=tmi aws cloudfront get-invalidation \
+  --distribution-id EDFBI6U9CTWU7 --id <invalidation-id>
+```
+
+**Login fails / callback rejected.** See "Server dependency" above.
+
+## Cost
+
+ACM is free and the Route 53 zone already existed. At this traffic level the
+distribution, bucket and logs run in the low single digits of dollars per month.
+`PriceClass_100` restricts edges to North America and Europe; viewers elsewhere
+still work, with higher latency.

--- a/docs/superpowers/plans/2026-07-22-tmi-ux-aws-deployment.md
+++ b/docs/superpowers/plans/2026-07-22-tmi-ux-aws-deployment.md
@@ -1,0 +1,1185 @@
+# tmi-ux AWS Deployment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Serve the tmi-ux Angular SPA from S3 + CloudFront at `https://app.aws.tmi.dev` with ACM TLS, against the existing TMI server at `https://server.aws.tmi.dev`.
+
+**Architecture:** Pure static hosting. A new `aws` Angular build configuration bakes the API URL into the bundle; Terraform in this repo (separate state from the tmi server repo) provisions a private S3 bucket fronted by CloudFront with Origin Access Control, an ACM certificate, and Route 53 alias records. A manual shell script builds, syncs to S3 in three cache-control passes, and invalidates. `server.js` is not used.
+
+**Tech Stack:** Angular 22 / pnpm / Vitest, Terraform 1.15 + AWS provider 5.x, AWS S3 + CloudFront + ACM + Route 53.
+
+**Spec:** `docs/superpowers/specs/2026-07-22-tmi-ux-aws-deployment-design.md`
+
+## Global Constraints
+
+Every task's requirements implicitly include this section. Values are exact — do not paraphrase.
+
+- AWS profile: **`tmi`**. Every `aws` and `terraform` command runs with `AWS_PROFILE=tmi`.
+- AWS account: **`967218005408`**. Region: **`us-east-1`** (required — CloudFront viewer certificates must live in us-east-1).
+- Hostname: **`app.aws.tmi.dev`**. API origin: **`https://server.aws.tmi.dev`**.
+- Route 53 hosted zone ID: **`Z05646533D2YL1I678JXS`** (`aws.tmi.dev`).
+- Terraform state: bucket **`tmi-tfstate-967218005408`**, key **`tmi/aws-public/terraform.tfstate`** is the _server's_ — ours is **`tmi-ux/aws-public/terraform.tfstate`**. Lock table **`tmi-tf-locks`**.
+- S3 buckets: content **`tmi-ux-app-967218005408`**, logs **`tmi-ux-logs-967218005408`**.
+- CloudFront price class: **`PriceClass_100`**. Access logging: **on**, retention **30 days**.
+- Edge CSP is **`frame-ancestors 'none'` and nothing else** — see the spec's "Why the edge CSP is frame-ancestors only". Do not add fetch directives at the edge under any circumstances; the app injects its own CSP at runtime and two CSPs intersect.
+- Conventional Commits. Run `pnpm run lint:all` before any commit touching `src/`, `angular.json`, or `package.json`.
+- Work on a branch, not `main`.
+
+## File Structure
+
+| File                                       | Responsibility                                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------------- |
+| `src/environments/environment.aws.ts`      | Compiled-in config for the AWS deployment                                       |
+| `src/environments/environment.aws.spec.ts` | Guards the environment/infrastructure contract against drift                    |
+| `angular.json`                             | Adds the `aws` build configuration (`fileReplacements`)                         |
+| `package.json`                             | Adds the `build:aws` script                                                     |
+| `terraform/aws/versions.tf`                | Terraform + provider version constraints, S3 backend block                      |
+| `terraform/aws/backend.hcl`                | Backend bucket/region/lock table (committed, matches tmi's pattern)             |
+| `terraform/aws/variables.tf`               | Inputs with defaults for every Global Constraint value                          |
+| `terraform/aws/buckets.tf`                 | Content bucket and log bucket, with their hardening resources                   |
+| `terraform/aws/certificate.tf`             | ACM certificate + Route 53 DNS validation                                       |
+| `terraform/aws/cloudfront.tf`              | OAC, cache/response-header policies, distribution, content bucket policy        |
+| `terraform/aws/dns.tf`                     | A + AAAA alias records for `app.aws.tmi.dev`                                    |
+| `terraform/aws/outputs.tf`                 | `content_bucket`, `distribution_id`, `site_url` — consumed by the deploy script |
+| `terraform/aws/.gitignore`                 | Excludes `.terraform/`, `*.tfstate*`, `*.tfvars`                                |
+| `scripts/deploy-aws.sh`                    | Build + three-pass sync + invalidation                                          |
+| `docs/reference/aws-deployment.md`         | Runbook                                                                         |
+
+Terraform files split by responsibility rather than dumped in one `main.tf`, matching the file-per-concern layout the tmi repo uses in `terraform/modules/kubernetes/aws/`.
+
+---
+
+### Task 1: Angular `aws` build configuration
+
+**Files:**
+
+- Create: `src/environments/environment.aws.ts`
+- Create: `src/environments/environment.aws.spec.ts`
+- Modify: `angular.json` (add `aws` to `projects.tmi-ux.architect.build.configurations`)
+- Modify: `package.json` (add `build:aws` to `scripts`)
+
+**Interfaces:**
+
+- Consumes: `Environment` from `src/environments/environment.interface.ts`.
+- Produces: build output at `dist/tmi-ux/browser` via `pnpm run build:aws`. Task 6's deploy script depends on that exact path and script name.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/environments/environment.aws.spec.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+
+import { environment } from './environment.aws';
+
+describe('AWS deployment environment', () => {
+  it('is a production build so runtime config and CSP injection are active', () => {
+    expect(environment.production).toBe(true);
+  });
+
+  it('points at the deployed TMI server', () => {
+    expect(environment.apiUrl).toBe('https://server.aws.tmi.dev');
+  });
+
+  it('has no trailing slash on apiUrl', () => {
+    // SecurityConfigService derives the CSP connect-src origin from this value
+    // via `new URL(environment.apiUrl).origin`; a trailing slash is silently
+    // tolerated there but breaks naive string concatenation elsewhere.
+    expect(environment.apiUrl.endsWith('/')).toBe(false);
+  });
+
+  it('declares exactly the security headers CloudFront is configured to send', () => {
+    // Mirrors terraform/aws/cloudfront.tf. If you change one, change both:
+    // this object is what the app reports about itself, not what is enforced.
+    expect(environment.securityConfig).toEqual({
+      enableHSTS: true,
+      hstsMaxAge: 31536000,
+      hstsIncludeSubDomains: true,
+      hstsPreload: false,
+      frameOptions: 'DENY',
+      referrerPolicy: 'strict-origin-when-cross-origin',
+      permissionsPolicy: 'camera=(), microphone=(), geolocation=()',
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm exec vitest run src/environments/environment.aws.spec.ts
+```
+
+Expected: FAIL — `Failed to resolve import "./environment.aws"`.
+
+- [ ] **Step 3: Create the environment file**
+
+Create `src/environments/environment.aws.ts`:
+
+```ts
+/**
+ * AWS Environment Configuration
+ *
+ * Used by the S3 + CloudFront deployment at https://app.aws.tmi.dev.
+ * See docs/reference/aws-deployment.md and terraform/aws/.
+ *
+ * The securityConfig block below is what the application reports about its own
+ * posture; the headers are actually emitted by the CloudFront response-headers
+ * policy in terraform/aws/cloudfront.tf. Keep the two in sync.
+ */
+
+import { Environment } from './environment.interface';
+
+export const environment: Environment = {
+  production: true,
+  logLevel: 'INFO',
+  apiUrl: 'https://server.aws.tmi.dev',
+  authTokenExpiryMinutes: 60,
+  operatorName: 'TMI Project (AWS Demo)',
+  operatorContact: 'https://github.com/ericfitz/tmi/discussions',
+  operatorJurisdiction: 'Florida, United States of America',
+  securityConfig: {
+    enableHSTS: true,
+    hstsMaxAge: 31536000, // 1 year
+    hstsIncludeSubDomains: true,
+    hstsPreload: false,
+    frameOptions: 'DENY',
+    referrerPolicy: 'strict-origin-when-cross-origin',
+    permissionsPolicy: 'camera=(), microphone=(), geolocation=()',
+  },
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm exec vitest run src/environments/environment.aws.spec.ts
+```
+
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Add the `aws` build configuration**
+
+In `angular.json`, inside `projects.tmi-ux.architect.build.configurations`, add a sibling to `hosted-container`:
+
+```json
+"aws": {
+  "budgets": [
+    {
+      "type": "initial",
+      "maximumWarning": "2.5MB",
+      "maximumError": "3MB"
+    },
+    {
+      "type": "anyComponentStyle",
+      "maximumWarning": "20kB",
+      "maximumError": "25kB"
+    }
+  ],
+  "outputHashing": "all",
+  "fileReplacements": [
+    {
+      "replace": "src/environments/environment.ts",
+      "with": "src/environments/environment.aws.ts"
+    }
+  ]
+}
+```
+
+In `package.json`, add to `scripts` immediately after `"build:test"`:
+
+```json
+"build:aws": "ng build --configuration=aws",
+```
+
+- [ ] **Step 6: Verify the build produces the expected output**
+
+```bash
+pnpm run build:aws
+ls dist/tmi-ux/browser/index.html
+grep -c "server.aws.tmi.dev" dist/tmi-ux/browser/*.js
+```
+
+Expected: build succeeds; `index.html` exists; the grep reports at least one match in at least one bundle, confirming `fileReplacements` took effect. If the grep finds zero matches the configuration is wired wrong — do not proceed.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+pnpm run lint:all
+git add src/environments/environment.aws.ts src/environments/environment.aws.spec.ts angular.json package.json
+git commit -m "feat: add aws build configuration for app.aws.tmi.dev"
+```
+
+---
+
+### Task 2: Terraform skeleton and S3 buckets
+
+**Files:**
+
+- Create: `terraform/aws/versions.tf`, `terraform/aws/backend.hcl`, `terraform/aws/variables.tf`, `terraform/aws/buckets.tf`, `terraform/aws/.gitignore`
+
+**Interfaces:**
+
+- Produces: `aws_s3_bucket.content` and `aws_s3_bucket.logs`. Task 4 references `aws_s3_bucket.content.bucket_regional_domain_name`, `aws_s3_bucket.content.arn`, `aws_s3_bucket.content.id`, and `aws_s3_bucket.logs.bucket_domain_name`. Variables `var.domain_name`, `var.hosted_zone_id`, `var.content_bucket_name`, `var.log_retention_days`, `var.price_class`, `var.tags` are consumed by Tasks 3 and 4.
+
+- [ ] **Step 1: Create `terraform/aws/.gitignore`**
+
+```gitignore
+.terraform/
+.terraform.lock.hcl.bak
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example
+crash.log
+```
+
+- [ ] **Step 2: Create `terraform/aws/versions.tf`**
+
+```hcl
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+
+  # Remote, encrypted state. Bucket / region / lock table come from
+  # backend.hcl so the state location stays per-deployer, while the key and
+  # encryption flag are pinned here. Deliberately a DIFFERENT key from the
+  # tmi server repo's "tmi/aws-public/terraform.tfstate" so UI infrastructure
+  # can be planned, applied and destroyed without touching server state.
+  #
+  #   terraform init -backend-config=backend.hcl
+  backend "s3" {
+    key     = "tmi-ux/aws-public/terraform.tfstate"
+    encrypt = true
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.tags
+  }
+}
+```
+
+- [ ] **Step 3: Create `terraform/aws/backend.hcl`**
+
+```hcl
+bucket         = "tmi-tfstate-967218005408"
+region         = "us-east-1"
+dynamodb_table = "tmi-tf-locks"
+```
+
+> If `terraform init` emits a deprecation warning for `dynamodb_table` (Terraform 1.11+ prefers S3 native locking via `use_lockfile = true`), that warning is benign — the argument still functions. Leave it as-is for consistency with the tmi repo's backend; changing the locking mechanism is a deliberate decision to raise separately, not to make silently here.
+
+- [ ] **Step 4: Create `terraform/aws/variables.tf`**
+
+```hcl
+variable "aws_region" {
+  description = "AWS region. Must be us-east-1: CloudFront viewer certificates are only read from us-east-1."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "domain_name" {
+  description = "Public hostname for the tmi-ux SPA."
+  type        = string
+  default     = "app.aws.tmi.dev"
+}
+
+variable "hosted_zone_id" {
+  description = "Route 53 hosted zone ID for aws.tmi.dev."
+  type        = string
+  default     = "Z05646533D2YL1I678JXS"
+}
+
+variable "content_bucket_name" {
+  description = "S3 bucket holding the built SPA. Private; reached only via CloudFront OAC."
+  type        = string
+  default     = "tmi-ux-app-967218005408"
+}
+
+variable "log_bucket_name" {
+  description = "S3 bucket for CloudFront standard access logs."
+  type        = string
+  default     = "tmi-ux-logs-967218005408"
+}
+
+variable "log_retention_days" {
+  description = "Days before CloudFront access logs expire."
+  type        = number
+  default     = 30
+}
+
+variable "price_class" {
+  description = "CloudFront price class. PriceClass_100 is North America + Europe edges only."
+  type        = string
+  default     = "PriceClass_100"
+}
+
+variable "tags" {
+  description = "Tags applied to every resource via the provider's default_tags."
+  type        = map(string)
+  default = {
+    Project   = "tmi"
+    Component = "tmi-ux"
+    ManagedBy = "terraform"
+  }
+}
+```
+
+- [ ] **Step 5: Create `terraform/aws/buckets.tf`**
+
+```hcl
+# ---------------------------------------------------------------------------
+# Content bucket: the built SPA. Private in every respect — no website
+# hosting, no public ACLs, no public policy. CloudFront reaches it via Origin
+# Access Control (see cloudfront.tf), which is also where its bucket policy
+# lives, because that policy must reference the distribution ARN.
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "content" {
+  bucket = var.content_bucket_name
+}
+
+resource "aws_s3_bucket_public_access_block" "content" {
+  bucket                  = aws_s3_bucket.content.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "content" {
+  bucket = aws_s3_bucket.content.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "content" {
+  bucket = aws_s3_bucket.content.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "content" {
+  bucket = aws_s3_bucket.content.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Log bucket: CloudFront standard (legacy) logging delivers via S3 ACLs, which
+# is incompatible with BucketOwnerEnforced. This bucket therefore enables ACLs
+# — the single place this deployment relaxes a security default, and it
+# applies only to logs. CloudFront adds the awslogsdelivery grant itself; the
+# public access block stays fully on because that grant is not a public ACL.
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "logs" {
+  bucket = var.log_bucket_name
+}
+
+resource "aws_s3_bucket_public_access_block" "logs" {
+  bucket                  = aws_s3_bucket.logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "logs" {
+  bucket = aws_s3_bucket.logs.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    id     = "expire-access-logs"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = var.log_retention_days
+    }
+  }
+}
+```
+
+- [ ] **Step 6: Initialize and validate**
+
+```bash
+cd terraform/aws
+AWS_PROFILE=tmi terraform init -backend-config=backend.hcl
+AWS_PROFILE=tmi terraform fmt -check
+AWS_PROFILE=tmi terraform validate
+```
+
+Expected: `init` succeeds against the existing state bucket; `fmt -check` prints nothing; `validate` prints "Success! The configuration is valid."
+
+- [ ] **Step 7: Plan and confirm the blast radius**
+
+```bash
+AWS_PROFILE=tmi terraform plan
+```
+
+Expected: **10 to add, 0 to change, 0 to destroy** — two buckets plus their public-access-block, ownership-controls, encryption, versioning (content only) and lifecycle (logs only) resources. Any `destroy` or `change` in this plan means the state key is wrong and you are looking at the server's state — stop and re-check `versions.tf`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd ../..
+git add terraform/aws/
+git commit -m "feat: add terraform skeleton and S3 buckets for tmi-ux hosting"
+```
+
+---
+
+### Task 3: ACM certificate and DNS validation
+
+**Files:**
+
+- Create: `terraform/aws/certificate.tf`
+
+**Interfaces:**
+
+- Consumes: `var.domain_name`, `var.hosted_zone_id` from Task 2.
+- Produces: `aws_acm_certificate_validation.this.certificate_arn`. Task 4's `viewer_certificate` block depends on it — depend on the _validation_ resource, not the certificate, so the distribution is not created before the certificate is usable.
+
+- [ ] **Step 1: Create `terraform/aws/certificate.tf`**
+
+```hcl
+# Viewer certificate for the CloudFront distribution. Must be in us-east-1
+# regardless of where anything else lives — CloudFront reads viewer certs only
+# from that region. The provider is already pinned there via var.aws_region.
+
+resource "aws_acm_certificate" "this" {
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "certificate_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id         = var.hosted_zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 60
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "this" {
+  certificate_arn         = aws_acm_certificate.this.arn
+  validation_record_fqdns = [for record in aws_route53_record.certificate_validation : record.fqdn]
+}
+```
+
+- [ ] **Step 2: Validate**
+
+```bash
+cd terraform/aws
+AWS_PROFILE=tmi terraform fmt -check
+AWS_PROFILE=tmi terraform validate
+```
+
+Expected: no output from `fmt -check`; "Success!" from `validate`.
+
+- [ ] **Step 3: Plan**
+
+```bash
+AWS_PROFILE=tmi terraform plan
+```
+
+Expected: 3 more resources to add than Task 2's plan (certificate, one validation record, one validation gate) — **13 to add, 0 to change, 0 to destroy**. The existing `server.aws.tmi.dev` certificate and its validation CNAME must not appear anywhere in the plan.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ../..
+git add terraform/aws/certificate.tf
+git commit -m "feat: add ACM certificate with DNS validation for app.aws.tmi.dev"
+```
+
+---
+
+### Task 4: CloudFront distribution, OAC, and DNS
+
+**Files:**
+
+- Create: `terraform/aws/cloudfront.tf`, `terraform/aws/dns.tf`, `terraform/aws/outputs.tf`
+
+**Interfaces:**
+
+- Consumes: `aws_s3_bucket.content`, `aws_s3_bucket.logs` (Task 2); `aws_acm_certificate_validation.this` (Task 3).
+- Produces: outputs `content_bucket` (string, bucket name), `distribution_id` (string), `site_url` (string). Task 6's deploy script reads all three via `terraform output -raw`.
+
+- [ ] **Step 1: Create `terraform/aws/cloudfront.tf`**
+
+```hcl
+locals {
+  origin_id = "s3-${aws_s3_bucket.content.id}"
+}
+
+# Managed cache policies, looked up by name rather than hard-coded ID.
+data "aws_cloudfront_cache_policy" "caching_optimized" {
+  name = "Managed-CachingOptimized"
+}
+
+data "aws_cloudfront_cache_policy" "caching_disabled" {
+  name = "Managed-CachingDisabled"
+}
+
+resource "aws_cloudfront_origin_access_control" "this" {
+  name                              = "tmi-ux-oac"
+  description                       = "OAC for the tmi-ux content bucket"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# ---------------------------------------------------------------------------
+# Response headers.
+#
+# The Content-Security-Policy here is DELIBERATELY frame-ancestors only.
+# SecurityConfigService injects a complete, provider-aware CSP meta tag at
+# runtime, built from environment.apiUrl and the CONTENT_PROVIDERS registry
+# (which includes a https://*.sharepoint.com wildcard and origins the server
+# supplies at runtime). A second CSP is enforced as an INTERSECTION with the
+# first, so any fetch directive added here that is narrower than the app's
+# will silently break the Google Drive / OneDrive pickers. frame-ancestors is
+# safe to add — and necessary — because meta-tag CSPs ignore it entirely, so
+# it is currently enforced nowhere.
+#
+# See docs/superpowers/specs/2026-07-22-tmi-ux-aws-deployment-design.md.
+# ---------------------------------------------------------------------------
+resource "aws_cloudfront_response_headers_policy" "this" {
+  name = "tmi-ux-security-headers"
+
+  security_headers_config {
+    content_security_policy {
+      content_security_policy = "frame-ancestors 'none'"
+      override                = true
+    }
+
+    content_type_options {
+      override = true
+    }
+
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+
+    referrer_policy {
+      referrer_policy = "strict-origin-when-cross-origin"
+      override        = true
+    }
+
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = true
+      preload                    = false
+      override                   = true
+    }
+  }
+
+  custom_headers_config {
+    items {
+      header   = "Permissions-Policy"
+      value    = "camera=(), microphone=(), geolocation=()"
+      override = true
+    }
+  }
+}
+
+resource "aws_cloudfront_distribution" "this" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "tmi-ux SPA"
+  default_root_object = "index.html"
+  aliases             = [var.domain_name]
+  price_class         = var.price_class
+  http_version        = "http2and3"
+
+  origin {
+    domain_name              = aws_s3_bucket.content.bucket_regional_domain_name
+    origin_id                = local.origin_id
+    origin_access_control_id = aws_cloudfront_origin_access_control.this.id
+  }
+
+  logging_config {
+    bucket          = aws_s3_bucket.logs.bucket_domain_name
+    prefix          = "cloudfront/"
+    include_cookies = false
+  }
+
+  default_cache_behavior {
+    target_origin_id           = local.origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD"]
+    compress                   = true
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_optimized.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+  }
+
+  # index.html and config.json are the two entry points that must never be
+  # served stale: index.html references hash-named bundles, and config.json is
+  # the no-rebuild override hook read by src/main.ts before bootstrap.
+  ordered_cache_behavior {
+    path_pattern               = "/index.html"
+    target_origin_id           = local.origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD"]
+    compress                   = true
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+  }
+
+  ordered_cache_behavior {
+    path_pattern               = "/config.json"
+    target_origin_id           = local.origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD"]
+    compress                   = true
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+  }
+
+  # SPA deep-link routing. With OAC, S3 returns 403 (not 404) for a missing
+  # key because the OAC principal has no s3:ListBucket. Known trade-off: this
+  # also renders the app shell when the origin is genuinely misconfigured, so
+  # when debugging a blank app, test the S3 origin directly before trusting
+  # a 200 from CloudFront.
+  custom_error_response {
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.this.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+}
+
+# Grants only this distribution read access to the content bucket.
+data "aws_iam_policy_document" "content" {
+  statement {
+    sid       = "AllowCloudFrontServicePrincipalReadOnly"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.content.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.this.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "content" {
+  bucket = aws_s3_bucket.content.id
+  policy = data.aws_iam_policy_document.content.json
+}
+```
+
+- [ ] **Step 2: Create `terraform/aws/dns.tf`**
+
+```hcl
+resource "aws_route53_record" "ipv4" {
+  zone_id = var.hosted_zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.this.domain_name
+    zone_id                = aws_cloudfront_distribution.this.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "ipv6" {
+  zone_id = var.hosted_zone_id
+  name    = var.domain_name
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.this.domain_name
+    zone_id                = aws_cloudfront_distribution.this.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+```
+
+- [ ] **Step 3: Create `terraform/aws/outputs.tf`**
+
+```hcl
+output "content_bucket" {
+  description = "Name of the S3 bucket holding the built SPA."
+  value       = aws_s3_bucket.content.id
+}
+
+output "distribution_id" {
+  description = "CloudFront distribution ID, used for cache invalidation."
+  value       = aws_cloudfront_distribution.this.id
+}
+
+output "site_url" {
+  description = "Public URL of the deployed SPA."
+  value       = "https://${var.domain_name}"
+}
+```
+
+- [ ] **Step 4: Validate and plan**
+
+```bash
+cd terraform/aws
+AWS_PROFILE=tmi terraform fmt -check
+AWS_PROFILE=tmi terraform validate
+AWS_PROFILE=tmi terraform plan
+```
+
+Expected: `validate` succeeds. Plan adds 6 more resources than Task 3 (OAC, response-headers policy, distribution, bucket policy, two Route 53 records) — **19 to add, 0 to change, 0 to destroy**. Confirm in the plan output that `content_security_policy` reads exactly `frame-ancestors 'none'`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ../..
+git add terraform/aws/cloudfront.tf terraform/aws/dns.tf terraform/aws/outputs.tf
+git commit -m "feat: add cloudfront distribution, OAC and DNS for app.aws.tmi.dev"
+```
+
+---
+
+### Task 5: Apply the infrastructure
+
+**Files:** none — this task runs Terraform and verifies the result.
+
+**Interfaces:**
+
+- Consumes: everything from Tasks 2–4.
+- Produces: a live distribution. Task 6 needs `terraform output -raw content_bucket` and `distribution_id` to resolve.
+
+- [ ] **Step 1: Apply**
+
+```bash
+cd terraform/aws
+AWS_PROFILE=tmi terraform apply
+```
+
+Review the plan once more before confirming. Expected: 19 resources created. The apply blocks on `aws_acm_certificate_validation` while DNS propagates (typically 2–5 minutes) and again on distribution deployment (5–15 minutes).
+
+- [ ] **Step 2: Verify the certificate issued**
+
+```bash
+AWS_PROFILE=tmi aws acm list-certificates --region us-east-1 \
+  --query "CertificateSummaryList[?DomainName=='app.aws.tmi.dev'].Status" --output text
+```
+
+Expected: `ISSUED`
+
+- [ ] **Step 3: Verify the distribution is deployed and DNS resolves**
+
+```bash
+AWS_PROFILE=tmi aws cloudfront get-distribution \
+  --id "$(AWS_PROFILE=tmi terraform output -raw distribution_id)" \
+  --query 'Distribution.Status' --output text
+dig +short app.aws.tmi.dev
+```
+
+Expected: `Deployed`; `dig` returns CloudFront edge addresses.
+
+- [ ] **Step 4: Confirm the bucket is not publicly reachable**
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' \
+  "https://tmi-ux-app-967218005408.s3.amazonaws.com/index.html"
+```
+
+Expected: `403`. A `200` means the bucket is public — stop and fix before continuing.
+
+> No commit — this task changes no files.
+
+---
+
+### Task 6: Build and deploy script
+
+**Files:**
+
+- Create: `scripts/deploy-aws.sh`
+- Modify: `package.json` (add `deploy:aws` to `scripts`)
+
+**Interfaces:**
+
+- Consumes: `pnpm run build:aws` (Task 1), Terraform outputs `content_bucket` / `distribution_id` / `site_url` (Task 4).
+- Produces: a deployed site.
+
+- [ ] **Step 1: Create `scripts/deploy-aws.sh`**
+
+```bash
+#!/usr/bin/env bash
+
+# Build and deploy tmi-ux to the AWS S3 + CloudFront stack in terraform/aws.
+#
+# Usage:
+#   ./scripts/deploy-aws.sh [--no-build]
+#
+# Options:
+#   --no-build   Deploy whatever is already in dist/tmi-ux/browser
+#   --help       Show this help message
+#
+# Prerequisites:
+#   - AWS CLI configured with the "tmi" profile
+#   - terraform/aws applied (see docs/reference/aws-deployment.md)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+TF_DIR="$ROOT_DIR/terraform/aws"
+DIST_DIR="$ROOT_DIR/dist/tmi-ux/browser"
+
+export AWS_PROFILE="${AWS_PROFILE:-tmi}"
+
+RUN_BUILD=true
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --no-build)
+            RUN_BUILD=false
+            shift
+            ;;
+        --help)
+            sed -n '3,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+echo "==> Reading Terraform outputs"
+BUCKET="$(terraform -chdir="$TF_DIR" output -raw content_bucket)"
+DISTRIBUTION_ID="$(terraform -chdir="$TF_DIR" output -raw distribution_id)"
+SITE_URL="$(terraform -chdir="$TF_DIR" output -raw site_url)"
+echo "    bucket=$BUCKET distribution=$DISTRIBUTION_ID"
+
+if [[ "$RUN_BUILD" == true ]]; then
+    echo "==> Building (configuration=aws)"
+    (cd "$ROOT_DIR" && pnpm run build:aws)
+fi
+
+if [[ ! -f "$DIST_DIR/index.html" ]]; then
+    echo "Error: $DIST_DIR/index.html not found; run without --no-build." >&2
+    exit 1
+fi
+
+# src/main.ts fetches /config.json before bootstrap in production builds. On
+# S3 a missing key would be rewritten to index.html by the SPA fallback,
+# return 200, and fail JSON parsing — a warning on every page load. Publishing
+# an empty object keeps the load clean and leaves a hook for overriding
+# apiUrl / operator strings later without a rebuild.
+echo "==> Writing config.json"
+echo '{}' > "$DIST_DIR/config.json"
+
+# Pass 1 — stable-named assets. outputHashing only hashes build-emitted files,
+# so everything from public/ (favicon.ico, TMI-Logo.svg, site.webmanifest,
+# robots.txt) and src/assets/ (including i18n JSON) keeps a stable name and
+# must NOT be marked immutable. --delete is scoped by the same filters, so it
+# will not remove the hashed output uploaded by pass 2.
+echo "==> Pass 1/3: stable-named assets (max-age=3600)"
+aws s3 sync "$DIST_DIR" "s3://$BUCKET" --delete \
+    --cache-control "public,max-age=3600" \
+    --exclude "*.js" --exclude "*.css" --exclude "media/*" \
+    --exclude "index.html" --exclude "config.json"
+
+# Pass 2 — hash-named build output. Syncing from local (rather than an S3-to-S3
+# copy with --metadata-directive REPLACE) keeps the guessed Content-Type.
+echo "==> Pass 2/3: hashed build output (immutable)"
+aws s3 sync "$DIST_DIR" "s3://$BUCKET" --delete \
+    --cache-control "public,max-age=31536000,immutable" \
+    --exclude "*" --include "*.js" --include "*.css" --include "media/*"
+
+echo "==> Pass 3/3: entry points (no-store)"
+aws s3 cp "$DIST_DIR/index.html" "s3://$BUCKET/index.html" \
+    --cache-control "no-store" --content-type "text/html"
+aws s3 cp "$DIST_DIR/config.json" "s3://$BUCKET/config.json" \
+    --cache-control "no-store" --content-type "application/json"
+
+# Hashed files never need invalidating and the entry points sit on
+# CachingDisabled behaviors; this exists for the stable-named assets above.
+# One /* path counts as a single invalidation against the 1000/month free tier.
+echo "==> Invalidating CloudFront cache"
+INVALIDATION_ID="$(aws cloudfront create-invalidation \
+    --distribution-id "$DISTRIBUTION_ID" \
+    --paths '/*' \
+    --query 'Invalidation.Id' --output text)"
+
+echo "==> Deployed to $SITE_URL (invalidation $INVALIDATION_ID)"
+```
+
+- [ ] **Step 2: Make it executable and add the package script**
+
+```bash
+chmod +x scripts/deploy-aws.sh
+```
+
+In `package.json`, add to `scripts` immediately after `"build:aws"`:
+
+```json
+"deploy:aws": "sh scripts/deploy-aws.sh",
+```
+
+- [ ] **Step 3: Deploy**
+
+```bash
+pnpm run deploy:aws
+```
+
+Expected: build succeeds, three sync/copy passes report uploads, invalidation ID printed.
+
+- [ ] **Step 4: Verify the site serves and headers are right**
+
+```bash
+curl -sI https://app.aws.tmi.dev/ | grep -Ei 'HTTP/|strict-transport|content-security|x-frame|x-content-type|referrer-policy|permissions-policy|cache-control'
+```
+
+Expected: `HTTP/2 200`; `content-security-policy: frame-ancestors 'none'`; `strict-transport-security: max-age=31536000; includeSubDomains`; `x-frame-options: DENY`; `x-content-type-options: nosniff`; `referrer-policy: strict-origin-when-cross-origin`; `permissions-policy: camera=(), microphone=(), geolocation=()`; `cache-control: no-store`.
+
+- [ ] **Step 5: Verify cache-control per asset class and SPA routing**
+
+```bash
+# A hashed bundle must be immutable
+HASHED="$(curl -s https://app.aws.tmi.dev/ | grep -o '/[A-Za-z0-9._-]*\.js' | head -1)"
+curl -sI "https://app.aws.tmi.dev${HASHED}" | grep -i cache-control
+# A stable-named asset must NOT be immutable
+curl -sI https://app.aws.tmi.dev/favicon.ico | grep -i cache-control
+# config.json must parse as JSON
+curl -s https://app.aws.tmi.dev/config.json
+# Deep link must return the app, not an error
+curl -s -o /dev/null -w '%{http_code}\n' https://app.aws.tmi.dev/intake
+```
+
+Expected: `public,max-age=31536000,immutable`; `public,max-age=3600`; `{}`; `200`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/deploy-aws.sh package.json
+git commit -m "feat: add aws deploy script for s3 + cloudfront"
+```
+
+---
+
+### Task 7: Runbook and end-to-end verification
+
+**Files:**
+
+- Create: `docs/reference/aws-deployment.md`
+
+**Interfaces:**
+
+- Consumes: everything above.
+
+- [ ] **Step 1: Write the runbook**
+
+Create `docs/reference/aws-deployment.md`:
+
+````markdown
+# AWS deployment (app.aws.tmi.dev)
+
+The tmi-ux SPA is served from S3 + CloudFront in AWS account `967218005408`
+(`us-east-1`), against the TMI server at `https://server.aws.tmi.dev`.
+
+All commands use the `tmi` AWS profile.
+
+## Layout
+
+- `terraform/aws/` — S3 buckets, CloudFront, ACM, Route 53
+- `scripts/deploy-aws.sh` — build, sync, invalidate
+- `src/environments/environment.aws.ts` — compiled-in config
+
+## Deploy
+
+```bash
+pnpm run deploy:aws            # build + deploy
+pnpm run deploy:aws -- --no-build   # deploy the existing dist/
+```
+
+## Change infrastructure
+
+```bash
+cd terraform/aws
+AWS_PROFILE=tmi terraform init -backend-config=backend.hcl   # first time only
+AWS_PROFILE=tmi terraform plan
+AWS_PROFILE=tmi terraform apply
+```
+
+State lives at `tmi-ux/aws-public/terraform.tfstate` in
+`s3://tmi-tfstate-967218005408` — separate from the tmi server repo's state, so
+this stack can be applied and destroyed independently.
+
+## Caching model
+
+`outputHashing: "all"` hashes only build-emitted files. `public/` and
+`src/assets/` ship under stable names, so the deploy script uses three passes:
+stable names get one hour, hashed output gets a year `immutable`, and
+`index.html` / `config.json` get `no-store`. The `/*` invalidation exists for
+the stable-named assets.
+
+## Security headers
+
+CloudFront sends HSTS, `nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy`,
+`Permissions-Policy`, and a CSP of **`frame-ancestors 'none'` only**.
+
+The app injects its own complete CSP at runtime (`SecurityConfigService`),
+built from `environment.apiUrl` and the `CONTENT_PROVIDERS` registry. Two CSPs
+on one document are enforced as an intersection, so **do not add fetch
+directives to the CloudFront policy** — a directive narrower than the app's
+silently breaks the Google Drive and OneDrive pickers. `frame-ancestors` is the
+exception: meta-tag CSPs ignore it, so the edge is the only place it can be set.
+
+Known gap: the meta tag is injected during Angular bootstrap, so it does not
+cover the initial document parse (the Font Awesome and Google Fonts links in
+`index.html`). Closing that means baking a static CSP into `index.html` at
+build time.
+
+## Server dependency
+
+The server must allowlist this origin's OAuth callbacks, via
+`TMI_OAUTH_CLIENT_CALLBACK_ALLOWLIST=https://app.aws.tmi.dev/*` in the
+`tmi-server-config` ConfigMap (namespace `tmi-platform`). The allowlist is
+fail-closed: unset means every callback is rejected and login fails. The
+ConfigMap is Terraform-owned in the tmi repo and consumed via `envFrom`, so it
+needs `kubectl -n tmi-platform rollout restart deployment/tmi-server`.
+
+## Troubleshooting
+
+**Blank app, HTTP 200.** The distribution maps origin 403/404 to
+`/index.html` with a 200 for SPA routing, which also masks a broken origin.
+Check the S3 origin directly before trusting the CloudFront response.
+
+**Stale assets after deploy.** Confirm the invalidation completed:
+`aws cloudfront get-invalidation --distribution-id <id> --id <id>`.
+
+**Login fails / callback rejected.** See "Server dependency" above.
+````
+
+- [ ] **Step 2: Verify the app loads cleanly in a browser**
+
+Open `https://app.aws.tmi.dev/` and check the DevTools console.
+
+Expected: no `Failed to fetch runtime config` warning, and **no CSP violation
+reports**. A CSP violation here means the edge policy is intersecting with the
+app's — re-read the CSP note in `cloudfront.tf` before changing anything.
+
+- [ ] **Step 3: Verify OAuth login end-to-end**
+
+Requires server ops to have applied `TMI_OAUTH_CLIENT_CALLBACK_ALLOWLIST`
+(see `deliverables/tmi-server-config-note.md`). Until then this step is blocked
+and login is expected to fail.
+
+Sign in via Google. Expected: redirect to the provider, return to
+`https://app.aws.tmi.dev/oauth2/callback`, and land authenticated.
+
+- [ ] **Step 4: Verify the content pickers open**
+
+With a signed-in session, open both the Google Drive and the OneDrive/SharePoint
+file pickers. Expected: both render. These are the specific features an
+over-broad edge CSP would break, so this check is not optional.
+
+- [ ] **Step 5: Verify access logs are being delivered**
+
+CloudFront delivers standard logs on a delay of up to an hour after first
+traffic.
+
+```bash
+AWS_PROFILE=tmi aws s3 ls s3://tmi-ux-logs-967218005408/cloudfront/ | head
+```
+
+Expected: at least one gzipped log object.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/reference/aws-deployment.md
+git commit -m "docs: add aws deployment runbook"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage.** Every spec section maps to a task: architecture and runtime
+config → Tasks 1, 6; Terraform resources and both trade-offs → Tasks 2–4;
+security headers and the CSP rationale → Task 4 + runbook; build/deploy and the
+three-pass rationale → Task 6; verification list → Tasks 5–7; server-side
+prerequisite → Task 7 Step 3 + runbook.
+
+**Deliberately out of scope** (per the spec): CI/CD and GitHub OIDC, WAF,
+retiring `scripts/push-ecr.sh`, and baking a build-time CSP into `index.html`.
+
+**Resource counts** in the plan-gate steps (10 → 13 → 19) are derived by hand
+from the resource blocks in each task. If a real plan differs, reconcile the
+difference before applying rather than assuming the plan document is right.

--- a/docs/superpowers/specs/2026-07-22-tmi-ux-aws-deployment-design.md
+++ b/docs/superpowers/specs/2026-07-22-tmi-ux-aws-deployment-design.md
@@ -1,0 +1,250 @@
+# tmi-ux AWS deployment — design
+
+**Date:** 2026-07-22
+**Status:** Approved (design); not yet implemented
+
+## Goal
+
+Serve the tmi-ux Angular SPA from AWS at **`https://app.aws.tmi.dev`**, with TLS from ACM,
+against the existing TMI server at `https://server.aws.tmi.dev`.
+
+## Existing environment (verified 2026-07-22)
+
+AWS account `967218005408`, region `us-east-1`, accessed via the named profile **`tmi`**.
+
+| Thing            | State                                                                                                               |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------- |
+| TMI server       | EKS cluster `tmi-eks`, namespace `tmi-platform`, behind an ALB created by the AWS Load Balancer Controller          |
+| DNS              | Route 53 hosted zone `aws.tmi.dev` = `Z05646533D2YL1I678JXS`; `server.aws.tmi.dev` CNAMEs to that ALB               |
+| TLS              | ACM cert for `server.aws.tmi.dev` (us-east-1, ISSUED)                                                               |
+| IaC              | `tmi/terraform/environments/aws-public`, state in `s3://tmi-tfstate-967218005408`, locks in DynamoDB `tmi-tf-locks` |
+| CloudFront / ECS | None                                                                                                                |
+
+`scripts/push-ecr.sh` in this repo references account `706702818127` — a **different** account.
+It is stale with respect to this deployment and is not used here.
+
+## Architecture
+
+```
+                    Route 53 (aws.tmi.dev)
+                      app.aws.tmi.dev  A/AAAA alias
+                              │
+                     CloudFront distribution
+                     ├── ACM cert (us-east-1)
+                     ├── Response-headers policy
+                     ├── Standard access logs ──▶ log bucket (30d)
+                     └── Origin: S3 via OAC (bucket private)
+                              │
+                       S3 bucket (SPA build)
+
+  Browser ──XHR/WSS──▶ https://server.aws.tmi.dev   (existing EKS ALB, unchanged)
+```
+
+Pure static hosting. `server.js` is **not** used in this deployment; it exists only for the
+container/Heroku targets. The browser calls the API cross-origin, exactly as it does under
+`ng serve` today. The server stack is untouched apart from one config value (see
+"Server-side prerequisite").
+
+### Runtime config
+
+`src/main.ts` fetches `/config.json` before bootstrap whenever `environment.production` is
+true. On S3 a missing `/config.json` would be rewritten to `index.html` by the SPA fallback,
+return 200, and fail JSON parsing — a caught-but-noisy warning on every page load.
+
+So the deploy publishes a real `config.json` containing `{}`. Deployment values live in
+`environment.aws.ts`; the empty `config.json` is the escape hatch for changing `apiUrl` or
+operator strings later without a rebuild.
+
+## Terraform
+
+New `terraform/aws/` in this repo. State key `tmi-ux/aws-public/terraform.tfstate` in the
+existing `tmi-tfstate-967218005408` bucket, locks via the existing `tmi-tf-locks` table —
+same `backend.hcl` shape as tmi's, supplied with `terraform init -backend-config=`.
+
+Separate state from the tmi repo, so UI infrastructure can be planned, applied, and destroyed
+without touching the server's state.
+
+### Resources
+
+| Resource                                 | Configuration                                                                                                                                                                                                         |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `aws_s3_bucket` (content)                | Private. Public access block on all four settings, versioning enabled, SSE-S3 (AES256) default encryption, object ownership `BucketOwnerEnforced`. No S3 website hosting.                                             |
+| `aws_s3_bucket` (logs)                   | Ownership `BucketOwnerPreferred` with ACLs enabled — required by CloudFront standard logging. Lifecycle rule expires objects at **30 days**.                                                                          |
+| `aws_cloudfront_origin_access_control`   | SigV4, always sign. Bucket policy grants `cloudfront.amazonaws.com` read, scoped to the distribution ARN.                                                                                                             |
+| `aws_acm_certificate` + validation       | `app.aws.tmi.dev`, DNS validation via Route 53 records, us-east-1, `create_before_destroy`.                                                                                                                           |
+| `aws_cloudfront_distribution`            | Alias `app.aws.tmi.dev`; `default_root_object = index.html`; viewer protocol redirect-to-https; TLSv1.2_2021 + SNI; compression on; HTTP/2 + HTTP/3; IPv6 on; **PriceClass_100**; standard logging to the log bucket. |
+| Cache behaviors                          | Default → AWS managed `CachingOptimized`. Ordered behaviors for `/index.html` and `/config.json` → managed `CachingDisabled`.                                                                                         |
+| `custom_error_response`                  | 403 → `/index.html` (200) and 404 → `/index.html` (200), for SPA deep links.                                                                                                                                          |
+| `aws_cloudfront_response_headers_policy` | See "Security headers".                                                                                                                                                                                               |
+| `aws_route53_record`                     | A + AAAA alias records into `Z05646533D2YL1I678JXS`.                                                                                                                                                                  |
+
+### Known trade-off: the SPA fallback masks errors
+
+Mapping 403 → 200 means a genuinely broken OAC/bucket-policy configuration renders the app
+shell instead of failing loudly. This is the standard trade for SPA routing on S3 + OAC and is
+accepted here, but it is a real debuggability cost: when diagnosing a blank app, check the
+S3 origin directly before trusting the CloudFront response.
+
+### Known trade-off: log bucket ownership
+
+CloudFront standard (legacy) logging delivers via S3 ACLs, which is incompatible with
+`BucketOwnerEnforced`. The log bucket therefore enables ACLs. This is the one place the design
+relaxes a security default, and it applies only to the log bucket — the content bucket keeps
+`BucketOwnerEnforced`.
+
+## Security headers
+
+CloudFront sends, via the response-headers policy:
+
+- `Strict-Transport-Security` (max-age 31536000, includeSubDomains, no preload)
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Permissions-Policy: camera=(), microphone=(), geolocation=()`
+- `Content-Security-Policy: frame-ancestors 'none'` — **and nothing else**
+
+### Why the edge CSP is frame-ancestors only
+
+The app already ships a complete CSP. `SecurityConfigService`, constructed unconditionally at
+startup, builds a policy and injects it as a `<meta http-equiv="Content-Security-Policy">` tag
+(this is what the `<!-- CSP will be dynamically injected by the application -->` comment in
+`src/index.html` refers to). It sets `default-src`, `script-src`, `style-src`, `font-src`,
+`img-src`, `connect-src`, `base-uri`, `form-action`, `object-src`, `media-src`, `worker-src`,
+`manifest-src`, `frame-src`, and `upgrade-insecure-requests`.
+
+Critically, it is built **at runtime** from `environment.apiUrl` and the `CONTENT_PROVIDERS`
+registry:
+
+```
+frameSrc:   https://docs.google.com, https://accounts.google.com,
+            https://*.sharepoint.com, https://login.microsoftonline.com
+scriptSrc:  https://apis.google.com, https://accounts.google.com/gsi/client
+formAction: https://*.sharepoint.com
+```
+
+When a document carries two CSPs the browser enforces **both independently** — the effective
+policy is their intersection, and neither can loosen the other. A CloudFront CSP would have to
+be an exact superset of the above or it would silently break the Google Drive and OneDrive
+pickers. It cannot be reliably replicated in Terraform: the list contains a wildcard
+(`https://*.sharepoint.com`), and the Microsoft picker's real `picker_origin` is supplied to
+the client at runtime by the server (`microsoft-file-picker.service.ts:155`).
+
+The service's own comments identify what a meta tag cannot express: `frame-ancestors`,
+`report-uri`, and `sandbox`. `frame-ancestors` is consequently **not enforced anywhere today**.
+CloudFront supplies exactly that, closing a real gap with no risk of intersect-blocking the app.
+
+`environment.aws.ts` must carry `securityConfig` values matching what CloudFront actually
+sends, so the app's self-reported security posture stays honest.
+
+### Accepted limitation
+
+The meta-tag CSP is injected during Angular bootstrap, so it does not cover the initial
+document parse — the Font Awesome (`cdnjs.cloudflare.com`) and Google Fonts stylesheet links in
+`index.html` load before any CSP exists. Closing that means baking a static CSP into
+`index.html` at build time, which reintroduces the same enumeration problem. Logged as a
+follow-up, out of scope here.
+
+## Build and deploy
+
+### Build
+
+- New `src/environments/environment.aws.ts`, mirroring `environment.hosted-container.ts` with
+  `apiUrl: 'https://server.aws.tmi.dev'` and the `securityConfig` values above.
+- New `aws` configuration in `angular.json` with the matching `fileReplacements`, modelled on
+  the existing `hosted-container` configuration.
+- New `build:aws` script in `package.json`. Output path is unchanged: `dist/tmi-ux/browser`.
+
+### `scripts/deploy-aws.sh`
+
+Reads the bucket name and distribution ID from `terraform output`, then:
+
+1. `aws s3 sync … --delete --cache-control "public,max-age=3600"` — everything
+2. Re-upload `*.js`, `*.css`, `media/*` with `public,max-age=31536000,immutable`
+3. Upload `index.html` and `config.json` with `no-store`
+4. `aws cloudfront create-invalidation --paths '/*'`
+
+Runs manually with `AWS_PROFILE=tmi`. No CI deploy, no GitHub OIDC role. If CI is wanted later,
+this script becomes the CI step without rework.
+
+### Why three passes
+
+`outputHashing: "all"` hashes only build-emitted files. Everything in `public/`
+(`favicon.ico`, `TMI-Logo.svg`, `site.webmanifest`, `robots.txt`, …) and `src/assets/i18n/*.json`
+ships under stable names. Marking the whole bucket `immutable` for a year would strand a
+year-old logo or translation file in every visitor's cache. Hashed output gets `immutable`;
+stable names get a one-hour default.
+
+The `/*` invalidation exists for those stable-named assets. Hashed files never need it, and
+`index.html` / `config.json` sit on `CachingDisabled` behaviors. One `/*` path counts as a
+single invalidation against the 1,000/month free tier.
+
+## Server-side prerequisite
+
+One change is required on the TMI server before login works from the new origin. Handed to
+server ops as `deliverables/tmi-server-config-note.md`.
+
+**Required** — add to the `tmi-server-config` ConfigMap (namespace `tmi-platform`):
+
+```
+TMI_OAUTH_CLIENT_CALLBACK_ALLOWLIST = "https://app.aws.tmi.dev/*"
+```
+
+The UI passes a `client_callback` to `/oauth2/authorize`, and
+`auth/client_callback_allowlist.go` is fail-closed: an empty allowlist rejects every callback.
+The variable is currently unset on the running ConfigMap. A wildcard is needed because the UI
+uses three callbacks and one carries a dynamic query string:
+
+- `https://app.aws.tmi.dev/oauth2/callback`
+- `https://app.aws.tmi.dev/oauth2/link/callback`
+- `https://app.aws.tmi.dev/oauth2/content-callback?return_to=<...>`
+
+Matching is a plain string prefix. Because the prefix includes the trailing `/` after the host
+it can only match our own origin — `https://app.aws.tmi.dev.evil.com/` does not match.
+
+**Recommended, not blocking** — `TMI_CORS_ALLOWED_ORIGINS = "https://app.aws.tmi.dev"`. A
+preflight from the new origin already succeeds today, because with the variable unset the
+server reflects any `Origin` back in `access-control-allow-origin` alongside
+`access-control-allow-credentials: true`. Setting it explicitly closes that down; it must
+include every other origin already in use, since setting it switches the server from
+reflect-all to allowlist-only.
+
+The ConfigMap is Terraform-owned (`kubernetes_config_map_v1.tmi` in
+`tmi/terraform/modules/kubernetes/aws/k8s_resources.tf`), so a `kubectl edit` would be reverted.
+The Deployment consumes it via `envFrom`, which requires
+`kubectl -n tmi-platform rollout restart deployment/tmi-server`.
+
+### Confidence note
+
+The three callback URLs above were read from `auth.service.ts`, `identity-link.service.ts`, and
+`content-token.service.ts` (`${window.location.origin}` + path); the flow was not exercised
+end-to-end. That the allowlist rejects the new origin today is inferred from the unset variable
+plus the fail-closed code path — direct probes were rejected by OpenAPI request validation
+before reaching the allowlist handler. Verify during implementation.
+
+## Verification
+
+1. `terraform plan` reviewed before apply; ACM validation reaches ISSUED.
+2. `curl -I https://app.aws.tmi.dev` — 200, expected security headers, valid cert chain.
+3. Deep link (e.g. `https://app.aws.tmi.dev/intake`) returns the app, not an error.
+4. Browser console clean on load — specifically no `config.json` parse warning and no CSP
+   violations.
+5. `Cache-Control` correct per class: `immutable` on a hashed `*.js`, `no-store` on
+   `index.html`, one hour on `/favicon.ico`.
+6. OAuth login end-to-end **after** server ops applies the allowlist change.
+7. Google Drive and OneDrive pickers both open — the specific thing an over-broad edge CSP
+   would have broken.
+8. Access logs appear in the log bucket.
+
+## Cost
+
+ACM is free; the Route 53 zone already exists. S3 storage and requests are negligible at this
+scale. CloudFront on PriceClass_100 at low traffic plus log storage lands in the low single
+digits of dollars per month — roughly **$2–5/month**, against the existing stack's ~$140/month.
+
+## Out of scope
+
+- Any change to the EKS/server deployment beyond the ConfigMap value above
+- CI/CD deploy automation and GitHub OIDC
+- WAF
+- Retiring the stale `scripts/push-ecr.sh`
+- Baking a build-time CSP into `index.html` to cover the pre-bootstrap window

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:prod": "ng build --configuration=production",
     "build:test": "ng build --configuration=test",
     "build:aws": "ng build --configuration=aws",
+    "deploy:aws": "bash scripts/deploy-aws.sh",
     "watch": "ng build --watch --configuration development",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "ng build",
     "build:prod": "ng build --configuration=production",
     "build:test": "ng build --configuration=test",
+    "build:aws": "ng build --configuration=aws",
     "watch": "ng build --watch --configuration development",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/deploy-aws.sh
+++ b/scripts/deploy-aws.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# Build and deploy tmi-ux to the AWS S3 + CloudFront stack in terraform/aws.
+#
+# Usage:
+#   ./scripts/deploy-aws.sh [--no-build]
+#
+# Options:
+#   --no-build   Deploy whatever is already in dist/tmi-ux/browser
+#   --help       Show this help message
+#
+# Prerequisites:
+#   - AWS CLI configured with the "tmi" profile
+#   - terraform/aws applied (see docs/reference/aws-deployment.md)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+TF_DIR="$ROOT_DIR/terraform/aws"
+DIST_DIR="$ROOT_DIR/dist/tmi-ux/browser"
+
+export AWS_PROFILE="${AWS_PROFILE:-tmi}"
+
+RUN_BUILD=true
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --no-build)
+            RUN_BUILD=false
+            shift
+            ;;
+        --help)
+            sed -n '3,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+echo "==> Reading Terraform outputs"
+BUCKET="$(terraform -chdir="$TF_DIR" output -raw content_bucket)"
+DISTRIBUTION_ID="$(terraform -chdir="$TF_DIR" output -raw distribution_id)"
+SITE_URL="$(terraform -chdir="$TF_DIR" output -raw site_url)"
+echo "    bucket=$BUCKET distribution=$DISTRIBUTION_ID"
+
+if [[ "$RUN_BUILD" == true ]]; then
+    echo "==> Building (configuration=aws)"
+    (cd "$ROOT_DIR" && pnpm run build:aws)
+fi
+
+if [[ ! -f "$DIST_DIR/index.html" ]]; then
+    echo "Error: $DIST_DIR/index.html not found; run without --no-build." >&2
+    exit 1
+fi
+
+# src/main.ts fetches /config.json before bootstrap in production builds. On
+# S3 a missing key would be rewritten to index.html by the SPA fallback,
+# return 200, and fail JSON parsing — a warning on every page load. Publishing
+# an empty object keeps the load clean and leaves a hook for overriding
+# apiUrl / operator strings later without a rebuild.
+echo "==> Writing config.json"
+echo '{}' > "$DIST_DIR/config.json"
+
+# Pass 1 — stable-named assets. outputHashing only hashes build-emitted files,
+# so everything from public/ (favicon.ico, TMI-Logo.svg, site.webmanifest,
+# robots.txt) and src/assets/ (including i18n JSON) keeps a stable name and
+# must NOT be marked immutable. --delete is scoped by the same filters, so it
+# will not remove the hashed output uploaded by pass 2.
+echo "==> Pass 1/3: stable-named assets (max-age=3600)"
+aws s3 sync "$DIST_DIR" "s3://$BUCKET" --delete \
+    --cache-control "public,max-age=3600" \
+    --exclude "*.js" --exclude "*.css" --exclude "media/*" \
+    --exclude "index.html" --exclude "config.json"
+
+# Pass 2 — hash-named build output. Syncing from local (rather than an S3-to-S3
+# copy with --metadata-directive REPLACE) keeps the guessed Content-Type.
+echo "==> Pass 2/3: hashed build output (immutable)"
+aws s3 sync "$DIST_DIR" "s3://$BUCKET" --delete \
+    --cache-control "public,max-age=31536000,immutable" \
+    --exclude "*" --include "*.js" --include "*.css" --include "media/*"
+
+echo "==> Pass 3/3: entry points (no-store)"
+aws s3 cp "$DIST_DIR/index.html" "s3://$BUCKET/index.html" \
+    --cache-control "no-store" --content-type "text/html"
+aws s3 cp "$DIST_DIR/config.json" "s3://$BUCKET/config.json" \
+    --cache-control "no-store" --content-type "application/json"
+
+# Hashed files never need invalidating and the entry points sit on
+# CachingDisabled behaviors; this exists for the stable-named assets above.
+# One /* path counts as a single invalidation against the 1000/month free tier.
+echo "==> Invalidating CloudFront cache"
+INVALIDATION_ID="$(aws cloudfront create-invalidation \
+    --distribution-id "$DISTRIBUTION_ID" \
+    --paths '/*' \
+    --query 'Invalidation.Id' --output text)"
+
+echo "==> Deployed to $SITE_URL (invalidation $INVALIDATION_ID)"

--- a/scripts/deploy-aws.sh
+++ b/scripts/deploy-aws.sh
@@ -56,37 +56,91 @@ if [[ ! -f "$DIST_DIR/index.html" ]]; then
     exit 1
 fi
 
+# Every Angular build configuration emits to the same dist/tmi-ux/browser, so
+# the presence of index.html proves nothing about *which* environment was
+# compiled in. A dist/ left over from `pnpm run build:prod` or `build:test`
+# would deploy the wrong apiUrl to app.aws.tmi.dev, and the failure mode (login
+# and API calls silently pointed at another server) is not obvious in the
+# browser. environment.aws.ts is the only environment file carrying this host,
+# so its presence in the emitted bundles is a reliable fingerprint. This runs
+# for built and --no-build deploys alike.
+echo "==> Verifying dist/ was built with configuration=aws"
+if ! grep -rqlF 'server.aws.tmi.dev' "$DIST_DIR" --include='*.js'; then
+    echo "Error: no bundle in $DIST_DIR references server.aws.tmi.dev." >&2
+    echo "       This dist/ was built with a different configuration and must" >&2
+    echo "       not be deployed to app.aws.tmi.dev. Run: pnpm run build:aws" >&2
+    exit 1
+fi
+
 # src/main.ts fetches /config.json before bootstrap in production builds. On
 # S3 a missing key would be rewritten to index.html by the SPA fallback,
 # return 200, and fail JSON parsing — a warning on every page load. Publishing
-# an empty object keeps the load clean and leaves a hook for overriding
-# apiUrl / operator strings later without a rebuild.
+# an empty object keeps the load clean.
+#
+# NOTE: this is rewritten to {} and re-uploaded on EVERY deploy. It is not a
+# durable override hook — anything hand-edited into s3://…/config.json is lost
+# on the next deploy. src/environments/environment.aws.ts is the durable place
+# to configure this deployment.
 echo "==> Writing config.json"
 echo '{}' > "$DIST_DIR/config.json"
 
-# Pass 1 — stable-named assets. outputHashing only hashes build-emitted files,
-# so everything from public/ (favicon.ico, TMI-Logo.svg, site.webmanifest,
-# robots.txt) and src/assets/ (including i18n JSON) keeps a stable name and
-# must NOT be marked immutable. --delete is scoped by the same filters, so it
-# will not remove the hashed output uploaded by pass 2.
-echo "==> Pass 1/3: stable-named assets (max-age=3600)"
-aws s3 sync "$DIST_DIR" "s3://$BUCKET" --delete \
-    --cache-control "public,max-age=3600" \
-    --exclude "*.js" --exclude "*.css" --exclude "media/*" \
-    --exclude "index.html" --exclude "config.json"
+# ---------------------------------------------------------------------------
+# Upload ordering matters — do not "simplify" this into a single sync --delete.
+#
+# index.html references hashed bundles by name. If deletion of the previous
+# build's bundles happens before the new index.html is published, the origin
+# serves an index.html whose bundles are gone. CloudFront rewrites those origin
+# 403s to /index.html with status 200 (SPA fallback), so the browser receives
+# HTML where JavaScript was expected: "Uncaught SyntaxError: Unexpected token
+# '<'". With `set -e`, an interruption anywhere in that window leaves the site
+# permanently in that state.
+#
+# So: add everything new first (no --delete), publish the entry points, and
+# only then prune what is no longer referenced. Between passes 1 and 3 the
+# bucket holds both builds and serves the old one correctly.
+# ---------------------------------------------------------------------------
 
-# Pass 2 — hash-named build output. Syncing from local (rather than an S3-to-S3
-# copy with --metadata-directive REPLACE) keeps the guessed Content-Type.
-echo "==> Pass 2/3: hashed build output (immutable)"
-aws s3 sync "$DIST_DIR" "s3://$BUCKET" --delete \
+# Pass 1 — hash-named build output, added alongside the previous build's.
+# Syncing from local (rather than an S3-to-S3 copy with --metadata-directive
+# REPLACE) keeps the guessed Content-Type.
+echo "==> Pass 1/4: hashed build output (immutable, no delete)"
+aws s3 sync "$DIST_DIR" "s3://$BUCKET" \
     --cache-control "public,max-age=31536000,immutable" \
     --exclude "*" --include "*.js" --include "*.css" --include "media/*"
 
-echo "==> Pass 3/3: entry points (no-store)"
+# Pass 2 — stable-named assets. outputHashing only hashes build-emitted files,
+# so everything from public/ (favicon.ico, TMI-Logo.svg, site.webmanifest,
+# robots.txt) and src/assets/ (including i18n JSON) keeps a stable name and
+# must NOT be marked immutable.
+echo "==> Pass 2/4: stable-named assets (max-age=3600, no delete)"
+aws s3 sync "$DIST_DIR" "s3://$BUCKET" \
+    --cache-control "public,max-age=3600" \
+    --exclude "*.js" --exclude "*.css" --exclude "media/*" \
+    --exclude "index.html" --exclude "config.json" \
+    --exclude "site.webmanifest"
+
+# Python's mimetypes table has no .webmanifest entry, so the sync above would
+# upload it as binary/octet-stream and browsers would ignore the manifest.
+if [[ -f "$DIST_DIR/site.webmanifest" ]]; then
+    aws s3 cp "$DIST_DIR/site.webmanifest" "s3://$BUCKET/site.webmanifest" \
+        --cache-control "public,max-age=3600" \
+        --content-type "application/manifest+json"
+fi
+
+# Pass 3 — entry points. This is the cutover: from here the site references the
+# bundles uploaded in pass 1.
+echo "==> Pass 3/4: entry points (no-store)"
 aws s3 cp "$DIST_DIR/index.html" "s3://$BUCKET/index.html" \
     --cache-control "no-store" --content-type "text/html"
 aws s3 cp "$DIST_DIR/config.json" "s3://$BUCKET/config.json" \
     --cache-control "no-store" --content-type "application/json"
+
+# Pass 4 — prune. Everything local is now in the bucket, so this only issues
+# deletes for keys the current build no longer produces (the previous build's
+# hashed bundles, removed assets). --size-only keeps it from re-uploading and
+# clobbering the per-class Cache-Control set above.
+echo "==> Pass 4/4: pruning objects no longer in dist/"
+aws s3 sync "$DIST_DIR" "s3://$BUCKET" --delete --size-only
 
 # Hashed files never need invalidating and the entry points sit on
 # CachingDisabled behaviors; this exists for the stable-named assets above.
@@ -96,5 +150,48 @@ INVALIDATION_ID="$(aws cloudfront create-invalidation \
     --distribution-id "$DISTRIBUTION_ID" \
     --paths '/*' \
     --query 'Invalidation.Id' --output text)"
+
+echo "==> Waiting for invalidation $INVALIDATION_ID to complete"
+aws cloudfront wait invalidation-completed \
+    --distribution-id "$DISTRIBUTION_ID" --id "$INVALIDATION_ID"
+
+# Post-deploy verification. The SPA fallback turns origin 403/404 into a 200
+# HTML response, so a 200 on "/" alone does not prove the deploy is intact —
+# check a hashed bundle that the freshly built index.html actually references.
+echo "==> Verifying deployment"
+
+http_status() {
+    curl -sS -o /dev/null -w '%{http_code}' --max-time 30 "$1"
+}
+
+ROOT_STATUS="$(http_status "$SITE_URL/")"
+if [[ "$ROOT_STATUS" != "200" ]]; then
+    echo "Error: GET $SITE_URL/ returned HTTP $ROOT_STATUS (expected 200)." >&2
+    exit 1
+fi
+echo "    $SITE_URL/ -> 200"
+
+BUNDLE="$(grep -oE '(src|href)="[^"]+\.js"' "$DIST_DIR/index.html" |
+    head -n 1 | sed -E 's/^(src|href)="//; s/"$//; s#^/##')"
+if [[ -z "$BUNDLE" ]]; then
+    echo "Error: could not find a .js reference in $DIST_DIR/index.html." >&2
+    exit 1
+fi
+
+BUNDLE_PROBE="$(curl -sS -o /dev/null --max-time 30 \
+    -w '%{http_code} %{content_type}' "$SITE_URL/$BUNDLE")"
+BUNDLE_STATUS="${BUNDLE_PROBE%% *}"
+BUNDLE_TYPE="${BUNDLE_PROBE#* }"
+# A missing bundle also answers 200: the distribution's custom_error_response
+# rewrites the origin's 403 to /index.html. Content-Type is what distinguishes
+# the two, so check it as well as the status.
+if [[ "$BUNDLE_STATUS" != "200" || "$BUNDLE_TYPE" != *javascript* ]]; then
+    echo "Error: GET $SITE_URL/$BUNDLE returned HTTP $BUNDLE_STATUS ($BUNDLE_TYPE);" >&2
+    echo "       expected 200 with a JavaScript Content-Type. The published" >&2
+    echo "       index.html references a bundle the origin does not have," >&2
+    echo "       and the SPA fallback is serving HTML in its place." >&2
+    exit 1
+fi
+echo "    $SITE_URL/$BUNDLE -> 200 ($BUNDLE_TYPE)"
 
 echo "==> Deployed to $SITE_URL (invalidation $INVALIDATION_ID)"

--- a/src/app/auth/components/login/login.component.spec.ts
+++ b/src/app/auth/components/login/login.component.spec.ts
@@ -29,6 +29,7 @@ describe('LoginComponent', () => {
     debugComponent: ReturnType<typeof vi.fn>;
   };
   let mockDialog: { open: ReturnType<typeof vi.fn> };
+  let mockCdr: { markForCheck: ReturnType<typeof vi.fn>; detectChanges: ReturnType<typeof vi.fn> };
 
   const mockOAuthProviders: OAuthProviderInfo[] = [
     {
@@ -98,6 +99,11 @@ describe('LoginComponent', () => {
       }),
     };
 
+    mockCdr = {
+      markForCheck: vi.fn(),
+      detectChanges: vi.fn(),
+    };
+
     // Clear sessionStorage before each test
     sessionStorage.clear();
 
@@ -107,6 +113,7 @@ describe('LoginComponent', () => {
       mockRouter as any,
       mockLogger as any,
       mockDialog as any,
+      mockCdr as any,
     );
   });
 
@@ -174,6 +181,33 @@ describe('LoginComponent', () => {
       component.ngOnInit();
 
       expect(component.providersLoading).toBe(false);
+      expect(component.error).toBe('Failed to load authentication providers');
+    });
+
+    // Regression test for the intermittent "Loading authentication providers"
+    // hang. app-root (the router-outlet host) is OnPush, and this forkJoin
+    // resolves from an async HTTP callback rather than a template event, so the
+    // change-detection tick that follows is pruned at the clean OnPush ancestor
+    // and never reaches this CheckAlways component — the spinner stays up even
+    // though the data arrived. The fix marks the component (and its ancestors)
+    // for check. These tests guard that both the success and error paths call
+    // markForCheck.
+    it('should mark for check after providers load so the OnPush ancestor is traversed', () => {
+      component.ngOnInit();
+
+      expect(mockCdr.markForCheck).toHaveBeenCalled();
+      expect(component.providersLoading).toBe(false);
+    });
+
+    it('should mark for check after a provider load error', () => {
+      mockCdr.markForCheck.mockClear();
+      mockAuthService.getAvailableProviders.mockReturnValue(
+        throwError(() => new Error('Network error')),
+      );
+
+      component.ngOnInit();
+
+      expect(mockCdr.markForCheck).toHaveBeenCalled();
       expect(component.error).toBe('Failed to load authentication providers');
     });
 

--- a/src/app/auth/components/login/login.component.ts
+++ b/src/app/auth/components/login/login.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
@@ -52,6 +52,7 @@ export class LoginComponent implements OnInit {
     private router: Router,
     private logger: LoggerService,
     private dialog: MatDialog,
+    private cdr: ChangeDetectorRef,
   ) {}
 
   // SEM@dad0c81f4d87ea8457ac6ef32b1aedf685dc20ad: initialize login page: surface stored auth error and fetch providers
@@ -96,6 +97,16 @@ export class LoginComponent implements OnInit {
       oauth: this.authService.getAvailableProviders(),
       saml: this.authService.getAvailableSAMLProviders(),
     }).subscribe({
+      // markForCheck is required, not optional. app-root (the router-outlet
+      // host) is OnPush, and this forkJoin resolves from an async HTTP
+      // callback rather than a template event. Without marking the path
+      // dirty, the change-detection tick that follows starts at the OnPush
+      // app-root, finds it clean, and prunes this whole subtree — so this
+      // CheckAlways component is never checked and the "Loading authentication
+      // providers" spinner stays up even though the data arrived. It only
+      // rendered intermittently, on loads where some other event happened to
+      // dirty an ancestor. markForCheck marks LoginComponent up through
+      // app-root so the tick reaches it.
       next: ({ oauth, saml }) => {
         this.oauthProviders = this.sortProviders(oauth);
         this.samlProviders = this.sortProviders(saml);
@@ -103,6 +114,8 @@ export class LoginComponent implements OnInit {
 
         // Load provider logos
         this.loadProviderLogos();
+
+        this.cdr.markForCheck();
 
         // this.logger.debugComponent('Auth', `Loaded providers`, {
         //   oauthCount: oauth.length,
@@ -114,6 +127,7 @@ export class LoginComponent implements OnInit {
       error: error => {
         this.providersLoading = false;
         this.error = 'Failed to load authentication providers';
+        this.cdr.markForCheck();
         this.logger.error('Failed to load authentication providers', error);
       },
     });

--- a/src/environments/environment.aws.spec.ts
+++ b/src/environments/environment.aws.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { environment } from './environment.aws';
+
+describe('AWS deployment environment', () => {
+  it('is a production build so runtime config and CSP injection are active', () => {
+    expect(environment.production).toBe(true);
+  });
+
+  it('points at the deployed TMI server', () => {
+    expect(environment.apiUrl).toBe('https://server.aws.tmi.dev');
+  });
+
+  it('has no trailing slash on apiUrl', () => {
+    // SecurityConfigService derives the CSP connect-src origin from this value
+    // via `new URL(environment.apiUrl).origin`; a trailing slash is silently
+    // tolerated there but breaks naive string concatenation elsewhere.
+    expect(environment.apiUrl.endsWith('/')).toBe(false);
+  });
+
+  it('declares exactly the security headers CloudFront is configured to send', () => {
+    // Mirrors terraform/aws/cloudfront.tf. If you change one, change both:
+    // this object is what the app reports about itself, not what is enforced.
+    expect(environment.securityConfig).toEqual({
+      enableHSTS: true,
+      hstsMaxAge: 31536000,
+      hstsIncludeSubDomains: true,
+      hstsPreload: false,
+      frameOptions: 'DENY',
+      referrerPolicy: 'strict-origin-when-cross-origin',
+      permissionsPolicy: 'camera=(), microphone=(), geolocation=()',
+    });
+  });
+});

--- a/src/environments/environment.aws.spec.ts
+++ b/src/environments/environment.aws.spec.ts
@@ -18,9 +18,14 @@ describe('AWS deployment environment', () => {
     expect(environment.apiUrl.endsWith('/')).toBe(false);
   });
 
-  it('declares exactly the security headers CloudFront is configured to send', () => {
-    // Mirrors terraform/aws/cloudfront.tf. If you change one, change both:
-    // this object is what the app reports about itself, not what is enforced.
+  it('pins the advisory securityConfig copy so edits are deliberate', () => {
+    // This compares environment.aws.ts against a literal in this same repo, so
+    // it only detects edits to environment.aws.ts — it cannot see edits to
+    // terraform/aws/cloudfront.tf, which is what actually decides the headers
+    // browsers receive. It is a change-detector on the copy, not verification
+    // of the edge. The copy feeds only generateRecommendedHeaders(), an
+    // advisory report; drift here is a reporting inaccuracy, not a
+    // vulnerability. If you change either file, change both by hand.
     expect(environment.securityConfig).toEqual({
       enableHSTS: true,
       hstsMaxAge: 31536000,

--- a/src/environments/environment.aws.ts
+++ b/src/environments/environment.aws.ts
@@ -1,0 +1,31 @@
+/**
+ * AWS Environment Configuration
+ *
+ * Used by the S3 + CloudFront deployment at https://app.aws.tmi.dev.
+ * See docs/reference/aws-deployment.md and terraform/aws/.
+ *
+ * The securityConfig block below is what the application reports about its own
+ * posture; the headers are actually emitted by the CloudFront response-headers
+ * policy in terraform/aws/cloudfront.tf. Keep the two in sync.
+ */
+
+import { Environment } from './environment.interface';
+
+export const environment: Environment = {
+  production: true,
+  logLevel: 'INFO',
+  apiUrl: 'https://server.aws.tmi.dev',
+  authTokenExpiryMinutes: 60,
+  operatorName: 'TMI Project (AWS Demo)',
+  operatorContact: 'https://github.com/ericfitz/tmi/discussions',
+  operatorJurisdiction: 'Florida, United States of America',
+  securityConfig: {
+    enableHSTS: true,
+    hstsMaxAge: 31536000, // 1 year
+    hstsIncludeSubDomains: true,
+    hstsPreload: false,
+    frameOptions: 'DENY',
+    referrerPolicy: 'strict-origin-when-cross-origin',
+    permissionsPolicy: 'camera=(), microphone=(), geolocation=()',
+  },
+};

--- a/src/environments/environment.aws.ts
+++ b/src/environments/environment.aws.ts
@@ -4,9 +4,15 @@
  * Used by the S3 + CloudFront deployment at https://app.aws.tmi.dev.
  * See docs/reference/aws-deployment.md and terraform/aws/.
  *
- * The securityConfig block below is what the application reports about its own
- * posture; the headers are actually emitted by the CloudFront response-headers
- * policy in terraform/aws/cloudfront.tf. Keep the two in sync.
+ * The securityConfig block below is a hand-maintained copy of the headers the
+ * CloudFront response-headers policy in terraform/aws/cloudfront.tf actually
+ * emits. Nothing here is enforced: it feeds only generateRecommendedHeaders()
+ * in core/services/security-config.service.ts, which publishes an advisory
+ * observable. Drift makes that report wrong, nothing more.
+ *
+ * environment.aws.spec.ts pins this block against a literal in the same repo,
+ * so it catches edits here but cannot see edits to cloudfront.tf. Keeping the
+ * two in sync is a manual discipline, not something the test verifies.
  */
 
 import { Environment } from './environment.interface';

--- a/terraform/aws/.gitignore
+++ b/terraform/aws/.gitignore
@@ -1,0 +1,7 @@
+.terraform/
+.terraform.lock.hcl.bak
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example
+crash.log

--- a/terraform/aws/.gitignore
+++ b/terraform/aws/.gitignore
@@ -5,3 +5,8 @@
 *.tfvars
 !*.tfvars.example
 crash.log
+
+# Backend configuration is per-deployer and not versioned, matching the
+# sibling tmi repo's `**/backend.hcl` rule. Its contents are documented in
+# docs/reference/aws-deployment.md so the stack can be re-initialized.
+backend.hcl

--- a/terraform/aws/.terraform.lock.hcl
+++ b/terraform/aws/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.55.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:99+MYIg/y3gmsZkhAcffwOpMat+liRJ8b+eyCIax6hk=",
+    "zh:1161fb2d032ad982587b2662a5229e5d06598c5b7fc5c86b2ad64d49225047cd",
+    "zh:1f412b09bbece216da0ba08106f3bbb42d8c8971c02d032ab518629915086966",
+    "zh:2c8b789450bb67181b5f0546714bf6336ba21183c307e001fe848c22dac1f8a6",
+    "zh:31eec91f896743bab641c06930fe0c277143f17dd25b2510991c08e013c8da67",
+    "zh:4419d3e906f1ca9c99703b2c4c5082f58aaeb8b8b82e2657a187a6bdf42d8881",
+    "zh:58e9a7e0581e8cd5f35eb2ce308b2d572073c112facdd0a60aee032146b146b5",
+    "zh:72fdb02a0cb6351626df460c047d1471f26dad781160cc95abd84f8849daf950",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:aa527913348c33969d80527d424917876657741493f294e160f1191dbc7c1d45",
+    "zh:b66e5abd756064f55ff06e1ef83eb8d0b7ea6d96625cfcd24408df5472d5f899",
+    "zh:ba9ab4ba151ac69a854407e27d3a12a2eb260fc4205bbb5c25618e6c8ce69568",
+    "zh:e1bf63e8a6b9790836f74848b458cdf679a7841e66a25b4b9f6034efc9310b34",
+    "zh:ec4adcec426f7181faa5de976cedbd35e15d7d1ac2914bbd9cab9f4f8b018b7f",
+    "zh:f17b485ae74bb4272d2bd680e7d47b0cfd073d192a4f10c8bdfd9d9f25c990a1",
+    "zh:f6650c2d0d3e614c3ccd623bb027a52bce1f5285c4f1824a26f265eb7529a45a",
+    "zh:f7383732f8704099db2166a3516e0a803bf46f42c30cd20a0471b55658ae6e51",
+  ]
+}

--- a/terraform/aws/backend.hcl
+++ b/terraform/aws/backend.hcl
@@ -1,0 +1,3 @@
+bucket         = "tmi-tfstate-967218005408"
+region         = "us-east-1"
+dynamodb_table = "tmi-tf-locks"

--- a/terraform/aws/backend.hcl
+++ b/terraform/aws/backend.hcl
@@ -1,3 +1,0 @@
-bucket         = "tmi-tfstate-967218005408"
-region         = "us-east-1"
-dynamodb_table = "tmi-tf-locks"

--- a/terraform/aws/buckets.tf
+++ b/terraform/aws/buckets.tf
@@ -1,0 +1,92 @@
+# ---------------------------------------------------------------------------
+# Content bucket: the built SPA. Private in every respect — no website
+# hosting, no public ACLs, no public policy. CloudFront reaches it via Origin
+# Access Control (see cloudfront.tf), which is also where its bucket policy
+# lives, because that policy must reference the distribution ARN.
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "content" {
+  bucket = var.content_bucket_name
+}
+
+resource "aws_s3_bucket_public_access_block" "content" {
+  bucket                  = aws_s3_bucket.content.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "content" {
+  bucket = aws_s3_bucket.content.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "content" {
+  bucket = aws_s3_bucket.content.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "content" {
+  bucket = aws_s3_bucket.content.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Log bucket: CloudFront standard (legacy) logging delivers via S3 ACLs, which
+# is incompatible with BucketOwnerEnforced. This bucket therefore enables ACLs
+# — the single place this deployment relaxes a security default, and it
+# applies only to logs. CloudFront adds the awslogsdelivery grant itself; the
+# public access block stays fully on because that grant is not a public ACL.
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "logs" {
+  bucket = var.log_bucket_name
+}
+
+resource "aws_s3_bucket_public_access_block" "logs" {
+  bucket                  = aws_s3_bucket.logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "logs" {
+  bucket = aws_s3_bucket.logs.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    id     = "expire-access-logs"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = var.log_retention_days
+    }
+  }
+}

--- a/terraform/aws/buckets.tf
+++ b/terraform/aws/buckets.tf
@@ -40,6 +40,39 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "content" {
   }
 }
 
+# Deliberately NO force_destroy here. Versioning is on so a bad deploy can be
+# rolled back; letting `terraform destroy` silently discard every version is
+# worse than the destroy failing with BucketNotEmpty. Emptying the bucket is a
+# conscious step — see docs/reference/aws-deployment.md.
+#
+# Versioning plus a deploy on every push would otherwise accumulate noncurrent
+# copies of each hashed bundle forever, so bound it here.
+resource "aws_s3_bucket_lifecycle_configuration" "content" {
+  bucket = aws_s3_bucket.content.id
+
+  rule {
+    id     = "expire-noncurrent-versions"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+
+  rule {
+    id     = "abort-incomplete-multipart-uploads"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
 # ---------------------------------------------------------------------------
 # Log bucket: CloudFront standard (legacy) logging delivers via S3 ACLs, which
 # is incompatible with BucketOwnerEnforced. This bucket therefore enables ACLs
@@ -50,6 +83,10 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "content" {
 
 resource "aws_s3_bucket" "logs" {
   bucket = var.log_bucket_name
+
+  # Access logs are disposable and the bucket is never empty in practice, so
+  # without this `terraform destroy` fails with BucketNotEmpty.
+  force_destroy = true
 }
 
 resource "aws_s3_bucket_public_access_block" "logs" {

--- a/terraform/aws/certificate.tf
+++ b/terraform/aws/certificate.tf
@@ -1,0 +1,48 @@
+# ---------------------------------------------------------------------------
+# Viewer certificate for the CloudFront distribution. Must be in us-east-1
+# regardless of where anything else lives — CloudFront reads viewer certs
+# only from that region. The provider is already pinned there via
+# var.aws_region.
+#
+# The hosted zone (aws.tmi.dev) already contains a certificate-validation
+# CNAME for server.aws.tmi.dev, owned by the separate TMI server deployment.
+# This resource only ever creates/manages records keyed by this
+# certificate's own domain_validation_options, so it cannot collide with
+# that record. allow_overwrite exists to let re-plans/re-creates of this
+# certificate's own validation record succeed, not to touch unrelated
+# records.
+# ---------------------------------------------------------------------------
+
+resource "aws_acm_certificate" "this" {
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "certificate_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id         = var.hosted_zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 60
+  allow_overwrite = true
+}
+
+# Gate: Task 4's CloudFront distribution must depend on this validation
+# resource (not the bare certificate) so the distribution isn't created
+# before the certificate has actually finished validating and become usable.
+resource "aws_acm_certificate_validation" "this" {
+  certificate_arn         = aws_acm_certificate.this.arn
+  validation_record_fqdns = [for record in aws_route53_record.certificate_validation : record.fqdn]
+}

--- a/terraform/aws/cloudfront.tf
+++ b/terraform/aws/cloudfront.tf
@@ -1,0 +1,188 @@
+locals {
+  origin_id = "s3-${aws_s3_bucket.content.id}"
+}
+
+# Managed cache policies, looked up by name rather than hard-coded ID.
+data "aws_cloudfront_cache_policy" "caching_optimized" {
+  name = "Managed-CachingOptimized"
+}
+
+data "aws_cloudfront_cache_policy" "caching_disabled" {
+  name = "Managed-CachingDisabled"
+}
+
+resource "aws_cloudfront_origin_access_control" "this" {
+  name                              = "tmi-ux-oac"
+  description                       = "OAC for the tmi-ux content bucket"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# ---------------------------------------------------------------------------
+# Response headers.
+#
+# The Content-Security-Policy here is DELIBERATELY frame-ancestors only.
+# SecurityConfigService injects a complete, provider-aware CSP meta tag at
+# runtime, built from environment.apiUrl and the CONTENT_PROVIDERS registry
+# (which includes a https://*.sharepoint.com wildcard and origins the server
+# supplies at runtime). A second CSP is enforced as an INTERSECTION with the
+# first, so any fetch directive added here that is narrower than the app's
+# will silently break the Google Drive / OneDrive pickers. frame-ancestors is
+# safe to add — and necessary — because meta-tag CSPs ignore it entirely, so
+# it is currently enforced nowhere.
+#
+# See docs/superpowers/specs/2026-07-22-tmi-ux-aws-deployment-design.md.
+# ---------------------------------------------------------------------------
+resource "aws_cloudfront_response_headers_policy" "this" {
+  name = "tmi-ux-security-headers"
+
+  security_headers_config {
+    content_security_policy {
+      content_security_policy = "frame-ancestors 'none'"
+      override                = true
+    }
+
+    content_type_options {
+      override = true
+    }
+
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+
+    referrer_policy {
+      referrer_policy = "strict-origin-when-cross-origin"
+      override        = true
+    }
+
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = true
+      preload                    = false
+      override                   = true
+    }
+  }
+
+  custom_headers_config {
+    items {
+      header   = "Permissions-Policy"
+      value    = "camera=(), microphone=(), geolocation=()"
+      override = true
+    }
+  }
+}
+
+resource "aws_cloudfront_distribution" "this" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "tmi-ux SPA"
+  default_root_object = "index.html"
+  aliases             = [var.domain_name]
+  price_class         = var.price_class
+  http_version        = "http2and3"
+
+  origin {
+    domain_name              = aws_s3_bucket.content.bucket_regional_domain_name
+    origin_id                = local.origin_id
+    origin_access_control_id = aws_cloudfront_origin_access_control.this.id
+  }
+
+  logging_config {
+    bucket          = aws_s3_bucket.logs.bucket_domain_name
+    prefix          = "cloudfront/"
+    include_cookies = false
+  }
+
+  default_cache_behavior {
+    target_origin_id           = local.origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD"]
+    compress                   = true
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_optimized.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+  }
+
+  # index.html and config.json are the two entry points that must never be
+  # served stale: index.html references hash-named bundles, and config.json is
+  # the no-rebuild override hook read by src/main.ts before bootstrap.
+  ordered_cache_behavior {
+    path_pattern               = "/index.html"
+    target_origin_id           = local.origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD"]
+    compress                   = true
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+  }
+
+  ordered_cache_behavior {
+    path_pattern               = "/config.json"
+    target_origin_id           = local.origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD"]
+    compress                   = true
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+  }
+
+  # SPA deep-link routing. With OAC, S3 returns 403 (not 404) for a missing
+  # key because the OAC principal has no s3:ListBucket. Known trade-off: this
+  # also renders the app shell when the origin is genuinely misconfigured, so
+  # when debugging a blank app, test the S3 origin directly before trusting
+  # a 200 from CloudFront.
+  custom_error_response {
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.this.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+}
+
+# Grants only this distribution read access to the content bucket.
+data "aws_iam_policy_document" "content" {
+  statement {
+    sid       = "AllowCloudFrontServicePrincipalReadOnly"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.content.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.this.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "content" {
+  bucket = aws_s3_bucket.content.id
+  policy = data.aws_iam_policy_document.content.json
+}

--- a/terraform/aws/dns.tf
+++ b/terraform/aws/dns.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_record" "ipv4" {
+  zone_id = var.hosted_zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.this.domain_name
+    zone_id                = aws_cloudfront_distribution.this.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "ipv6" {
+  zone_id = var.hosted_zone_id
+  name    = var.domain_name
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.this.domain_name
+    zone_id                = aws_cloudfront_distribution.this.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -1,0 +1,14 @@
+output "content_bucket" {
+  description = "Name of the S3 bucket holding the built SPA."
+  value       = aws_s3_bucket.content.id
+}
+
+output "distribution_id" {
+  description = "CloudFront distribution ID, used for cache invalidation."
+  value       = aws_cloudfront_distribution.this.id
+}
+
+output "site_url" {
+  description = "Public URL of the deployed SPA."
+  value       = "https://${var.domain_name}"
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -1,0 +1,51 @@
+variable "aws_region" {
+  description = "AWS region. Must be us-east-1: CloudFront viewer certificates are only read from us-east-1."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "domain_name" {
+  description = "Public hostname for the tmi-ux SPA."
+  type        = string
+  default     = "app.aws.tmi.dev"
+}
+
+variable "hosted_zone_id" {
+  description = "Route 53 hosted zone ID for aws.tmi.dev."
+  type        = string
+  default     = "Z05646533D2YL1I678JXS"
+}
+
+variable "content_bucket_name" {
+  description = "S3 bucket holding the built SPA. Private; reached only via CloudFront OAC."
+  type        = string
+  default     = "tmi-ux-app-967218005408"
+}
+
+variable "log_bucket_name" {
+  description = "S3 bucket for CloudFront standard access logs."
+  type        = string
+  default     = "tmi-ux-logs-967218005408"
+}
+
+variable "log_retention_days" {
+  description = "Days before CloudFront access logs expire."
+  type        = number
+  default     = 30
+}
+
+variable "price_class" {
+  description = "CloudFront price class. PriceClass_100 is North America + Europe edges only."
+  type        = string
+  default     = "PriceClass_100"
+}
+
+variable "tags" {
+  description = "Tags applied to every resource via the provider's default_tags."
+  type        = map(string)
+  default = {
+    Project   = "tmi"
+    Component = "tmi-ux"
+    ManagedBy = "terraform"
+  }
+}

--- a/terraform/aws/versions.tf
+++ b/terraform/aws/versions.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+
+  # Remote, encrypted state. Bucket / region / lock table come from
+  # backend.hcl so the state location stays per-deployer, while the key and
+  # encryption flag are pinned here. Deliberately a DIFFERENT key from the
+  # tmi server repo's "tmi/aws-public/terraform.tfstate" so UI infrastructure
+  # can be planned, applied and destroyed without touching server state.
+  #
+  #   terraform init -backend-config=backend.hcl
+  backend "s3" {
+    key     = "tmi-ux/aws-public/terraform.tfstate"
+    encrypt = true
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.tags
+  }
+}


### PR DESCRIPTION
Serves the tmi-ux SPA from S3 + CloudFront at **https://app.aws.tmi.dev** with ACM TLS, against the existing TMI server at `https://server.aws.tmi.dev`. **Deployed and verified live.**

## What's here

- **`terraform/aws/`** — private S3 bucket + CloudFront (OAC), ACM cert (DNS-validated), Route 53 A/AAAA, response-headers policy, 30-day access logs. Separate state key (`tmi-ux/aws-public/…`) from the server repo.
- **`src/environments/environment.aws.ts`** + `aws` build configuration (`build:aws`).
- **`scripts/deploy-aws.sh`** — 4-pass S3 sync (add hashed → stable assets → cut over entry points → prune), `/*` invalidation, and post-deploy verification (invalidation wait + `/` and a hashed-bundle content-type check).
- **`docs/reference/aws-deployment.md`** — runbook.

## Design decisions

- **Edge CSP is `frame-ancestors 'none'` only.** The app already injects a complete, provider-aware CSP at runtime; a second CSP is enforced as an intersection and a narrower fetch directive would silently break the Google Drive / OneDrive pickers. See the spec.
- **SPA fallback** maps origin 403/404 → `/index.html` (200); the deploy ordering avoids a broken-site window; the content bucket is versioned with a noncurrent-version lifecycle (no `force_destroy`).

## Login change-detection fix (found during verification)

`app-root` (the router-outlet host) is OnPush; LoginComponent (CheckAlways) resolved its provider list from an async HTTP callback, so the CD tick was pruned at the clean OnPush ancestor and the "Loading authentication providers" spinner hung intermittently. Fixed with `ChangeDetectorRef.markForCheck()`. Verified 5/5 cold loads render (was ~0/5). Not specific to this deployment — cross-origin latency merely exposed the latent race.

## Server-side prerequisite (already applied)

`TMI_OAUTH_CLIENT_CALLBACK_ALLOWLIST=https://app.aws.tmi.dev/*` on `tmi-server-config`. Google login verified end-to-end.

## Not included (out of scope, surfaced during testing)

- TMI provider advertised on the interactive-login endpoint in production, and Microsoft/GitHub not advertised — both are server-side provider-list concerns; client-side filtering was explicitly declined.

## Verification

`pnpm test` → 5979 passed. `lint:all` clean. `build:aws` clean. Live: security headers correct, per-class cache-control correct, deep links route, direct-S3 returns 403, access logs delivering, browser console clean (no CSP violations), Google login e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)