### PR TITLE
fix: repaint routed pages by reverting app-root to CheckAlways

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmi-ux",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "type": "module",
   "scripts": {
     "prepare": "git config core.hooksPath .husky 2>/dev/null || true",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,37 @@
+// This project uses vitest for all unit tests, with native vitest syntax.
+// Do not use Jasmine or Jest, or Jasmine or Jest syntax anywhere in the project.
+
+import '@angular/compiler';
+
+import { describe, it, expect } from 'vitest';
+
+import { AppComponent } from './app.component';
+
+describe('AppComponent', () => {
+  describe('change detection strategy', () => {
+    // AppComponent hosts the <router-outlet>, so every routed page renders
+    // inside its view. If this component is OnPush, a change-detection tick
+    // starts here, finds it clean, and prunes the entire subtree — a routed
+    // CheckAlways page that mutates state from an async callback (HTTP
+    // subscribe, setTimeout, Promise.then) then updates its model but never
+    // repaints.
+    //
+    // That is not hypothetical: making this OnPush in 67ba1fef hung the
+    // "Loading authentication providers" spinner on the login page and left
+    // every admin list page (groups, settings, users, ...) spinning forever
+    // while their APIs returned 200. It read as intermittent only because the
+    // navbar's async pipes transiently mark this component dirty, letting a
+    // full traversal through.
+    //
+    // Do not convert this component to OnPush.
+    it('is CheckAlways so routed pages are not pruned from change detection', () => {
+      // ɵcmp is private Angular API with no compatibility promise. It has been
+      // stable since Ivy, and the failure mode is a loud test break at upgrade
+      // time rather than a silent pass. If this breaks during an Angular
+      // upgrade, update the probe — do not "fix" it by changing the strategy.
+      const def = (AppComponent as unknown as { ɵcmp: { onPush: boolean } }).ɵcmp;
+
+      expect(def.onPush).toBe(false);
+    });
+  });
+});

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -27,7 +27,15 @@ import { SessionManagerService } from './auth/services/session-manager.service';
   standalone: true,
   imports: [RouterOutlet, CommonModule, NavbarComponent, FooterComponent],
   templateUrl: './app.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // Must stay CheckAlways. This component hosts the <router-outlet>, so every
+  // routed page renders inside its view. Under OnPush, a change-detection tick
+  // starts at this (clean) component and prunes the entire subtree, so a routed
+  // CheckAlways page that mutates state from an async callback — an HTTP
+  // subscribe, setTimeout, Promise.then — updates its model but never repaints.
+  // That produced hung loading spinners across the admin pages and the login
+  // page; it looked intermittent only because the navbar's async pipes
+  // transiently mark this component dirty and let a full traversal through.
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './app.component.scss',
 })
 // SEM@4ed130a60616a970c685c78ff132b21800f7ae3b: root application shell; bootstraps injector and session manager (mutates shared state)

--- a/src/app/auth/components/identity-link-callback/identity-link-callback.component.spec.ts
+++ b/src/app/auth/components/identity-link-callback/identity-link-callback.component.spec.ts
@@ -1,6 +1,7 @@
 import '@angular/compiler';
 
 import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { ChangeDetectorRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -40,6 +41,7 @@ function buildFixture(overrides: MockOverrides): {
   auth: { initiateStepUp: ReturnType<typeof vi.fn> };
   router: { navigateByUrl: ReturnType<typeof vi.fn> };
   snackBar: { open: ReturnType<typeof vi.fn> };
+  markForCheck: ReturnType<typeof vi.spyOn>;
 } {
   const identityLink = {
     getPending: overrides.getPending ?? vi.fn().mockReturnValue(of(PENDING)),
@@ -70,8 +72,16 @@ function buildFixture(overrides: MockOverrides): {
   }).compileComponents();
 
   const fixture = TestBed.createComponent(IdentityLinkCallbackComponent);
+
+  // Spy before the first detectChanges so ngOnInit's async resolve is observed.
+  // Note ComponentFixture.detectChanges() force-checks this view regardless of
+  // its dirty flag, so asserting on rendered DOM cannot catch a missing
+  // markForCheck — only spying on the ChangeDetectorRef can.
+  const cdr = (fixture.componentInstance as unknown as { cdr: ChangeDetectorRef }).cdr;
+  const markForCheck = vi.spyOn(cdr, 'markForCheck');
+
   fixture.detectChanges();
-  return { fixture, identityLink, auth, router, snackBar };
+  return { fixture, identityLink, auth, router, snackBar, markForCheck };
 }
 
 describe('IdentityLinkCallbackComponent', () => {
@@ -95,6 +105,40 @@ describe('IdentityLinkCallbackComponent', () => {
     expect(identityLink.getPending).toHaveBeenCalledWith('tok');
     expect(component.state).toBe('confirm');
     expect(component.pending).toEqual(PENDING);
+  });
+
+  // Regression tests for the hung-spinner class of bug. This component is
+  // OnPush, so state it assigns from an HTTP callback (rather than a template
+  // event) is never repainted unless it marks itself for check — the view stays
+  // on the 'loading' spinner even though the data arrived. Same defect that hung
+  // the login page (e6fc5244) and the admin list pages.
+  it('marks for check when pending details resolve so the confirm view repaints', () => {
+    const { markForCheck } = buildFixture({ queryParams: { link_pending: 'tok' } });
+
+    expect(markForCheck).toHaveBeenCalled();
+  });
+
+  it('marks for check when loading pending details fails', () => {
+    const { markForCheck, fixture } = buildFixture({
+      queryParams: { link_pending: 'tok' },
+      getPending: vi.fn().mockReturnValue(throwError(() => ({ status: 404 }))),
+    });
+
+    expect(fixture.componentInstance.state).toBe('error');
+    expect(markForCheck).toHaveBeenCalled();
+  });
+
+  it('marks for check when confirm fails so the error view repaints', () => {
+    const { markForCheck, fixture } = buildFixture({
+      queryParams: { link_pending: 'tok' },
+      confirmLink: vi.fn().mockReturnValue(throwError(() => ({ status: 404 }))),
+    });
+    markForCheck.mockClear();
+
+    fixture.componentInstance.onConfirm();
+
+    expect(fixture.componentInstance.state).toBe('error');
+    expect(markForCheck).toHaveBeenCalled();
   });
 
   it('initiates step-up re-auth when confirmLink throws StepUpRequiredError', () => {

--- a/src/app/auth/components/identity-link-callback/identity-link-callback.component.ts
+++ b/src/app/auth/components/identity-link-callback/identity-link-callback.component.ts
@@ -1,4 +1,10 @@
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  OnInit,
+  inject,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
@@ -43,6 +49,7 @@ export class IdentityLinkCallbackComponent implements OnInit {
   private auth = inject(AuthService);
   private transloco = inject(TranslocoService);
   private logger = inject(LoggerService);
+  private cdr = inject(ChangeDetectorRef);
 
   state: ViewState = 'loading';
   errorKey = 'identities.link.error.generic';
@@ -80,6 +87,9 @@ export class IdentityLinkCallbackComponent implements OnInit {
       next: details => {
         this.pending = details;
         this.state = 'confirm';
+        // OnPush: this resolves from an HTTP callback, not a template event, so
+        // without markForCheck the view stays on the 'loading' spinner forever.
+        this.cdr.markForCheck();
       },
       error: (err: unknown) => {
         this.logger.warn('Failed to load pending identity link', err);
@@ -89,6 +99,7 @@ export class IdentityLinkCallbackComponent implements OnInit {
             ? 'identities.link.error.expired'
             : 'identities.link.error.generic';
         this.state = 'error';
+        this.cdr.markForCheck();
       },
     });
   }
@@ -130,5 +141,7 @@ export class IdentityLinkCallbackComponent implements OnInit {
     }
     this.logger.warn('Identity-link confirm failed', err);
     this.state = 'error';
+    // Reached from confirmLink()'s async error callback — see loadPending().
+    this.cdr.markForCheck();
   }
 }

--- a/src/app/auth/components/login/login.component.spec.ts
+++ b/src/app/auth/components/login/login.component.spec.ts
@@ -184,15 +184,15 @@ describe('LoginComponent', () => {
       expect(component.error).toBe('Failed to load authentication providers');
     });
 
-    // Regression test for the intermittent "Loading authentication providers"
-    // hang. app-root (the router-outlet host) is OnPush, and this forkJoin
-    // resolves from an async HTTP callback rather than a template event, so the
-    // change-detection tick that follows is pruned at the clean OnPush ancestor
-    // and never reaches this CheckAlways component — the spinner stays up even
-    // though the data arrived. The fix marks the component (and its ancestors)
-    // for check. These tests guard that both the success and error paths call
-    // markForCheck.
-    it('should mark for check after providers load so the OnPush ancestor is traversed', () => {
+    // Regression tests for the intermittent "Loading authentication providers"
+    // hang, which occurred while app-root (the router-outlet host) was OnPush:
+    // this forkJoin resolves from an async HTTP callback rather than a template
+    // event, so the tick was pruned at the clean OnPush ancestor and never
+    // reached this CheckAlways component — the spinner stayed up even though the
+    // data arrived. app-root is CheckAlways again (guarded by
+    // app.component.spec.ts), so these markForCheck calls are now defense in
+    // depth rather than load-bearing. These tests keep them from being dropped.
+    it('should mark for check after providers load so the component repaints', () => {
       component.ngOnInit();
 
       expect(mockCdr.markForCheck).toHaveBeenCalled();

--- a/src/app/auth/components/login/login.component.ts
+++ b/src/app/auth/components/login/login.component.ts
@@ -97,16 +97,14 @@ export class LoginComponent implements OnInit {
       oauth: this.authService.getAvailableProviders(),
       saml: this.authService.getAvailableSAMLProviders(),
     }).subscribe({
-      // markForCheck is required, not optional. app-root (the router-outlet
-      // host) is OnPush, and this forkJoin resolves from an async HTTP
-      // callback rather than a template event. Without marking the path
-      // dirty, the change-detection tick that follows starts at the OnPush
-      // app-root, finds it clean, and prunes this whole subtree — so this
-      // CheckAlways component is never checked and the "Loading authentication
-      // providers" spinner stays up even though the data arrived. It only
-      // rendered intermittently, on loads where some other event happened to
-      // dirty an ancestor. markForCheck marks LoginComponent up through
-      // app-root so the tick reaches it.
+      // Kept as defense in depth. While app-root (the router-outlet host) was
+      // OnPush — between 67ba1fef and the fix that reverted it to CheckAlways —
+      // this forkJoin resolving from an async HTTP callback left the "Loading
+      // authentication providers" spinner up: the tick started at the clean
+      // OnPush app-root and pruned this whole subtree before reaching this
+      // CheckAlways component. app-root is CheckAlways again, so these calls are
+      // no longer load-bearing, but they keep this component correct on its own
+      // terms rather than relying on an ancestor's strategy.
       next: ({ oauth, saml }) => {
         this.oauthProviders = this.sortProviders(oauth);
         this.samlProviders = this.sortProviders(saml);

--- a/src/app/pages/chat/components/chat-page/chat-page.component.ts
+++ b/src/app/pages/chat/components/chat-page/chat-page.component.ts
@@ -625,6 +625,10 @@ export class ChatPageComponent implements OnInit {
         },
         error: err => {
           this.logger.error('Failed to load sessions', err);
+          // Callers clear active-session state before calling this and rely on
+          // the success path to repaint. If the reload fails, this OnPush view
+          // would otherwise keep showing the deleted session's messages.
+          this.cdr.markForCheck();
         },
       });
   }

--- a/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.spec.ts
+++ b/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.spec.ts
@@ -16,6 +16,7 @@ describe('AiFeedbackDialogComponent', () => {
   let mockSnack: { open: ReturnType<typeof vi.fn> };
   let mockTransloco: TranslocoService;
   let mockLogger: Record<string, ReturnType<typeof vi.fn>>;
+  let mockCdr: { markForCheck: ReturnType<typeof vi.fn>; detectChanges: ReturnType<typeof vi.fn> };
 
   // SEM@03e5c5f70bd2b59edee41faf9772e5f114bffc49: build an AiFeedbackDialogComponent with mocked dependencies for unit testing (pure)
   function build(data: AiFeedbackDialogData, init = true): AiFeedbackDialogComponent {
@@ -27,6 +28,7 @@ describe('AiFeedbackDialogComponent', () => {
       mockSnack as never,
       mockTransloco,
       mockLogger as never,
+      mockCdr as never,
     );
     if (init) component.ngOnInit();
     return component;
@@ -44,6 +46,7 @@ describe('AiFeedbackDialogComponent', () => {
     mockSnack = { open: vi.fn() };
     mockTransloco = { translate: vi.fn((key: string) => key) } as unknown as TranslocoService;
     mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    mockCdr = { markForCheck: vi.fn(), detectChanges: vi.fn() };
   });
 
   describe('initialization', () => {
@@ -137,6 +140,20 @@ describe('AiFeedbackDialogComponent', () => {
       expect(mockLogger['error']).toHaveBeenCalled();
       expect(component.submitting).toBe(false);
       expect(mockDialogRef.close).not.toHaveBeenCalled();
+    });
+
+    // This dialog is OnPush and `submitting` gates [disabled] on both buttons.
+    // Clearing it from an HTTP error callback (not a DOM event) does not repaint
+    // on its own, so without markForCheck a failed submit leaves the dialog
+    // permanently unusable — the user can neither retry nor cancel.
+    it('marks for check on submit failure so the buttons re-enable', () => {
+      mockFeedback.submit.mockReturnValue(throwError(() => new Error('boom')));
+      const component = build({ ...threatData, initialSentiment: 'up' });
+      mockCdr.markForCheck.mockClear();
+
+      component.onSubmit();
+
+      expect(mockCdr.markForCheck).toHaveBeenCalled();
     });
   });
 

--- a/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.ts
+++ b/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.ts
@@ -1,4 +1,10 @@
-import { ChangeDetectionStrategy, Component, Inject, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Inject,
+  OnInit,
+} from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -57,6 +63,7 @@ export class AiFeedbackDialogComponent implements OnInit {
     private readonly _snack: MatSnackBar,
     private readonly _transloco: TranslocoService,
     private readonly _logger: LoggerService,
+    private readonly _cdr: ChangeDetectorRef,
   ) {
     this.form = fb.group({
       sentiment: [data.initialSentiment ?? null, Validators.required],
@@ -132,6 +139,9 @@ export class AiFeedbackDialogComponent implements OnInit {
         error: err => {
           this._logger.error('AI feedback submit failed', err);
           this.submitting = false;
+          // OnPush: without this the Submit/Cancel buttons stay disabled after a
+          // failed submit, since this runs in an HTTP callback, not a DOM event.
+          this._cdr.markForCheck();
           this._snack.open(this._transloco.translate('aiFeedback.snackbarFailed'), undefined, {
             duration: 6000,
           });

--- a/src/app/shared/components/usability-feedback-dialog/usability-feedback-dialog.component.spec.ts
+++ b/src/app/shared/components/usability-feedback-dialog/usability-feedback-dialog.component.spec.ts
@@ -120,6 +120,20 @@ describe('UsabilityFeedbackDialogComponent', () => {
       expect(mockDialogRef.close).not.toHaveBeenCalled();
       expect(mockSnack.open).toHaveBeenCalled();
     });
+
+    // This dialog is OnPush and `submitting` gates [disabled] on both buttons.
+    // Clearing it from an HTTP error callback (not a DOM event) does not repaint
+    // on its own, so without markForCheck a failed submit leaves the dialog
+    // permanently unusable — the user can neither retry nor cancel.
+    it('marks for check on submit failure so the buttons re-enable', () => {
+      mockFeedback.submit.mockReturnValue(throwError(() => new Error('boom')));
+      const component = build({ surface: 'dashboard', initialSentiment: 'up' });
+      mockCdr.markForCheck.mockClear();
+
+      component.onSubmit();
+
+      expect(mockCdr.markForCheck).toHaveBeenCalled();
+    });
   });
 
   describe('onCancel', () => {

--- a/src/app/shared/components/usability-feedback-dialog/usability-feedback-dialog.component.ts
+++ b/src/app/shared/components/usability-feedback-dialog/usability-feedback-dialog.component.ts
@@ -124,6 +124,9 @@ export class UsabilityFeedbackDialogComponent {
         error: err => {
           this._logger.error('Usability feedback submit failed', err);
           this.submitting = false;
+          // OnPush: without this the Submit/Cancel buttons stay disabled after a
+          // failed submit, since this runs in an HTTP callback, not a DOM event.
+          this._cdr.markForCheck();
           this._snack.open(
             this._transloco.translate('usabilityFeedback.snackbarFailed'),
             undefined,


### PR DESCRIPTION
## Problem

The admin list pages (groups, settings, users, …) hang on their loading spinner even though the APIs return 200.

Captured on the live AWS deployment before the fix:

- `GET /admin/groups?limit=25&offset=0` → **200**, and the component logged `Groups loaded` — which runs *after* `this.loading = false` — while the DOM still showed `mat-spinner` with 0 rows.
- Clicking a navbar button then rendered all 6 rows instantly, with the network log still showing **exactly one** request. The data was already in the component; only the repaint was missing.

## Root cause

`app.component` (`app-root`) hosts the `<router-outlet>`, so every routed page renders inside its view. `67ba1fef` converted it to `OnPush` as part of the #757 bulk convention cleanup — the same cleanup later closed not-planned in #759 for having no measurable benefit.

A change-detection tick then starts at the clean OnPush `app-root` and prunes the entire subtree, so a routed CheckAlways page that mutates state from an async callback (HTTP `subscribe`, `setTimeout`, `Promise.then`) updates its model but never repaints.

It looked intermittent and page-dependent only because the navbar's four `| async` bindings transiently mark `app-root` dirty (`markViewDirty` walks every ancestor), letting a full traversal through.

## Fix

Revert `app-root` to CheckAlways. That fixes the class for all ~50 Eager routed components at once, rather than adding `markForCheck` to each and requiring every future component to remember it. Same defect that hung the login page in `e6fc5244`, which was patched per-component.

## App-wide sweep

All 74 OnPush components were scanned for state mutations inside async callbacks lacking `markForCheck` (11 candidates, each manually verified), plus a scan for Eager components nested under a non-`app-root` OnPush parent — **zero**, so `app-root` was the app's only such nesting. These four are genuinely OnPush and needed fixing regardless:

- **identity-link-callback** — stuck on its loading spinner after the token resolved
- **ai-feedback-dialog** / **usability-feedback-dialog** — a failed submit left `submitting` true on screen, disabling both buttons, making the dialog permanently unusable (no retry, no cancel)
- **chat-page** — `loadSessions()` error path could keep showing a deleted session's messages

## Testing note

`ComponentFixture.detectChanges()` force-checks the view regardless of its dirty flag, so **DOM assertions cannot catch this class of bug** — which is why 5985 passing tests never saw it. The new tests spy on `ChangeDetectorRef.markForCheck` instead, matching the precedent from `e6fc5244`. New `app.component.spec.ts` guards that `app-root` stays CheckAlways.

Both new guards were confirmed to **fail** when the fix is reverted.

## Verification

- `pnpm run build` — clean
- `pnpm run lint:all` — clean
- `pnpm run test` — 304 files, 5985 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1EUmdZR1Co4JPVW7CeFny