### PR TITLE
build(deps-dev): bump @oxc-project/runtime to 0.141.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@axe-core/playwright": "^4.12.1",
     "@eslint/js": "^10.0.1",
     "@material/material-color-utilities": "^0.4.0",
-    "@oxc-project/runtime": "^0.140.0",
+    "@oxc-project/runtime": "^0.141.0",
     "@playwright/test": "^1.61.1",
     "@testing-library/angular": "^19.4.1",
     "@types/jsdom": "^28.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmi-ux",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "type": "module",
   "scripts": {
     "prepare": "git config core.hooksPath .husky 2>/dev/null || true",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,8 +191,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
       '@oxc-project/runtime':
-        specifier: ^0.140.0
-        version: 0.140.0
+        specifier: ^0.141.0
+        version: 0.141.0
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
@@ -1619,8 +1619,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-project/runtime@0.140.0':
-    resolution: {integrity: sha512-ZYZwESARwc2fB/vLHj+991uu3iGIsor3gPTA7wgouM6xEJzJsz11dt+/Xl5tUinERqmq6auyRhSMWzChhfez6w==}
+  '@oxc-project/runtime@0.141.0':
+    resolution: {integrity: sha512-Z/6jQ0dyvE2fVjMUO7GoD4h+3q0G4lI4BWQNjaPhC4RPxaS4hF1b7/QYKB/Tl+KAQwqqKgMF54ukR/VvV5FILg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@oxc-project/types@0.121.0':
@@ -6212,7 +6212,7 @@ snapshots:
   '@oxc-parser/binding-win32-x64-msvc@0.121.0':
     optional: true
 
-  '@oxc-project/runtime@0.140.0': {}
+  '@oxc-project/runtime@0.141.0': {}
 
   '@oxc-project/types@0.121.0': {}
 


### PR DESCRIPTION
Bumps `@oxc-project/runtime` 0.140.0 → 0.141.0 (build-tooling dev dependency).

The recent dependency bump (#794) intended to carry this — its apply step resolved 0.141.0 — but the merged result on main landed on 0.140.0. This closes that gap so the checked-in tree matches what the tooling resolves.

Trivial patch. `pnpm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1EUmdZR1Co4JPVW7CeFny