### PR TITLE
ops: move version bump onto the PR (fixes #789)

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,15 +1,36 @@
 name: Version Bump
 
-# Single source of truth for semantic version bumping. Runs on every push to
-# main (PR merges and direct pushes alike), derives the bump from the pushed
-# conventional commits, and commits `chore: bump version to X.Y.Z [skip ci]`
-# plus a vX.Y.Z tag back to main.
+# Version bumping runs on the PR, not after merge (issue #789). The `main`
+# repository ruleset requires a PR plus the CodeQL check with no bypass actors,
+# so nothing — not even the built-in GITHUB_TOKEN — can push straight to main.
 #
-# No loop: the commit is pushed with the built-in GITHUB_TOKEN, whose pushes do
-# not trigger new workflow runs. The `[skip ci]` marker and the job-level guard
-# below are belt-and-suspenders.
+# Design:
+#   - bump (pull_request): derive the target version from the PR's conventional
+#     commits and commit the bump to the PR head branch. The push uses the
+#     DEPS_BOT GitHub App token (not GITHUB_TOKEN) precisely because an App-token
+#     push RE-TRIGGERS workflows, so CodeQL re-runs on the bumped head commit and
+#     the required check is satisfied on the SHA that will merge. A GITHUB_TOKEN
+#     push does not re-trigger CI and would leave the required check missing,
+#     blocking the merge forever.
+#   - tag (push: main): after the PR merges, create/push the vX.Y.Z tag for the
+#     version now on main. Tags live under refs/tags/* which the branch ruleset
+#     does not cover, so a tag push is allowed. Idempotent, so it also self-heals
+#     any version already on main that never got tagged.
+#   - check-bump (pull_request): fork and dependabot[bot] PRs run with a
+#     read-only token and no access to the App secret, so we cannot push a bump
+#     to them. Instead fail with an actionable message telling the author which
+#     version to set by hand. This check is not in the ruleset's required set, so
+#     it flags loudly without hard-blocking the merge.
+#
+# Idempotency: the target is computed from the merge-base (the version on main),
+# never from the PR's current package.json, so re-running on `synchronize` — including
+# the synchronize fired by our own bump push — never double-bumps. Version math
+# lives in scripts/compute-next-version.mjs.
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
   push:
     branches: [main]
 
@@ -17,14 +38,68 @@ permissions:
   contents: write
 
 concurrency:
-  group: version-bump
+  group: version-bump-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   bump:
+    # Auto-bump only PRs we can push to: same-repo head branch, not dependabot[bot].
+    # Fork and dependabot[bot] PRs are handled by check-bump below.
+    if: >-
+      ${{ github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
-    # Skip our own bump commits (redundant with GITHUB_TOKEN non-retrigger, kept explicit).
-    if: "${{ !startsWith(github.event.head_commit.message, 'chore: bump version') }}"
+    steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DEPS_BOT_APP_ID }}
+          private-key: ${{ secrets.DEPS_BOT_APP_PRIVATE_KEY }}
+
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Compute and apply version bump
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+
+          # Shared version math (BASE/HEAD_VER/BUMP/TARGET). A non-zero exit here
+          # aborts the job (set -e on the assignment) rather than silently skipping.
+          OUT=$(bash scripts/pr-version-target.sh)
+          eval "$OUT"
+
+          if [ "$TARGET" = "$HEAD_VER" ]; then
+            echo "package.json already at $HEAD_VER (target $TARGET); nothing to do."
+            exit 0
+          fi
+
+          echo "Bumping $HEAD_VER -> $TARGET (base $BASE, bump ${BUMP:-none})"
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('./package.json','utf8'));p.version='$TARGET';fs.writeFileSync('./package.json',JSON.stringify(p,null,2)+'\n');"
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add package.json
+          git commit -m "chore: bump version to $TARGET"
+          git push origin "HEAD:$HEAD_REF"
+          echo "Pushed bump to $TARGET on $HEAD_REF."
+
+  tag:
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,89 +112,60 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      - name: Compute and apply version bump
+      - name: Create and push tag if missing
+        run: |
+          set -euo pipefail
+          V=$(node -p "require('./package.json').version")
+          TAG="v$V"
+          if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already on origin; nothing to do."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "$TAG" -m "Release version $V"
+          git push origin "$TAG"
+          echo "Tagged $TAG."
+
+  check-bump:
+    # Fork and dependabot[bot] PRs cannot be pushed to (read-only token, no App
+    # secret). Fail with an actionable message so the author bumps by hand.
+    if: >-
+      ${{ github.event_name == 'pull_request'
+      && (github.event.pull_request.head.repo.full_name != github.repository
+      || github.actor == 'dependabot[bot]') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout PR merge ref
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Verify the version was bumped manually
         env:
-          BEFORE: ${{ github.event.before }}
-          AFTER: ${{ github.event.after }}
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           set -euo pipefail
 
-          # --- Determine the commit range for this push ---
-          # For an existing branch, github.event.before is the prior tip. Guard against
-          # the all-zeros sentinel (branch creation) by falling back to the first parent.
-          if printf '%s' "$BEFORE" | grep -qE '^0+$'; then
-            RANGE_BASE=$(git rev-parse HEAD^ 2>/dev/null || echo '')
-          else
-            RANGE_BASE="$BEFORE"
-          fi
+          # Same shared version math the bump job uses, so the advisory target
+          # matches exactly what auto-bump would have produced. For a fork PR the
+          # default checkout is the merge ref (refs/pull/N/merge); its first
+          # parent is origin/BASE_REF, so the merge base resolves to current main.
+          OUT=$(bash scripts/pr-version-target.sh)
+          eval "$OUT"
 
-          # --- Relevant-files filter (mirrors the retired post-commit hook) ---
-          # Bump only when the push touches version-relevant files: package.json or
-          # src/ excluding tests, testing utilities, and environment configs.
-          if [ -n "$RANGE_BASE" ]; then
-            CHANGED=$(git diff --name-only "$RANGE_BASE" "$AFTER")
-          else
-            CHANGED=$(git show --name-only --pretty=format: HEAD)
-          fi
-          RELEVANT=$(printf '%s\n' "$CHANGED" \
-            | grep -E '^(package\.json|src/)' \
-            | grep -v '\.spec\.ts$' \
-            | grep -v '^src/testing/' \
-            | grep -v '^src/environments/' || true)
-          if [ -z "$RELEVANT" ]; then
-            echo "No version-relevant files changed; skipping bump."
+          if [ "$TARGET" = "$BASE" ] || [ "$HEAD_VER" = "$TARGET" ]; then
+            echo "Version OK: base $BASE, head $HEAD_VER, target $TARGET."
             exit 0
           fi
 
-          # --- Derive bump type from the conventional commits in the range ---
-          # minor wins over patch; feat/refactor -> minor, other bumpable types -> patch.
-          if [ -n "$RANGE_BASE" ]; then
-            SUBJECTS=$(git log --format='%s' "${RANGE_BASE}..${AFTER}")
-          else
-            SUBJECTS=$(git log -1 --format='%s' HEAD)
-          fi
-          # Drop our own bump commits, then extract the leading conventional type from each subject.
-          TYPES=$(printf '%s\n' "$SUBJECTS" \
-            | grep -vE '^chore: bump version' \
-            | sed -nE 's/^([a-z]+)(\(.+\))?!?: .+/\1/p' || true)
-          if printf '%s\n' "$TYPES" | grep -qE '^(feat|refactor)$'; then
-            BUMP='minor'
-          elif printf '%s\n' "$TYPES" | grep -qE '^(fix|docs|perf|test|build|ci|chore|deps|ops)$'; then
-            BUMP='patch'
-          else
-            BUMP=''
-          fi
-
-          if [ -z "$BUMP" ]; then
-            echo "No bumpable conventional commits in range; skipping bump."
-            exit 0
-          fi
-
-          # --- Compute the next version ---
-          CURRENT=$(node -p "require('./package.json').version")
-          if [ -n "$RANGE_BASE" ]; then
-            PREVIOUS=$(git show "${RANGE_BASE}:package.json" 2>/dev/null \
-              | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).version))" \
-              2>/dev/null || echo "$CURRENT")
-          else
-            PREVIOUS="$CURRENT"
-          fi
-          NEW=$(node scripts/compute-next-version.mjs "$CURRENT" "$PREVIOUS" "$BUMP")
-
-          if [ "$NEW" = "$CURRENT" ]; then
-            echo "Version already $CURRENT ($BUMP resolved to no change); nothing to do."
-            exit 0
-          fi
-          echo "Bumping $CURRENT -> $NEW ($BUMP)"
-
-          # --- Apply, commit, tag, push (GITHUB_TOKEN push does not re-trigger) ---
-          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('./package.json','utf8'));p.version='$NEW';fs.writeFileSync('./package.json',JSON.stringify(p,null,2)+'\n');"
-
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add package.json
-          git commit -m "chore: bump version to $NEW [skip ci]"
-          git tag -a "v$NEW" -m "Release version $NEW"
-          git push origin HEAD:main
-          git push origin "v$NEW"
-          echo "Bumped to $NEW and tagged v$NEW."
+          echo "::error title=Version bump required::This PR is not auto-version-bumped (fork or Dependabot). Set package.json \"version\" to $TARGET and push the change."
+          exit 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmi-ux",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "type": "module",
   "scripts": {
     "prepare": "git config core.hooksPath .husky 2>/dev/null || true",

--- a/scripts/pr-version-target.sh
+++ b/scripts/pr-version-target.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Compute the PR's target package.json version for the Version Bump workflow
+# (.github/workflows/version-bump.yml). Shared by the `bump` and `check-bump`
+# jobs so their version math can never drift.
+#
+# Inputs (environment):
+#   BASE_REF  PR base branch, e.g. `main` (github.base_ref). Required.
+#   HEAD_REF  PR head branch name (github.head_ref). Optional; used only for the
+#             `release/*` durable signal, so it works for fork PRs too (the name
+#             is still known even though the branch lives in the fork).
+#
+# Requires a full-history checkout (fetch-depth: 0) and node on PATH.
+#
+# Emits eval-able KEY=VALUE lines on stdout; all diagnostics go to stderr:
+#   BASE=<package.json version on BASE_REF at the merge base>
+#   HEAD_VER=<package.json version in the current checkout>
+#   BUMP=<minor|patch|"">   (conventional-commit bump for the PR range)
+#   TARGET=<computed next version>
+#
+# Idempotency: TARGET for a plain bump is computed from BASE (the merge-base
+# version), never from HEAD_VER, so re-running on `synchronize` — including the
+# synchronize fired by the bump job's own push — resolves to the same TARGET and
+# no-ops. Human-owned versions (release/* finalization, manual major raise) are
+# computed from HEAD_VER and preserved via durable signals that survive re-runs.
+set -euo pipefail
+
+: "${BASE_REF:?BASE_REF is required}"
+HEAD_REF="${HEAD_REF:-}"
+
+ROOT=$(git rev-parse --show-toplevel)
+
+# git fetch chatter belongs on stderr so it never pollutes the KEY=VALUE stdout.
+git fetch --no-tags origin "$BASE_REF" 1>&2
+MERGE_BASE=$(git merge-base "origin/$BASE_REF" HEAD)
+
+read_version() {
+  node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).version))"
+}
+
+BASE=$(git show "$MERGE_BASE:package.json" | read_version)
+HEAD_VER=$(node -p "require('$ROOT/package.json').version")
+
+major() { printf '%s' "$1" | sed -E 's/^([0-9]+)\..*/\1/'; }
+has_pre() { printf '%s' "$1" | grep -q '-'; }
+
+# Relevant-files filter: bump only for package.json or src/, excluding tests,
+# testing utilities, and environment configs. Infra-only changes (.github/,
+# scripts/, docs) do not bump.
+CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
+RELEVANT=$(printf '%s\n' "$CHANGED" \
+  | grep -E '^(package\.json|src/)' \
+  | grep -v '\.spec\.ts$' \
+  | grep -v '^src/testing/' \
+  | grep -v '^src/environments/' || true)
+
+# Derive the conventional-commit bump type from the PR range, dropping our own
+# bump commits. minor wins over patch.
+SUBJECTS=$(git log --format='%s' "${MERGE_BASE}..HEAD")
+TYPES=$(printf '%s\n' "$SUBJECTS" \
+  | grep -vE '^chore: bump version' \
+  | sed -nE 's/^([a-z]+)(\(.+\))?!?: .+/\1/p' || true)
+if printf '%s\n' "$TYPES" | grep -qE '^(feat|refactor)$'; then
+  BUMP='minor'
+elif printf '%s\n' "$TYPES" | grep -qE '^(fix|docs|perf|test|build|ci|chore|deps|ops)$'; then
+  BUMP='patch'
+else
+  BUMP=''
+fi
+if [ -z "$RELEVANT" ]; then
+  BUMP=''
+fi
+
+# Human-owned versions are preserved/finalized (computed from HEAD_VER), never
+# auto-incremented; their signals survive re-runs. Everything else is a plain
+# bump computed from BASE.
+if printf '%s' "$HEAD_REF" | grep -qE '^release/' \
+  || has_pre "$HEAD_VER" \
+  || [ "$(major "$HEAD_VER")" -gt "$(major "$BASE")" ]; then
+  TARGET=$(node "$ROOT/scripts/compute-next-version.mjs" "$HEAD_VER" "$BASE" "")
+else
+  TARGET=$(node "$ROOT/scripts/compute-next-version.mjs" "$BASE" "$BASE" "$BUMP")
+fi
+
+printf 'BASE=%s\nHEAD_VER=%s\nBUMP=%s\nTARGET=%s\n' "$BASE" "$HEAD_VER" "$BUMP" "$TARGET"


### PR DESCRIPTION
Fixes #789.

## Problem

The `main` ruleset requires a PR + the CodeQL check `Analyze (javascript-typescript)` with **no bypass actors**. The old `Version Bump` workflow ran on `push: [main]` and pushed a bump commit + tag straight to `main`, which is now rejected (`GH013`). The version is stuck at `1.5.2` with no tags.

## Change

`version-bump.yml` is redesigned into three jobs:

| Job | Trigger | Does |
|-----|---------|------|
| `bump` | `pull_request` (same-repo, non-dependabot) | Computes the target from the PR's conventional commits against the merge base and commits the bump to the **PR head branch** |
| `tag` | `push: main` | Creates/pushes `vX.Y.Z` for the version now on main, if missing |
| `check-bump` | `pull_request` (fork / `dependabot[bot]`) | Fails with an actionable message telling the author to bump by hand |

### Why the App token (not `GITHUB_TOKEN`)

The bump is pushed to the PR head with the existing **DEPS_BOT App** token. A `GITHUB_TOKEN` push does **not** re-trigger workflows, so CodeQL would never run on the bumped head SHA and the required check would be permanently missing — blocking the merge. An App-token push re-triggers CI, so the required check runs against the version that will actually merge.

### Why tags still work

Both rulesets are **branch-scoped** (`refs/heads/*`); tags (`refs/tags/*`) aren't covered, so the `tag` job's push is allowed. It's idempotent, so it also **self-heals** the currently-stuck `1.5.2` on the next push to main.

### Idempotency

`TARGET` is computed from the **merge base** (the version on main), never from the PR's current `package.json`, so re-running on `synchronize` — including the synchronize fired by the bump job's own push — resolves to the same target and no-ops. `release/*` finalization (strip `-rc.N`) and manual major raises are preserved via durable signals (branch name, prerelease suffix, `major(HEAD) > major(BASE)`). The shared math lives in `scripts/pr-version-target.sh`, used by both `bump` and `check-bump` so they can't drift.

## Validation

- `actionlint` + `shellcheck` clean; `compute-next-version.mjs --test` 11/11.
- Offline end-to-end test of `pr-version-target.sh` across: plain fix (`1.5.3`), idempotent re-run (no double-bump), feat-on-top upgrade (`1.6.0`), `release/*` finalization (`1.7.0-rc.0` → `1.7.0`, stable), manual major (`2.0.0` preserved), infra-only/tests-only (no bump).

## Notes

- This PR is workflow/scripts-only, so `bump` will correctly **no-op** (no version-relevant files) — that's expected; the real exercise is the first `feat:`/`fix:` PR after merge.
- Fork/Dependabot PRs merge without a bump but get a red (non-blocking) advisory check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)