### PR TITLE
fix: point the dev API URL at the tmi-server NodePort

### DIFF
--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -8,7 +8,9 @@ export const environment: Environment = {
   production: false,
   logLevel: 'DEBUG', // Most verbose logging in development
   debugComponents: ['websocket-api', 'websocket-adapter'], // Enable component-specific debug logging for WebSocket messages
-  apiUrl: 'http://192.168.1.2:8080',
+  // rp2 on the k3s-rp cluster. 30080 is the tmi-server NodePort; 8080 is only
+  // the in-cluster Service port and is not reachable from outside the cluster.
+  apiUrl: 'http://192.168.1.2:30080',
   authTokenExpiryMinutes: 1440, // 24 hours for easier development
   operatorName: 'Local development',
   operatorContact: '',


### PR DESCRIPTION
One-line dev config fix: `environment.dev.ts` targeted `http://192.168.1.2:8080`, but that port is unreachable.

`192.168.1.2` is rp2 on the k3s-rp cluster, and `8080` is only the in-cluster Service port for `tmi-server` (`service/tmi-server 8080:30080/TCP`). From outside the cluster the server answers on NodePort **30080**; nothing listens on 8080.

Since `environment.dev.ts` is what `ng serve` file-replaces under its default `development` configuration, this is the config `pnpm run dev` actually uses.

## Symptom

A blank page at `localhost:4200` with an entirely clean console — no error, no spinner, nothing rendered.

The cause is that two `APP_INITIALIZER`s perform network I/O and Angular awaits both before creating the root component. Against a port where packets are dropped rather than refused, `AuthService.checkAuthStatus()` (which has no timeout) never settles, so the app never renders and nothing is logged:

```
[DEBUG] [api] GET request to http://192.168.1.2:8080/me
[WARN]  BrandingConfigService: GET /config timed out
```

After the change, the same call reaches `:30080` with no timeouts and the landing page renders.

That blank-page failure mode is a real defect in its own right — an unreachable backend should not produce a white screen with no diagnostics — and is tracked separately in #823. **This PR does not fix #823**; it only corrects the config that exposed it.

## Verification

`pnpm run lint:all`, `pnpm run build`, and `pnpm test` (305 files / 5995 tests) all pass. Verified in a real browser: the app renders and `GET /me` reaches the NodePort cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aFQknKKppj67mESWUzJ3p