### PR TITLE
ops(aws): point tmi-ux SPA at www.tmi.dev

### DIFF
--- a/terraform/aws/certificate.tf
+++ b/terraform/aws/certificate.tf
@@ -4,13 +4,12 @@
 # only from that region. The provider is already pinned there via
 # var.aws_region.
 #
-# The hosted zone (aws.tmi.dev) already contains a certificate-validation
-# CNAME for server.aws.tmi.dev, owned by the separate TMI server deployment.
-# This resource only ever creates/manages records keyed by this
-# certificate's own domain_validation_options, so it cannot collide with
-# that record. allow_overwrite exists to let re-plans/re-creates of this
-# certificate's own validation record succeed, not to touch unrelated
-# records.
+# The hosted zone (tmi.dev, migrated into this account) contains many
+# unrelated records (mail, delegations, other ACM validation CNAMEs). This
+# resource only ever creates/manages records keyed by this certificate's own
+# domain_validation_options, so it cannot collide with them. allow_overwrite
+# exists to let re-plans/re-creates of this certificate's own validation
+# record succeed, not to touch unrelated records.
 # ---------------------------------------------------------------------------
 
 resource "aws_acm_certificate" "this" {

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -7,13 +7,13 @@ variable "aws_region" {
 variable "domain_name" {
   description = "Public hostname for the tmi-ux SPA."
   type        = string
-  default     = "app.aws.tmi.dev"
+  default     = "www.tmi.dev"
 }
 
 variable "hosted_zone_id" {
-  description = "Route 53 hosted zone ID for aws.tmi.dev."
+  description = "Route 53 hosted zone ID for tmi.dev (migrated into this account)."
   type        = string
-  default     = "Z05646533D2YL1I678JXS"
+  default     = "Z017072317XPHCAN503JC"
 }
 
 variable "content_bucket_name" {


### PR DESCRIPTION
Moves the S3+CloudFront SPA from `app.aws.tmi.dev` to `www.tmi.dev`, now that the `tmi.dev` hosted zone has been migrated into this AWS account (`967218005408`, zone `Z017072317XPHCAN503JC`).

## Change
Flips the two Terraform variable defaults that drive the entire stack:
- `domain_name` → `www.tmi.dev`
- `hosted_zone_id` → `Z017072317XPHCAN503JC`

Plus a refresh of the now-stale `certificate.tf` comment that described the old `aws.tmi.dev` zone.

## Already applied
This was `terraform apply`-d against the live stack: new ACM cert for `www.tmi.dev` **ISSUED**, CloudFront alias moved, `www` A/AAAA created in the new zone, and `app.aws.tmi.dev` records + old cert destroyed (hard cutover). Verified: `https://www.tmi.dev/` → 200, TLS valid, `/intake` deep link → 200.

`apiUrl` is unchanged (`server.aws.tmi.dev`), so the env spec and deploy build-fingerprint are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)