### PR TITLE
test: fix stale login locators broken by the #676 sentence-case pass

### DIFF
--- a/e2e/pages/login.page.ts
+++ b/e2e/pages/login.page.ts
@@ -12,5 +12,5 @@ export class LoginPage {
   readonly loginHintInput = () => this.page.getByLabel('Username');
 
   readonly signInButton = () =>
-    this.page.getByRole('button', { name: 'Sign In', exact: true });
+    this.page.getByRole('button', { name: 'Sign in', exact: true });
 }


### PR DESCRIPTION
PR #676 (May 9) applied mechanical sentence-case corrections to en-US translations, changing the login dialog button from "Sign In" to "Sign in". The E2E login page object (`e2e/pages/login.page.ts`) still used `getByRole('button', { name: 'Sign In', exact: true })`, so every spec whose `beforeAll` performs a fresh `AuthFlow.loginAs()` has been failing at the login step since then. The gap went unnoticed because runs with cached auth state (or against long-lived dev servers) skip the fresh-login path.

Audited `e2e/` for other victims of the sentence-case pass: `'Sign In'` was the only stale locator against translated UI text (other Title-Case strings are describe titles or seeded fixture names, not locators).

Verification: `core-lifecycle.spec.ts` + `dfd-controls.spec.ts` (24 tests, two fresh-login `beforeAll` hooks) — 24/24 pass with the fix; `lint:e2e` and `tsc --noEmit -p tsconfig.e2e.json` clean.

Discovered while executing #446 (x6 v3 upgrade E2E validation). Related hardening: #827.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UVtkhfoKshZypZVAghX4Z