### PR TITLE
deps: upgrade @antv/x6 to v3.1.7 (consolidated plugins, ESM patch, v3 behavior fixes)

### DIFF
--- a/docs/superpowers/plans/2026-08-01-antv-x6-v3-upgrade.md
+++ b/docs/superpowers/plans/2026-08-01-antv-x6-v3-upgrade.md
@@ -6,7 +6,7 @@
 
 **Goal:** Upgrade `@antv/x6` 2.19.2 → 3.1.7, remove the six now-consolidated `@antv/x6-plugin-*` packages, and work around the upstream ESM/CJS packaging bug so build, unit tests, and E2E all pass.
 
-**Architecture:** v3 merges all plugins plus `@antv/x6-common`/`@antv/x6-geometry` into the core package; `graph.use(new Plugin())` is unchanged, only import paths move. The DFD module's x6 access is already funneled through infrastructure adapters/services, so source changes are confined to four files. The one real engineering obstacle is upstream [antvis/X6#5048](https://github.com/antvis/X6/issues/5048): `@antv/x6@3.1.7` declares `"type": "module"` with `"main": "lib/index.js"` (CJS content, no `exports` map), so Node's ESM loader crashes on it — which breaks Vitest. We fix it with a `pnpm patch` that points `main` at the real ESM build (`es/index.js`).
+**Architecture:** v3 merges all plugins plus `@antv/x6-common`/`@antv/x6-geometry` into the core package; `graph.use(new Plugin())` is unchanged, only import paths move. The DFD module's x6 access is already funneled through infrastructure adapters/services, so source changes are confined to four files. The one real engineering obstacle is upstream [antvis/X6#5048](https://github.com/antvis/X6/issues/5048): `@antv/x6@3.1.7` declares `"type": "module"` with `"main": "lib/index.js"` (CJS content, no `exports` map), so Node's ESM loader crashes on it — which breaks Vitest. We fix it with a `pnpm patch` that flips the package's `type` field to `"commonjs"`, removing the type/main mismatch at the root. (Mechanism corrected during execution: the originally planned `main` → `es/index.js` redirect fails with `ERR_UNSUPPORTED_DIR_IMPORT` because the `es/` build itself uses extensionless directory imports Node rejects — a second upstream defect. Bundler builds are unaffected either way: they resolve via the `module` field with their own, laxer resolvers.)
 
 **Tech Stack:** Angular 22, Vitest 4 (jsdom), Playwright E2E (incl. visual regression), pnpm 10 (`pnpm patch`).
 
@@ -35,7 +35,7 @@ Behavioral note for testing: in v3, when panning and the Selection plugin confli
 
 ## Decision points (approve before executing)
 
-1. **ESM/CJS workaround = `pnpm patch` of `@antv/x6@3.1.7`** (change `"main"` to `"es/index.js"`). Alternative considered: Vitest-only `resolve.alias` to `@antv/x6/es/index.js`. The patch is preferred because it fixes every Node-resolution consumer in one place and is self-documenting in `package.json` `patchedDependencies`; the alias fixes only Vitest and can drift. Drop the patch when upstream ships a fixed release (leave a follow-up note on #446).
+1. **ESM/CJS workaround = `pnpm patch` of `@antv/x6@3.1.7`** (change `"type"` to `"commonjs"`, leaving `main`/`module` untouched). Alternative considered: Vitest-only `resolve.alias` to `@antv/x6/es/index.js`. The patch is preferred because it fixes every Node-resolution consumer in one place and is self-documenting in `package.json` `patchedDependencies`; the alias fixes only Vitest and can drift. (A `"main"` → `"es/index.js"` redirect was also considered and rejected — it fails under Node with `ERR_UNSUPPORTED_DIR_IMPORT` because the `es/` build uses extensionless directory imports.) Drop the patch when upstream ships a fixed release (leave a follow-up note on #446).
 2. **Exact-pin 3.1.7** (see Global Constraints). This keeps the package out of `/bump` auto-updates, which is intended while the patch exists.
 
 ---
@@ -83,7 +83,7 @@ pnpm patch @antv/x6@3.1.7
 # pnpm prints an editable dir, e.g. /private/var/.../antv-x6@3.1.7
 ```
 
-In the printed directory, edit `package.json`: change `"main": "lib/index.js"` to `"main": "es/index.js"`. Then:
+In the printed directory, edit `package.json`: change `"type": "module"` to `"type": "commonjs"` (leave `main` and `module` untouched). Do NOT instead point `main` at `es/index.js` — that variant fails under Node with `ERR_UNSUPPORTED_DIR_IMPORT` (the `es/` build uses extensionless directory imports). Then:
 
 ```bash
 pnpm patch-commit <printed-dir>
@@ -102,7 +102,7 @@ Expected: prints `function`.
 In `package.json`, replace the `comments.dependencies["@antv/x6"]` value with:
 
 ```json
-"@antv/x6": "Pinned exact at 3.1.7: pnpm patch (patches/@antv__x6@3.1.7.patch) fixes upstream antvis/X6#5048 (type:module + CJS main); a version bump invalidates the patch. Remove patch + relax pin when upstream ships a fix. See issue #446."
+"@antv/x6": "Pinned exact at 3.1.7: pnpm patch (patches/@antv__x6@3.1.7.patch) sets type:commonjs to fix upstream antvis/X6#5048 (type:module declared over a CJS main build; the es/ build is also un-loadable by Node due to directory imports); a version bump invalidates the patch. Remove patch + relax pin when upstream ships a fix. See issue #446."
 ```
 
 - [ ] **Step 7: Commit**
@@ -113,7 +113,7 @@ git commit -m "deps: upgrade @antv/x6 to 3.1.7, drop consolidated plugin package
 
 Removes @antv/x6-plugin-{clipboard,export,history,selection,snapline,transform}
 (merged into @antv/x6 core in v3; history was never imported).
-Adds a pnpm patch pointing main at the ESM build to work around antvis/X6#5048."
+Adds a pnpm patch setting type:commonjs to work around antvis/X6#5048."
 ```
 
 Note: the build is **expected to be broken** at this commit (TS2702 in `infra-edge.service.ts`); Task 2 fixes it. Do not push yet.

--- a/docs/superpowers/plans/2026-08-01-antv-x6-v3-upgrade.md
+++ b/docs/superpowers/plans/2026-08-01-antv-x6-v3-upgrade.md
@@ -1,0 +1,365 @@
+# @antv/x6 v2 → v3 Upgrade Implementation Plan (issue #446)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Graphify rule:** any subagent exploring code MUST run `graphify query "<question>"` before reading/grepping raw source files (project rule; graphify-out/graph.json exists).
+
+**Goal:** Upgrade `@antv/x6` 2.19.2 → 3.1.7, remove the six now-consolidated `@antv/x6-plugin-*` packages, and work around the upstream ESM/CJS packaging bug so build, unit tests, and E2E all pass.
+
+**Architecture:** v3 merges all plugins plus `@antv/x6-common`/`@antv/x6-geometry` into the core package; `graph.use(new Plugin())` is unchanged, only import paths move. The DFD module's x6 access is already funneled through infrastructure adapters/services, so source changes are confined to four files. The one real engineering obstacle is upstream [antvis/X6#5048](https://github.com/antvis/X6/issues/5048): `@antv/x6@3.1.7` declares `"type": "module"` with `"main": "lib/index.js"` (CJS content, no `exports` map), so Node's ESM loader crashes on it — which breaks Vitest. We fix it with a `pnpm patch` that points `main` at the real ESM build (`es/index.js`).
+
+**Tech Stack:** Angular 22, Vitest 4 (jsdom), Playwright E2E (incl. visual regression), pnpm 10 (`pnpm patch`).
+
+## Global Constraints
+
+- `@antv/x6` must be pinned **exact** at `3.1.7`: the pnpm patch is keyed to `@antv/x6@3.1.7`, and a range bump would silently invalidate it. Keep a `comments.dependencies` entry explaining this.
+- All six `@antv/x6-plugin-*` packages are removed, including the never-imported `@antv/x6-plugin-history`. Do **not** adopt `@antv/x6-plugin-clipboard@3.0.0` — clipboard lives in core now.
+- Use pnpm scripts only: `pnpm run build`, `pnpm test`, `pnpm run lint:all`, `pnpm test:e2e`. No bespoke `ng`/`vitest`/`playwright` invocations.
+- Conventional commits; branch `feature/x6-v3-upgrade` off `main`; integrate via PR (main ruleset requires PR + CodeQL).
+- After code changes land, run `graphify update .` (project rule).
+
+## Verified v3 facts (from the shipped 3.1.7 tarball, not guesswork)
+
+| v2 usage                                                                       | v3 replacement                                                                                        | Where used                          |
+| ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `import { Snapline/Transform/Export/Clipboard } from '@antv/x6-plugin-*'`      | same names `from '@antv/x6'`                                                                          | `infra-x6-graph.adapter.ts:26-31`   |
+| `import { Selection, Transform } from '@antv/x6-plugin-*'`                     | same names `from '@antv/x6'`                                                                          | `infra-x6-selection.adapter.ts:3-4` |
+| `Edge.Properties` (namespace type — **removed**, TS2702)                       | flat `EdgeProperties` interface                                                                       | `infra-edge.service.ts:266` (×2)    |
+| `Markup.JSONMarkup`                                                            | flat `MarkupJSONMarkup` type                                                                          | `edge-markup.util.ts:12`            |
+| `Shape.Rect.define` / `Shape.Edge.define`                                      | unchanged (`Shape` is still a module-object export)                                                   | `infra-x6-shape-definitions.ts`     |
+| `Cell, Edge, Graph, Model, Node, NumberExt, Shape, Markup` value/class imports | all still exported from core                                                                          | 76 files — no change needed         |
+| `.transition()` animation API (removed in v3)                                  | not used anywhere in src (verified)                                                                   | —                                   |
+| `panning` now default-enabled                                                  | we already configure panning explicitly in `infra-x6-graph.adapter.ts` (~L369) — verify, don't change | —                                   |
+
+Behavioral note for testing: in v3, when panning and the Selection plugin conflict, **selection takes priority**. We use both; E2E + manual smoke must confirm rubber-band select and canvas pan still behave as before.
+
+## Decision points (approve before executing)
+
+1. **ESM/CJS workaround = `pnpm patch` of `@antv/x6@3.1.7`** (change `"main"` to `"es/index.js"`). Alternative considered: Vitest-only `resolve.alias` to `@antv/x6/es/index.js`. The patch is preferred because it fixes every Node-resolution consumer in one place and is self-documenting in `package.json` `patchedDependencies`; the alias fixes only Vitest and can drift. Drop the patch when upstream ships a fixed release (leave a follow-up note on #446).
+2. **Exact-pin 3.1.7** (see Global Constraints). This keeps the package out of `/bump` auto-updates, which is intended while the patch exists.
+
+---
+
+### Task 1: Branch, dependency swap, ESM/CJS patch
+
+**Files:**
+
+- Modify: `package.json` (deps + `comments.dependencies` + `pnpm.patchedDependencies` added by pnpm)
+- Create: `patches/@antv__x6@3.1.7.patch` (generated by `pnpm patch-commit`)
+- Modify: `pnpm-lock.yaml` (generated)
+
+**Interfaces:**
+
+- Consumes: nothing (first task)
+- Produces: an installed `@antv/x6@3.1.7` that loads under Node ESM; plugin packages gone. Later tasks assume `import { EdgeProperties, MarkupJSONMarkup, Export, Snapline, Transform, Clipboard, Selection } from '@antv/x6'` resolves.
+
+- [ ] **Step 1: Create the feature branch**
+
+```bash
+git checkout main && git pull && git checkout -b feature/x6-v3-upgrade
+```
+
+- [ ] **Step 2: Swap dependencies**
+
+```bash
+pnpm remove @antv/x6-plugin-clipboard @antv/x6-plugin-export @antv/x6-plugin-history @antv/x6-plugin-selection @antv/x6-plugin-snapline @antv/x6-plugin-transform
+pnpm add --save-exact @antv/x6@3.1.7
+```
+
+Expected: install succeeds, no `@antv/x6-plugin-*` remains in `package.json`.
+
+- [ ] **Step 3: Demonstrate the upstream bug (failing check first)**
+
+```bash
+node -e "import('@antv/x6').then(m => console.log(typeof m.Graph))"
+```
+
+Expected: **FAIL** — an ESM/CJS error (e.g. `require is not defined` or `Unexpected token 'module.exports'`) because `main` points CJS `lib/index.js` at Node's ESM loader.
+
+- [ ] **Step 4: Patch the package**
+
+```bash
+pnpm patch @antv/x6@3.1.7
+# pnpm prints an editable dir, e.g. /private/var/.../antv-x6@3.1.7
+```
+
+In the printed directory, edit `package.json`: change `"main": "lib/index.js"` to `"main": "es/index.js"`. Then:
+
+```bash
+pnpm patch-commit <printed-dir>
+```
+
+- [ ] **Step 5: Verify the check now passes**
+
+```bash
+node -e "import('@antv/x6').then(m => console.log(typeof m.Graph))"
+```
+
+Expected: prints `function`.
+
+- [ ] **Step 6: Update the pin-reason comment**
+
+In `package.json`, replace the `comments.dependencies["@antv/x6"]` value with:
+
+```json
+"@antv/x6": "Pinned exact at 3.1.7: pnpm patch (patches/@antv__x6@3.1.7.patch) fixes upstream antvis/X6#5048 (type:module + CJS main); a version bump invalidates the patch. Remove patch + relax pin when upstream ships a fix. See issue #446."
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml patches/
+git commit -m "deps: upgrade @antv/x6 to 3.1.7, drop consolidated plugin packages
+
+Removes @antv/x6-plugin-{clipboard,export,history,selection,snapline,transform}
+(merged into @antv/x6 core in v3; history was never imported).
+Adds a pnpm patch pointing main at the ESM build to work around antvis/X6#5048."
+```
+
+Note: the build is **expected to be broken** at this commit (TS2702 in `infra-edge.service.ts`); Task 2 fixes it. Do not push yet.
+
+---
+
+### Task 2: Source migration (4 files)
+
+**Files:**
+
+- Modify: `src/app/pages/dfd/infrastructure/adapters/infra-x6-graph.adapter.ts:25-31`
+- Modify: `src/app/pages/dfd/infrastructure/adapters/infra-x6-selection.adapter.ts:2-4`
+- Modify: `src/app/pages/dfd/infrastructure/services/infra-edge.service.ts:2,266`
+- Modify: `src/app/pages/dfd/infrastructure/utils/edge-markup.util.ts:1,12`
+
+**Interfaces:**
+
+- Consumes: Task 1's installed/patched `@antv/x6@3.1.7`.
+- Produces: a compiling app (`pnpm run build` green). No public API of any adapter/service changes — this is import-path and type-name substitution only.
+
+- [ ] **Step 1: Capture the failing baseline**
+
+```bash
+pnpm run build 2>&1 | grep -E "ERROR|error TS" | head -30
+```
+
+Expected: FAIL with `TS2702: 'Edge' only refers to a type...` at `infra-edge.service.ts` and module-not-found for the removed `@antv/x6-plugin-*` imports. Save the full list — any error beyond these four files is new information; handle it in Step 4.
+
+- [ ] **Step 2: Apply the four edits**
+
+`infra-x6-graph.adapter.ts` — replace lines 25–31:
+
+```typescript
+// Before
+import { Graph, Node, Edge, Cell } from '@antv/x6';
+import '@antv/x6-plugin-export';
+import { Export } from '@antv/x6-plugin-export';
+import { Snapline } from '@antv/x6-plugin-snapline';
+import { Transform } from '@antv/x6-plugin-transform';
+import '@antv/x6-plugin-clipboard';
+import { Clipboard } from '@antv/x6-plugin-clipboard';
+
+// After
+import { Graph, Node, Edge, Cell, Export, Snapline, Transform, Clipboard } from '@antv/x6';
+```
+
+(The two bare side-effect imports existed only to register the plugins' module augmentation; v3 core needs neither.)
+
+`infra-x6-selection.adapter.ts` — replace lines 2–4:
+
+```typescript
+// Before
+import { Graph, Node, Edge, Cell } from '@antv/x6';
+import { Selection } from '@antv/x6-plugin-selection';
+import { Transform } from '@antv/x6-plugin-transform';
+
+// After
+import { Graph, Node, Edge, Cell, Selection, Transform } from '@antv/x6';
+```
+
+`infra-edge.service.ts` — line 2 and line 266:
+
+```typescript
+// Before (line 2)
+import { Edge, Node } from '@antv/x6';
+// After
+import { Edge, Node, type EdgeProperties } from '@antv/x6';
+
+// Before (line 266)
+private _ensureEdgeAttrs(attrs: Edge.Properties['attrs']): Edge.Properties['attrs'] {
+// After
+private _ensureEdgeAttrs(attrs: EdgeProperties['attrs']): EdgeProperties['attrs'] {
+```
+
+If nothing else in the file still uses `Edge` as a value after this change, drop `Edge` from the import (lint will flag it).
+
+`edge-markup.util.ts` — line 1 and line 12:
+
+```typescript
+// Before
+import { Markup } from '@antv/x6';
+export function getEdgeMarkup(): Markup.JSONMarkup[] {
+// After
+import type { MarkupJSONMarkup } from '@antv/x6';
+export function getEdgeMarkup(): MarkupJSONMarkup[] {
+```
+
+- [ ] **Step 3: Rebuild**
+
+```bash
+pnpm run build
+```
+
+Expected: PASS, or a strictly smaller error list than Step 1's baseline.
+
+- [ ] **Step 4: Triage any residual compile errors (spike loop)**
+
+For each remaining error: find the v3 replacement by inspecting the installed typings under `node_modules/@antv/x6/lib/**/*.d.ts` (v3 pattern: namespace types became flat `<Class><Member>` interfaces, e.g. `Cell.Properties` → `CellProperties`, `Node.Metadata` → `NodeMetadata`). Apply the same substitution style as Step 2. If an API was _removed_ (not renamed) — stop and surface it for discussion before inventing a workaround; that would be new scope beyond this plan's verified facts.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/pages/dfd/
+git commit -m "refactor: migrate DFD x6 imports and namespace types to v3 API"
+```
+
+---
+
+### Task 3: Unit test pass
+
+**Files:**
+
+- Modify: only what failures dictate (most likely candidates: `src/app/pages/dfd/**/*.spec.ts`, `src/app/pages/dfd/application/services/test-helpers/mock-services.ts`, `src/app/shared/services/cell-data-extraction.service.spec.ts`)
+
+**Interfaces:**
+
+- Consumes: compiling app from Task 2.
+- Produces: green unit suite; proves the pnpm patch works for Vitest's Node-ESM resolution (this is the load-bearing validation of the Task 1 decision).
+
+- [ ] **Step 1: Run the DFD-scoped tests first (fast signal)**
+
+```bash
+pnpm test -- src/app/pages/dfd src/app/shared/services/cell-data-extraction.service.spec.ts
+```
+
+Expected: PASS. If x6 fails to _load_ (ESM/CJS errors), the Task 1 patch is insufficient — check whether Vitest resolved a different copy (`pnpm why @antv/x6`), and fix the patch rather than adding config workarounds.
+
+- [ ] **Step 2: Run the full unit suite**
+
+```bash
+pnpm test
+```
+
+Expected: PASS. Fix any failures to root cause — never skip tests (repo rule). Assertion-level failures (not load failures) mean a v3 behavior change; compare against the v2 behavior before adjusting the assertion, and note each such change in the PR description.
+
+- [ ] **Step 3: Commit (only if test files changed)**
+
+```bash
+git add -u src/
+git commit -m "test: adjust DFD specs for @antv/x6 v3 behavior"
+```
+
+---
+
+### Task 4: Full local gate — build, lint, tests
+
+**Files:** none new; fixes only if the gate fails.
+
+**Interfaces:**
+
+- Consumes: Tasks 2–3 complete.
+- Produces: the repo's standard completion gate, all green, ready for E2E.
+
+- [ ] **Step 1: Run the gate**
+
+```bash
+pnpm run build && pnpm run lint:all && pnpm test
+```
+
+Expected: all PASS. Fix lint fallout (e.g. now-unused `Edge` import from Task 2) and commit as `style:` or fold into the relevant fix commit.
+
+---
+
+### Task 5: E2E — DFD workflows, field coverage, visual regression
+
+**Files:**
+
+- Possibly modify: `e2e/tests/visual-regression/dfd-visual-regression.spec.ts-snapshots/*` (baseline updates, only with justification)
+
+**Interfaces:**
+
+- Consumes: green local gate from Task 4.
+- Produces: evidence the rendered DFD canvas and interactions are unchanged (or a documented, approved list of intentional visual deltas).
+
+- [ ] **Step 1: Run the DFD E2E specs**
+
+```bash
+pnpm test:e2e -- --grep "dfd"
+```
+
+(If the project's e2e script doesn't accept `--grep`, run the suites by path: `e2e/tests/workflows/dfd-*.spec.ts`, `e2e/tests/field-coverage/dfd-*.spec.ts`, `e2e/tests/visual-regression/dfd-*.spec.ts` — but prefer whatever the pnpm script supports.)
+
+Expected: PASS. Pay particular attention to `dfd-interactions.spec.ts` and `dfd-controls.spec.ts` — the v3 "selection beats panning on conflict" change would surface here.
+
+- [ ] **Step 2: Triage any visual-regression mismatch with the `ui:vrt` skill**
+
+Per repo rule: on screenshot mismatch invoke `ui:vrt`, present baseline/actual/diff, and decide bug vs. intentional change. Do **not** silently regenerate baselines; each updated snapshot needs a stated reason (e.g. sub-pixel antialiasing change in v3 renderer).
+
+- [ ] **Step 3: Commit any approved baseline updates**
+
+```bash
+git add e2e/tests/visual-regression/
+git commit -m "test: update DFD visual baselines for x6 v3 rendering deltas"
+```
+
+---
+
+### Task 6: Manual smoke + behavior verification
+
+**Files:** none (verification only; findings loop back into Tasks 2–5 fixes).
+
+- [ ] **Step 1: Verify panning config is still explicit** — confirm the `panning` option in `infra-x6-graph.adapter.ts` (~L369) is set explicitly (v3 default flipped to enabled; explicit config means no behavior change).
+- [ ] **Step 2: Launch the app (`run` skill / dev server) and exercise, in one seeded diagram:** node create (all shapes: actor, process, store, security-boundary, text), edge draw between ports, node resize (Transform), snapline appearance while dragging, copy/paste (Clipboard, incl. paste offset), delete, undo/redo (app-level history), selection rubber-band + multi-select, canvas pan + zoom, node embedding into security boundary, z-order operations, label editing, SVG export and diagram thumbnail capture, autosave, and a two-tab collaborative session sanity check.
+- [ ] **Step 3: Record results** — note anything off as a finding; fix before PR or explicitly defer with a filed issue.
+
+---
+
+### Task 7: Review, PR, issue closure
+
+- [ ] **Step 1: Code review** — run `superpowers:requesting-code-review` on the branch diff (repo rule before committing/merging significant work).
+- [ ] **Step 2: Update the knowledge graph**
+
+```bash
+graphify update .
+```
+
+Commit any graphify-out changes if the repo tracks them.
+
+- [ ] **Step 3: Push and open the PR** (SSH push may require a physical key touch; on failure stop and hand off, never work around)
+
+```bash
+git push -u origin feature/x6-v3-upgrade
+gh pr create --title "deps: upgrade @antv/x6 to v3.1.7 (consolidated plugins, ESM patch)" --body "<summary: what changed, the pnpm patch rationale w/ link to antvis/X6#5048, v3 behavior notes (selection-vs-panning), test evidence incl. E2E/VRT results. Closes #446>"
+```
+
+The `deps:` type produces a patch version bump via the version-bump workflow; CodeQL must pass (required check).
+
+- [ ] **Step 4: After merge** — comment on #446 referencing the merge commit (repo rule) and close it (the `Closes #446` in the PR body should do this automatically; verify). Add a follow-up note (or new issue) : "when antvis/X6#5048 is fixed upstream, remove `patches/@antv__x6@3.1.7.patch`, relax the exact pin, and let `/bump` manage x6 again."
+
+---
+
+## Test plan summary
+
+| Layer                        | What                       | Command                           | What it proves                                                                                        |
+| ---------------------------- | -------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Package load                 | Node ESM import probe      | `node -e "import('@antv/x6')..."` | the pnpm patch neutralizes antvis/X6#5048                                                             |
+| Compile                      | Angular build              | `pnpm run build`                  | namespace-type migration complete; no missed v3 renames                                               |
+| Unit (82 DFD specs + shared) | Vitest/jsdom               | `pnpm test`                       | adapters/services behave identically on v3; x6 loads under Vitest                                     |
+| Lint                         | ESLint + i18n checks       | `pnpm run lint:all`               | no dead imports left by the migration                                                                 |
+| E2E functional               | 8 DFD workflow/field specs | `pnpm test:e2e` (dfd specs)       | real-browser interactions: draw, edit, history, autosave, controls                                    |
+| E2E visual                   | DFD VRT snapshots          | same run; triage via `ui:vrt`     | pixel-level rendering parity of the v3 canvas                                                         |
+| Manual                       | smoke checklist (Task 6)   | —                                 | plugin behaviors (clipboard/snapline/transform/export), selection-vs-panning priority, collab session |
+
+## Risks
+
+- **Upstream instability:** 3.2.7/3.3.7 were published-then-unpublished (2026-05-19); the exact pin + patch insulate us, at the cost of manual future upgrades.
+- **Hidden v3 type renames** beyond the four verified files — bounded by Task 2 Step 4's triage loop; the error baseline makes any surprise visible immediately.
+- **Behavioral deltas** (selection/panning priority, renderer changes) — covered by E2E + VRT + manual smoke rather than assumptions.
+- **Patch fragility:** anyone bumping x6 without reading the comment invalidates the patch; the exact pin plus the `comments.dependencies` note is the guard.

--- a/docs/superpowers/plans/2026-08-01-antv-x6-v3-upgrade.md
+++ b/docs/superpowers/plans/2026-08-01-antv-x6-v3-upgrade.md
@@ -20,16 +20,16 @@
 
 ## Verified v3 facts (from the shipped 3.1.7 tarball, not guesswork)
 
-| v2 usage                                                                       | v3 replacement                                                                                        | Where used                          |
-| ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| `import { Snapline/Transform/Export/Clipboard } from '@antv/x6-plugin-*'`      | same names `from '@antv/x6'`                                                                          | `infra-x6-graph.adapter.ts:26-31`   |
-| `import { Selection, Transform } from '@antv/x6-plugin-*'`                     | same names `from '@antv/x6'`                                                                          | `infra-x6-selection.adapter.ts:3-4` |
-| `Edge.Properties` (namespace type — **removed**, TS2702)                       | flat `EdgeProperties` interface                                                                       | `infra-edge.service.ts:266` (×2)    |
-| `Markup.JSONMarkup`                                                            | flat `MarkupJSONMarkup` type                                                                          | `edge-markup.util.ts:12`            |
-| `Shape.Rect.define` / `Shape.Edge.define`                                      | unchanged (`Shape` is still a module-object export)                                                   | `infra-x6-shape-definitions.ts`     |
-| `Cell, Edge, Graph, Model, Node, NumberExt, Shape, Markup` value/class imports | all still exported from core                                                                          | 76 files — no change needed         |
-| `.transition()` animation API (removed in v3)                                  | not used anywhere in src (verified)                                                                   | —                                   |
-| `panning` now default-enabled                                                  | we already configure panning explicitly in `infra-x6-graph.adapter.ts` (~L369) — verify, don't change | —                                   |
+| v2 usage                                                                       | v3 replacement                                                                                                                                                                                      | Where used                          |
+| ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `import { Snapline/Transform/Export/Clipboard } from '@antv/x6-plugin-*'`      | same names `from '@antv/x6'`                                                                                                                                                                        | `infra-x6-graph.adapter.ts:26-31`   |
+| `import { Selection, Transform } from '@antv/x6-plugin-*'`                     | same names `from '@antv/x6'`                                                                                                                                                                        | `infra-x6-selection.adapter.ts:3-4` |
+| `Edge.Properties` (namespace type — **removed**, TS2702)                       | flat `EdgeProperties` interface                                                                                                                                                                     | `infra-edge.service.ts:266` (×2)    |
+| `Markup.JSONMarkup`                                                            | `MarkupJSONMarkup` type exists in v3 but 3.1.7's public barrel (`lib/view/index.d.ts`) does not re-export it — deep import from `@antv/x6/lib/view/markup` required until the pnpm patch is dropped | `edge-markup.util.ts:12`            |
+| `Shape.Rect.define` / `Shape.Edge.define`                                      | unchanged (`Shape` is still a module-object export)                                                                                                                                                 | `infra-x6-shape-definitions.ts`     |
+| `Cell, Edge, Graph, Model, Node, NumberExt, Shape, Markup` value/class imports | all still exported from core                                                                                                                                                                        | 76 files — no change needed         |
+| `.transition()` animation API (removed in v3)                                  | not used anywhere in src (verified)                                                                                                                                                                 | —                                   |
+| `panning` now default-enabled                                                  | we already configure panning explicitly in `infra-x6-graph.adapter.ts` (~L369) — verify, don't change                                                                                               | —                                   |
 
 Behavioral note for testing: in v3, when panning and the Selection plugin conflict, **selection takes priority**. We use both; E2E + manual smoke must confirm rubber-band select and canvas pan still behave as before.
 
@@ -51,7 +51,7 @@ Behavioral note for testing: in v3, when panning and the Selection plugin confli
 **Interfaces:**
 
 - Consumes: nothing (first task)
-- Produces: an installed `@antv/x6@3.1.7` that loads under Node ESM; plugin packages gone. Later tasks assume `import { EdgeProperties, MarkupJSONMarkup, Export, Snapline, Transform, Clipboard, Selection } from '@antv/x6'` resolves.
+- Produces: an installed `@antv/x6@3.1.7` that loads under Node ESM; plugin packages gone. Later tasks assume `import { EdgeProperties, Export, Snapline, Transform, Clipboard, Selection } from '@antv/x6'` resolves; `MarkupJSONMarkup` is not part of the barrel and instead resolves via deep import from `@antv/x6/lib/view/markup` (see Verified v3 facts).
 
 - [ ] **Step 1: Create the feature branch**
 
@@ -197,7 +197,9 @@ If nothing else in the file still uses `Edge` as a value after this change, drop
 import { Markup } from '@antv/x6';
 export function getEdgeMarkup(): Markup.JSONMarkup[] {
 // After
-import type { MarkupJSONMarkup } from '@antv/x6';
+// v3.1.7's public barrel (lib/view/index.d.ts) re-exports the `Markup` value but not the
+// `MarkupJSONMarkup` type; deep import is intentional. Revisit when the pnpm patch is dropped.
+import type { MarkupJSONMarkup } from '@antv/x6/lib/view/markup';
 export function getEdgeMarkup(): MarkupJSONMarkup[] {
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmi-ux",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "prepare": "git config core.hooksPath .husky 2>/dev/null || true",

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
   },
   "comments": {
     "dependencies": {
-      "@antv/x6": "Pinned exact at 3.1.7: pnpm patch (patches/@antv__x6@3.1.7.patch) fixes upstream antvis/X6#5048 (published package.json declares type:module but its own ESM build uses extensionless directory imports Node's ESM resolver rejects) by setting type:commonjs so the CJS lib/index.js entry loads correctly under Node; a version bump invalidates the patch. Remove patch + relax pin when upstream ships a fix. See issue #446."
+      "@antv/x6": "Pinned exact at 3.1.7: pnpm patch (patches/@antv__x6@3.1.7.patch) sets type:commonjs to fix upstream antvis/X6#5048 (package.json declares type:module over a CJS main build). Separately, the package's own es/ (ESM) build is unloadable by Node due to extensionless directory imports, which is why the patch targets type rather than redirecting main to es/index.js. A version bump invalidates the patch. Remove patch + relax pin when upstream ships a fix. See issue #446."
     },
     "pnpm.overrides": {
       "@angular/build>vite": "Must track the vite major @angular/build is built for (22.1.2 -> vite 8/rolldown). Pinning vite 7 made the dev server register its Angular-linker prebundle plugin under rolldownOptions, which vite 7 silently ignores, so cold `ng serve` boots crashed with the _PlatformLocation JIT error. Retarget (not delete): the blanket vite@>=7.0.0 override re-locks 7.3.5 if this entry is merely removed."

--- a/package.json
+++ b/package.json
@@ -82,13 +82,7 @@
     "@angular/platform-browser": "^22.1.0",
     "@angular/platform-browser-dynamic": "^22.1.0",
     "@angular/router": "^22.1.0",
-    "@antv/x6": "2.19.2",
-    "@antv/x6-plugin-clipboard": "^2.1.6",
-    "@antv/x6-plugin-export": "^2.1.6",
-    "@antv/x6-plugin-history": "^2.2.4",
-    "@antv/x6-plugin-selection": "^2.2.2",
-    "@antv/x6-plugin-snapline": "^2.1.7",
-    "@antv/x6-plugin-transform": "^2.1.8",
+    "@antv/x6": "3.1.7",
     "@jsverse/transloco": "^8.4.0",
     "@types/prismjs": "^1.26.6",
     "ae-cvss-calculator": "^1.0.13",
@@ -211,11 +205,14 @@
       "msgpackr-extract",
       "playwright",
       "unrs-resolver"
-    ]
+    ],
+    "patchedDependencies": {
+      "@antv/x6@3.1.7": "patches/@antv__x6@3.1.7.patch"
+    }
   },
   "comments": {
     "dependencies": {
-      "@antv/x6": "Pinned to v2.x - blocked by upstream antvis/X6#5048 (ESM/CJS module type conflict in v3.x). Tracking in issue #446"
+      "@antv/x6": "Pinned exact at 3.1.7: pnpm patch (patches/@antv__x6@3.1.7.patch) fixes upstream antvis/X6#5048 (published package.json declares type:module but its own ESM build uses extensionless directory imports Node's ESM resolver rejects) by setting type:commonjs so the CJS lib/index.js entry loads correctly under Node; a version bump invalidates the patch. Remove patch + relax pin when upstream ships a fix. See issue #446."
     },
     "pnpm.overrides": {
       "@angular/build>vite": "Must track the vite major @angular/build is built for (22.1.2 -> vite 8/rolldown). Pinning vite 7 made the dev server register its Angular-linker prebundle plugin under rolldownOptions, which vite 7 silently ignores, so cold `ng serve` boots crashed with the _PlatformLocation JIT error. Retarget (not delete): the blanket vite@>=7.0.0 override re-locks 7.3.5 if this entry is merely removed."

--- a/patches/@antv__x6@3.1.7.patch
+++ b/patches/@antv__x6@3.1.7.patch
@@ -1,0 +1,13 @@
+diff --git a/package.json b/package.json
+index 4570c755a4a44bb13586d26b9b34a02cdd9713de..7aed0768c62e7e57e36d4becbf91b07035e4a0fd 100644
+--- a/package.json
++++ b/package.json
+@@ -7,7 +7,7 @@
+   "unpkg": "dist/x6.min.js",
+   "jsdelivr": "dist/x6.min.js",
+   "types": "lib/index.d.ts",
+-  "type": "module",
++  "type": "commonjs",
+   "files": [
+     "dist",
+     "es",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,11 @@ overrides:
   vite@>=7.0.0: '>=7.3.5'
   '@angular/build>vite': ^8.2.0
 
+patchedDependencies:
+  '@antv/x6@3.1.7':
+    hash: 9b3c54e6369bae06dc0b14b8d7f07805061ca86305660d77636d3629446d0320
+    path: patches/@antv__x6@3.1.7.patch
+
 importers:
 
   .:
@@ -70,26 +75,8 @@ importers:
         specifier: ^22.1.0
         version: 22.1.0(@angular/common@22.1.0(@angular/core@22.1.0(@angular/compiler@22.1.0)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.1.0(@angular/compiler@22.1.0)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.1.0(@angular/common@22.1.0(@angular/core@22.1.0(@angular/compiler@22.1.0)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.1.0(@angular/compiler@22.1.0)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
       '@antv/x6':
-        specifier: 2.19.2
-        version: 2.19.2
-      '@antv/x6-plugin-clipboard':
-        specifier: ^2.1.6
-        version: 2.1.6(@antv/x6@2.19.2)
-      '@antv/x6-plugin-export':
-        specifier: ^2.1.6
-        version: 2.1.6(@antv/x6@2.19.2)
-      '@antv/x6-plugin-history':
-        specifier: ^2.2.4
-        version: 2.2.4(@antv/x6@2.19.2)
-      '@antv/x6-plugin-selection':
-        specifier: ^2.2.2
-        version: 2.2.2(@antv/x6@2.19.2)
-      '@antv/x6-plugin-snapline':
-        specifier: ^2.1.7
-        version: 2.1.7(@antv/x6@2.19.2)
-      '@antv/x6-plugin-transform':
-        specifier: ^2.1.8
-        version: 2.1.8(@antv/x6@2.19.2)
+        specifier: 3.1.7
+        version: 3.1.7(patch_hash=9b3c54e6369bae06dc0b14b8d7f07805061ca86305660d77636d3629446d0320)
       '@jsverse/transloco':
         specifier: ^8.4.0
         version: 8.4.0(@angular/core@22.1.0(@angular/compiler@22.1.0)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)(typescript@6.0.3)
@@ -530,44 +517,9 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@antv/x6-common@2.0.17':
-    resolution: {integrity: sha512-37g7vmRkNdYzZPdwjaMSZEGv/MMH0S4r70/Jwoab1mioycmuIBN73iyziX8m56BvJSDucZ3J/6DU07otWqzS6A==}
-
-  '@antv/x6-geometry@2.0.5':
-    resolution: {integrity: sha512-MId6riEQkxphBpVeTcL4ZNXL4lScyvDEPLyIafvWMcWNTGK0jgkK7N20XSzqt8ltJb0mGUso5s56mrk8ysHu2A==}
-
-  '@antv/x6-plugin-clipboard@2.1.6':
-    resolution: {integrity: sha512-roZPLnZx6PK8MBvee0QMo90fz/TXeF0WNe4EGin2NBq5M1I5XTWrYvA6N2XVIiWAAI67gjQeEE8TpkL7f8QdqA==}
-    peerDependencies:
-      '@antv/x6': ^2.x
-
-  '@antv/x6-plugin-export@2.1.6':
-    resolution: {integrity: sha512-m0ukMmZhrFE5n7uCR43DVQBdiUfpjGN+vm1mc+6RTZdHK8pa6Mxr0RZztaxPy34YA4tli+bGY3ePslsNPfh6PQ==}
-    peerDependencies:
-      '@antv/x6': ^2.x
-
-  '@antv/x6-plugin-history@2.2.4':
-    resolution: {integrity: sha512-9gHHvEW4Fla+1hxUV49zNgJyIMoV9CjVM52MrFgAJcvyRn1Kvxz4MfxiKlG+DEZUs+/zvfjl9pS6gJOd8laRkg==}
-    peerDependencies:
-      '@antv/x6': ^2.x
-
-  '@antv/x6-plugin-selection@2.2.2':
-    resolution: {integrity: sha512-s2gtR9Onlhr7HOHqyqg0d+4sG76JCcQEbvrZZ64XmSChlvieIPlC3YtH4dg1KMNhYIuBmBmpSum6S0eVTEiPQw==}
-    peerDependencies:
-      '@antv/x6': ^2.x
-
-  '@antv/x6-plugin-snapline@2.1.7':
-    resolution: {integrity: sha512-AsysoCb9vES0U2USNhEpYuO/W8I0aYfkhlbee5Kt4NYiMfQfZKQyqW/YjDVaS2pm38C1NKu1LdPVk/BBr4CasA==}
-    peerDependencies:
-      '@antv/x6': ^2.x
-
-  '@antv/x6-plugin-transform@2.1.8':
-    resolution: {integrity: sha512-GvJuiJ4BKp0H7+qx3R1I+Vzbw5gXp9+oByXo/WyVxE3urOC7LC5sqnaDfIjyYMN6ROLPYPZraLSeSyYBgMgcDw==}
-    peerDependencies:
-      '@antv/x6': ^2.x
-
-  '@antv/x6@2.19.2':
-    resolution: {integrity: sha512-lr9sUAlrR7eSVANru8kUNZUqCRl7eOCgb36M61FMDonUYREwkHpRN+0zq+1egSSOdz3HHSDBjs7UMtGH1ZEg2w==}
+  '@antv/x6@3.1.7':
+    resolution: {integrity: sha512-NLKXtbCK51oLbazfFD0XsD93rMmih08UBW4gAuEyLBpwAqHmHe+vP8VhOZDkl5O9jV1LSv85IJghr9CT5tZjWw==}
+    engines: {node: '>=20.0.0'}
 
   '@asamuzakjp/css-color@6.0.5':
     resolution: {integrity: sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==}
@@ -2988,6 +2940,9 @@ packages:
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
+  dom-align@1.12.4:
+    resolution: {integrity: sha512-R8LUSEay/68zE5c8/3BDxiTEvgb4xZTF0RKmAHfiEVN3klfIpXfi2/QCoiWPccVQ0J/ZGdz9OjzL4uJEP/MRAw==}
+
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
@@ -3835,6 +3790,9 @@ packages:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
+
+  mousetrap@1.6.5:
+    resolution: {integrity: sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -5172,41 +5130,11 @@ snapshots:
       package-manager-detector: 1.7.0
       tinyexec: 1.2.4
 
-  '@antv/x6-common@2.0.17':
+  '@antv/x6@3.1.7(patch_hash=9b3c54e6369bae06dc0b14b8d7f07805061ca86305660d77636d3629446d0320)':
     dependencies:
+      dom-align: 1.12.4
       lodash-es: 4.18.1
-      utility-types: 3.11.0
-
-  '@antv/x6-geometry@2.0.5': {}
-
-  '@antv/x6-plugin-clipboard@2.1.6(@antv/x6@2.19.2)':
-    dependencies:
-      '@antv/x6': 2.19.2
-
-  '@antv/x6-plugin-export@2.1.6(@antv/x6@2.19.2)':
-    dependencies:
-      '@antv/x6': 2.19.2
-
-  '@antv/x6-plugin-history@2.2.4(@antv/x6@2.19.2)':
-    dependencies:
-      '@antv/x6': 2.19.2
-
-  '@antv/x6-plugin-selection@2.2.2(@antv/x6@2.19.2)':
-    dependencies:
-      '@antv/x6': 2.19.2
-
-  '@antv/x6-plugin-snapline@2.1.7(@antv/x6@2.19.2)':
-    dependencies:
-      '@antv/x6': 2.19.2
-
-  '@antv/x6-plugin-transform@2.1.8(@antv/x6@2.19.2)':
-    dependencies:
-      '@antv/x6': 2.19.2
-
-  '@antv/x6@2.19.2':
-    dependencies:
-      '@antv/x6-common': 2.0.17
-      '@antv/x6-geometry': 2.0.5
+      mousetrap: 1.6.5
       utility-types: 3.11.0
 
   '@asamuzakjp/css-color@6.0.5':
@@ -7306,6 +7234,8 @@ snapshots:
 
   dom-accessibility-api@0.5.16: {}
 
+  dom-align@1.12.4: {}
+
   dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -8164,6 +8094,8 @@ snapshots:
   minipass@7.1.3: {}
 
   mkdirp@3.0.1: {}
+
+  mousetrap@1.6.5: {}
 
   mrmime@2.0.1: {}
 

--- a/src/app/pages/dfd/application/facades/app-dfd.facade.spec.ts
+++ b/src/app/pages/dfd/application/facades/app-dfd.facade.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Test suite for AppDfdFacade.
  *
- * AppDfdFacade is a coordinator that delegates to 13 injected services. This
+ * AppDfdFacade is a coordinator that delegates to 14 injected services. This
  * suite covers the delegation and predicate surface — infrastructure setup,
  * connection/embedding validation, clipboard, selection, z-order, and the
  * cell-type predicates — by asserting the facade forwards to the right
@@ -34,6 +34,7 @@ describe('AppDfdFacade', () => {
   let facade: AppDfdFacade;
   let logger: Record<string, Mock>;
   let infraX6GraphAdapter: Record<string, Mock>;
+  let infraX6SelectionAdapter: Record<string, Mock>;
   let infraX6ZOrderAdapter: Record<string, Mock>;
   let infraNodeService: Record<string, Mock>;
   let appEdgeService: Record<string, Mock>;
@@ -64,6 +65,9 @@ describe('AppDfdFacade', () => {
       getGraph: vi.fn(() => mockGraph),
       executeCellDeletion: vi.fn(),
       setReadOnlyMode: vi.fn(),
+    };
+    infraX6SelectionAdapter = {
+      sanitizePastedCells: vi.fn(),
     };
     infraX6ZOrderAdapter = {
       moveSelectedCellsForward: vi.fn(),
@@ -100,6 +104,7 @@ describe('AppDfdFacade', () => {
     facade = new AppDfdFacade(
       logger as never,
       infraX6GraphAdapter as never,
+      infraX6SelectionAdapter as never,
       infraX6ZOrderAdapter as never,
       infraNodeService as never,
       appEdgeService as never,
@@ -297,10 +302,16 @@ describe('AppDfdFacade', () => {
 
     it('paste pastes when the clipboard is not empty', () => {
       mockGraph['isClipboardEmpty'].mockReturnValue(false);
+      const pastedCells = [{ id: 'pasted-1' }];
+      mockGraph['paste'].mockReturnValue(pastedCells);
 
       facade.paste();
 
       expect(mockGraph['paste']).toHaveBeenCalled();
+      expect(infraX6SelectionAdapter['sanitizePastedCells']).toHaveBeenCalledWith(
+        mockGraph,
+        pastedCells,
+      );
     });
 
     it('paste does nothing when the clipboard is empty', () => {

--- a/src/app/pages/dfd/application/facades/app-dfd.facade.ts
+++ b/src/app/pages/dfd/application/facades/app-dfd.facade.ts
@@ -27,6 +27,7 @@ import { NodeType } from '../../domain/value-objects/node-info';
 
 // Infrastructure services
 import { InfraX6GraphAdapter } from '../../infrastructure/adapters/infra-x6-graph.adapter';
+import { InfraX6SelectionAdapter } from '../../infrastructure/adapters/infra-x6-selection.adapter';
 import { InfraX6ZOrderAdapter } from '../../infrastructure/adapters/infra-x6-z-order.adapter';
 import { InfraNodeService } from '../../infrastructure/services/infra-node.service';
 import { AppEdgeService } from '../services/app-edge.service';
@@ -56,6 +57,7 @@ export class AppDfdFacade {
   constructor(
     private readonly logger: LoggerService,
     private readonly infraX6GraphAdapter: InfraX6GraphAdapter,
+    private readonly infraX6SelectionAdapter: InfraX6SelectionAdapter,
     private readonly infraX6ZOrderAdapter: InfraX6ZOrderAdapter,
     private readonly infraNodeService: InfraNodeService,
     private readonly appEdgeService: AppEdgeService,
@@ -834,7 +836,10 @@ export class AppDfdFacade {
     const graph = this.infraX6GraphAdapter.getGraph();
 
     if (!graph.isClipboardEmpty()) {
-      graph.paste();
+      const pastedCells = graph.paste();
+      // Clipboard clones carry the source cells' selection tools and glow;
+      // strip them since pasted cells are not selected
+      this.infraX6SelectionAdapter.sanitizePastedCells(graph, pastedCells);
       this.logger.debugComponent(
         'AppDfdFacade',
         'Paste operation initiated - cells will be captured retroactively',

--- a/src/app/pages/dfd/application/services/app-dfd-orchestrator.service.spec.ts
+++ b/src/app/pages/dfd/application/services/app-dfd-orchestrator.service.spec.ts
@@ -152,6 +152,12 @@ describe('AppDfdOrchestrator', () => {
         exportOptions: { padding: 20 },
       }),
       processSvg: vi.fn((svgString: string) => svgString),
+      prepareRasterExport: vi.fn((format: string) => ({
+        backgroundColor: 'white',
+        padding: 20,
+        quality: format === 'jpeg' ? 0.8 : 1,
+        beforeSerialize: vi.fn(),
+      })),
     };
 
     // Create a mock graph that will be returned by facade.getGraph()
@@ -901,7 +907,12 @@ describe('AppDfdOrchestrator', () => {
             expect(mockGraph.toPNG).toHaveBeenCalled();
             expect(mockGraph.toPNG).toHaveBeenCalledWith(
               expect.any(Function),
-              expect.objectContaining({ backgroundColor: 'white', padding: 20, quality: 1 }),
+              expect.objectContaining({
+                backgroundColor: 'white',
+                padding: 20,
+                quality: 1,
+                beforeSerialize: expect.any(Function),
+              }),
             );
             resolve();
           },

--- a/src/app/pages/dfd/application/services/app-dfd-orchestrator.service.ts
+++ b/src/app/pages/dfd/application/services/app-dfd-orchestrator.service.ts
@@ -464,18 +464,15 @@ export class AppDfdOrchestrator {
               // Clear selection before export to avoid highlighting selected cells
               this.clearSelection();
 
-              graph.toPNG(
-                (dataUri: string) => {
-                  try {
-                    const blob = this._dataUriToBlob(dataUri, 'image/png');
-                    observer.next(blob);
-                    observer.complete();
-                  } catch (error) {
-                    observer.error(error);
-                  }
-                },
-                { backgroundColor: 'white', padding: 20, quality: 1 },
-              );
+              graph.toPNG((dataUri: string) => {
+                try {
+                  const blob = this._dataUriToBlob(dataUri, 'image/png');
+                  observer.next(blob);
+                  observer.complete();
+                } catch (error) {
+                  observer.error(error);
+                }
+              }, this.appExportService.prepareRasterExport('png'));
             } catch (error) {
               observer.error(error);
             }
@@ -490,18 +487,15 @@ export class AppDfdOrchestrator {
               // Clear selection before export to avoid highlighting selected cells
               this.clearSelection();
 
-              graph.toJPEG(
-                (dataUri: string) => {
-                  try {
-                    const blob = this._dataUriToBlob(dataUri, 'image/jpeg');
-                    observer.next(blob);
-                    observer.complete();
-                  } catch (error) {
-                    observer.error(error);
-                  }
-                },
-                { backgroundColor: 'white', padding: 20, quality: 0.8 },
-              );
+              graph.toJPEG((dataUri: string) => {
+                try {
+                  const blob = this._dataUriToBlob(dataUri, 'image/jpeg');
+                  observer.next(blob);
+                  observer.complete();
+                } catch (error) {
+                  observer.error(error);
+                }
+              }, this.appExportService.prepareRasterExport('jpeg'));
             } catch (error) {
               observer.error(error);
             }

--- a/src/app/pages/dfd/application/services/app-dfd-orchestrator.service.ts
+++ b/src/app/pages/dfd/application/services/app-dfd-orchestrator.service.ts
@@ -13,7 +13,6 @@ import { Injectable } from '@angular/core';
 import { Observable, Subject, BehaviorSubject, of, throwError, combineLatest } from 'rxjs';
 import { map, catchError, tap, switchMap, filter } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
-import '@antv/x6-plugin-export';
 
 import { LoggerService } from '../../../../core/services/logger.service';
 import { AuthService } from '../../../../auth/services/auth.service';

--- a/src/app/pages/dfd/application/services/app-export.service.spec.ts
+++ b/src/app/pages/dfd/application/services/app-export.service.spec.ts
@@ -80,6 +80,7 @@ describe('AppExportService', () => {
         padding: 20,
         copyStyles: false,
         preserveAspectRatio: 'xMidYMid meet',
+        beforeSerialize: expect.any(Function),
       });
     });
 
@@ -101,6 +102,24 @@ describe('AppExportService', () => {
       const result = service.prepareImageExport(mockGraph as any, 10);
 
       expect(result?.viewBox).toBe('-10 -10 820 620');
+    });
+
+    it('should strip interactive tool overlays via beforeSerialize', () => {
+      const result = service.prepareImageExport(mockGraph as any);
+
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      const removeButton = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+      removeButton.setAttribute('data-tool-name', 'button-remove');
+      const toolsContainer = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+      toolsContainer.setAttribute('class', 'x6-cell-tools');
+      const shape = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+      svg.append(removeButton, toolsContainer, shape);
+
+      result?.exportOptions.beforeSerialize(svg);
+
+      expect(svg.querySelector('[data-tool-name]')).toBeNull();
+      expect(svg.querySelector('.x6-cell-tools')).toBeNull();
+      expect(svg.querySelector('rect')).not.toBeNull();
     });
 
     it('should return null if no cells to export', () => {

--- a/src/app/pages/dfd/application/services/app-export.service.spec.ts
+++ b/src/app/pages/dfd/application/services/app-export.service.spec.ts
@@ -209,6 +209,39 @@ describe('AppExportService', () => {
     });
   });
 
+  describe('prepareRasterExport()', () => {
+    it('should build PNG options with full quality and the strip hook', () => {
+      const options = service.prepareRasterExport('png');
+
+      expect(options).toEqual({
+        backgroundColor: 'white',
+        padding: 20,
+        quality: 1,
+        beforeSerialize: expect.any(Function),
+      });
+    });
+
+    it('should build JPEG options with reduced quality', () => {
+      const options = service.prepareRasterExport('jpeg');
+
+      expect(options.quality).toBe(0.8);
+      expect(options.beforeSerialize).toEqual(expect.any(Function));
+    });
+
+    it('should strip interactive tool overlays via beforeSerialize', () => {
+      const options = service.prepareRasterExport('png');
+
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      const removeButton = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+      removeButton.setAttribute('data-tool-name', 'button-remove');
+      svg.append(removeButton);
+
+      options.beforeSerialize(svg);
+
+      expect(svg.querySelector('[data-tool-name]')).toBeNull();
+    });
+  });
+
   describe('processSvg()', () => {
     it('should optimize SVG for export without encoding', () => {
       const svgString = '<svg>test content</svg>';

--- a/src/app/pages/dfd/application/services/app-export.service.ts
+++ b/src/app/pages/dfd/application/services/app-export.service.ts
@@ -89,6 +89,26 @@ export class AppExportService {
   }
 
   /**
+   * Build export options for raster (PNG/JPEG) image exports.
+   * Shares the tool-stripping beforeSerialize hook with the SVG export path —
+   * X6 renders raster exports from the same cloned-DOM SVG pipeline.
+   */
+  // SEM@4fb49728d1fcb8c162fd869008cfbe1294b345ef: build raster image export options with tool-stripping serialization hook (pure)
+  prepareRasterExport(format: 'png' | 'jpeg'): {
+    backgroundColor: string;
+    padding: number;
+    quality: number;
+    beforeSerialize: (svg: SVGSVGElement) => void;
+  } {
+    return {
+      backgroundColor: 'white',
+      padding: 20,
+      quality: format === 'jpeg' ? 0.8 : 1,
+      beforeSerialize: (svg: SVGSVGElement): void => this.stripInteractiveTooling(svg),
+    };
+  }
+
+  /**
    * Remove interactive tool overlays (selection boundary, remove button) from
    * the cloned SVG before serialization. X6's export plugin clones the live
    * DOM, so any cell tools present at export time would otherwise be baked

--- a/src/app/pages/dfd/application/services/app-export.service.ts
+++ b/src/app/pages/dfd/application/services/app-export.service.ts
@@ -36,6 +36,7 @@ export class AppExportService {
       copyStyles: boolean;
       preserveAspectRatio: string;
       viewBox?: string;
+      beforeSerialize: (svg: SVGSVGElement) => void;
     };
   } | null {
     // Get tight bbox of all cells + padding (no zoom needed for vector export)
@@ -51,6 +52,7 @@ export class AppExportService {
     }
 
     const viewBox = `${bbox.x - padding} ${bbox.y - padding} ${bbox.width + 2 * padding} ${bbox.height + 2 * padding}`;
+    const beforeSerialize = (svg: SVGSVGElement): void => this.stripInteractiveTooling(svg);
 
     // Validate viewBox calculation
     if (viewBox.includes('NaN') || viewBox.includes('undefined') || viewBox.includes('null')) {
@@ -64,6 +66,7 @@ export class AppExportService {
         padding,
         copyStyles: false,
         preserveAspectRatio: 'xMidYMid meet',
+        beforeSerialize,
       };
       return { bbox, viewBox: '', exportOptions };
     }
@@ -72,6 +75,7 @@ export class AppExportService {
       padding, // Still apply if needed for internal
       copyStyles: false,
       preserveAspectRatio: 'xMidYMid meet',
+      beforeSerialize,
       // Don't set viewBox here to avoid duplicates - we'll apply it during SVG processing
     };
 
@@ -82,6 +86,17 @@ export class AppExportService {
     });
 
     return { bbox, viewBox, exportOptions };
+  }
+
+  /**
+   * Remove interactive tool overlays (selection boundary, remove button) from
+   * the cloned SVG before serialization. X6's export plugin clones the live
+   * DOM, so any cell tools present at export time would otherwise be baked
+   * into the exported image.
+   */
+  // SEM@4fb49728d1fcb8c162fd869008cfbe1294b345ef: strip X6 cell tool overlays from a cloned SVG prior to export serialization (mutates argument)
+  private stripInteractiveTooling(svg: SVGSVGElement): void {
+    svg.querySelectorAll('[data-tool-name], .x6-cell-tools').forEach(el => el.remove());
   }
 
   /**

--- a/src/app/pages/dfd/infrastructure/adapters/infra-x6-graph.adapter.ts
+++ b/src/app/pages/dfd/infrastructure/adapters/infra-x6-graph.adapter.ts
@@ -22,13 +22,7 @@
 import { Injectable, Injector } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { Graph, Node, Edge, Cell } from '@antv/x6';
-import '@antv/x6-plugin-export';
-import { Export } from '@antv/x6-plugin-export';
-import { Snapline } from '@antv/x6-plugin-snapline';
-import { Transform } from '@antv/x6-plugin-transform';
-import '@antv/x6-plugin-clipboard';
-import { Clipboard } from '@antv/x6-plugin-clipboard';
+import { Graph, Node, Edge, Cell, Export, Snapline, Transform, Clipboard } from '@antv/x6';
 
 import { IGraphAdapter } from '../interfaces/graph-adapter.interface';
 import { DFD_STYLING, DFD_STYLING_HELPERS } from '../../constants/styling-constants';

--- a/src/app/pages/dfd/infrastructure/adapters/infra-x6-selection.adapter.spec.ts
+++ b/src/app/pages/dfd/infrastructure/adapters/infra-x6-selection.adapter.spec.ts
@@ -771,6 +771,34 @@ describe('InfraX6SelectionAdapter', () => {
       expect(adapter.clearSelection).toHaveBeenCalledWith(graph);
       expect(adapter.selectCells).toHaveBeenCalledWith(graph, cellsToPaste);
     });
+
+    it('should strip cloned selection tools and glow from pasted cells', () => {
+      adapter.setupSelectionEvents(graph);
+
+      // Simulate X6 clipboard behavior: the source cell is selected (tools and
+      // glow applied to its model), then cloned — the clone carries that
+      // ephemeral state into the graph without ever being selected itself
+      graph.trigger('selection:changed', { added: [nodes[0]], removed: [] });
+      const pasted = nodes[0].clone();
+      graph.addCell(pasted);
+      addNodeTypeInfoExtension(pasted, 'process');
+
+      expect(pasted.getTools()).toBeDefined();
+      expect(pasted.attr('body/filter')).not.toBe('none');
+
+      adapter.sanitizePastedCells(graph, [pasted]);
+
+      expect(pasted.getTools()).toBeUndefined();
+      expect(pasted.attr('body/filter')).toBe('none');
+    });
+
+    it('should handle sanitize with no pasted cells', () => {
+      const executeVisualEffectSpy = vi.spyOn(historyCoordinator, 'executeVisualEffect');
+
+      adapter.sanitizePastedCells(graph, []);
+
+      expect(executeVisualEffectSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('Alignment and Distribution Operations', () => {

--- a/src/app/pages/dfd/infrastructure/adapters/infra-x6-selection.adapter.ts
+++ b/src/app/pages/dfd/infrastructure/adapters/infra-x6-selection.adapter.ts
@@ -339,6 +339,37 @@ export class InfraX6SelectionAdapter {
   }
 
   /**
+   * Strip ephemeral selection state from cells cloned by X6's clipboard.
+   * The clipboard clones the full cell store, so cells copied while selected
+   * carry this adapter's tools and selection glow into the pasted copies.
+   * Pasted cells are never actually selected, so the deselection handler can
+   * never clean them — without this, the stale tool overlay and glow persist
+   * on canvas and leak into SVG exports.
+   */
+  // SEM@d35d1af6c1de1a1f60931cb1806860b7deef7d3a: remove cloned selection tools and glow from clipboard-pasted cells (mutates shared state)
+  sanitizePastedCells(graph: Graph, cells: Cell[]): void {
+    if (cells.length === 0) {
+      return;
+    }
+
+    // Use history coordinator to exclude the cleanup from undo/redo history
+    this.historyCoordinator.executeVisualEffect(graph, () => {
+      graph.batchUpdate(() => {
+        cells.forEach(cell => {
+          this.selectedCells.delete(cell.id);
+          this.removeSelectionEffect(cell);
+          this.removeHoverEffect(cell);
+          cell.removeTools();
+        });
+      });
+    });
+
+    this.logger.debugComponent('InfraX6SelectionAdapter', 'Sanitized pasted cells', {
+      count: cells.length,
+    });
+  }
+
+  /**
    * Group selected cells using SelectionService business logic
    */
   // SEM@fd85de89046cf53840424637275b588564e03d00: wrap selected nodes into a new group node and record in history (mutates shared state)

--- a/src/app/pages/dfd/infrastructure/adapters/infra-x6-selection.adapter.ts
+++ b/src/app/pages/dfd/infrastructure/adapters/infra-x6-selection.adapter.ts
@@ -1,7 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Graph, Node, Edge, Cell } from '@antv/x6';
-import { Selection } from '@antv/x6-plugin-selection';
-import { Transform } from '@antv/x6-plugin-transform';
+import { Graph, Node, Edge, Cell, Selection, Transform } from '@antv/x6';
 import { NODE_TOOLS, EDGE_TOOLS } from '../constants/tool-configurations';
 import { LoggerService } from '../../../../core/services/logger.service';
 import { SelectionService } from '../services/infra-selection.service';

--- a/src/app/pages/dfd/infrastructure/services/infra-edge.service.ts
+++ b/src/app/pages/dfd/infrastructure/services/infra-edge.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Edge, Node } from '@antv/x6';
+import { Edge, Node, type EdgeProperties } from '@antv/x6';
 import { LoggerService } from '../../../../core/services/logger.service';
 import { EdgeInfo } from '../../domain/value-objects/edge-info';
 import { DFD_STYLING } from '../../constants/styling-constants';
@@ -263,7 +263,7 @@ export class InfraEdgeService {
    * Ensure edge has proper attrs structure for visual rendering
    */
   // SEM@5f881a84d0935fecd8e018eac99b16974e7641c9: build edge visual attrs with required connection and stroke defaults when missing (pure)
-  private _ensureEdgeAttrs(attrs: Edge.Properties['attrs']): Edge.Properties['attrs'] {
+  private _ensureEdgeAttrs(attrs: EdgeProperties['attrs']): EdgeProperties['attrs'] {
     // If attrs is empty or missing critical styling, provide defaults.
     // The 'lines' group selector targets both 'wrap' and 'line' paths
     // (via groupSelector in markup) — connection: true is an X6 runtime

--- a/src/app/pages/dfd/infrastructure/utils/edge-markup.util.ts
+++ b/src/app/pages/dfd/infrastructure/utils/edge-markup.util.ts
@@ -1,4 +1,6 @@
-import { Markup } from '@antv/x6';
+// v3.1.7's public barrel (lib/view/index.d.ts) re-exports the `Markup` value but not the
+// `MarkupJSONMarkup` type; deep import is intentional. Revisit when the pnpm patch is dropped.
+import type { MarkupJSONMarkup } from '@antv/x6/lib/view/markup';
 
 /**
  * Returns the static X6 edge markup configuration shared by edge-creating
@@ -9,7 +11,7 @@ import { Markup } from '@antv/x6';
  * @returns The X6 JSON markup describing the edge's wrap and line paths.
  */
 // SEM@e99bb98ad3ad07b8d4047d771022c542c89d8e39: build the X6 edge markup with transparent hit-area and visible line paths (pure)
-export function getEdgeMarkup(): Markup.JSONMarkup[] {
+export function getEdgeMarkup(): MarkupJSONMarkup[] {
   return [
     {
       tagName: 'path',

--- a/src/app/pages/dfd/presentation/services/dfd-styling.service.spec.ts
+++ b/src/app/pages/dfd/presentation/services/dfd-styling.service.spec.ts
@@ -254,6 +254,20 @@ describe('DfdStylingService', () => {
 
       expect(result).toEqual([{ cellId: 'n1', nodeType: 'store', arch: null }]);
     });
+
+    it('does not throw and classifies arch as null when getData() returns undefined (x6 v3 behavior for cells with no data set)', () => {
+      // x6 v2's Cell.getData() returned {} for a cell with no explicit data;
+      // x6 v3 returns undefined. A freshly created node (e.g. via the
+      // orchestrator) has no data set until something writes to it.
+      const node = fakeCell({ id: 'n1', shape: 'process' });
+      node.getData = (() => undefined) as unknown as FakeCell['getData'];
+      const graph = fakeGraph([node]);
+
+      expect(() => service.buildIconPickerCells(graph, ['n1'])).not.toThrow();
+      expect(service.buildIconPickerCells(graph, ['n1'])).toEqual([
+        { cellId: 'n1', nodeType: 'process', arch: null },
+      ]);
+    });
   });
 
   describe('applyNodeStyleChange', () => {

--- a/src/app/pages/dfd/presentation/services/dfd-styling.service.ts
+++ b/src/app/pages/dfd/presentation/services/dfd-styling.service.ts
@@ -94,7 +94,7 @@ export class DfdStylingService {
       .map(cell => ({
         cellId: cell.id,
         nodeType: cell.shape,
-        arch: (cell.getData()['_arch'] as ArchIconData) ?? null,
+        arch: ((cell.getData() ?? {})['_arch'] as ArchIconData) ?? null,
       }));
   }
 


### PR DESCRIPTION
Upgrades `@antv/x6` 2.19.2 → 3.1.7 and removes the six now-consolidated `@antv/x6-plugin-*` packages (v3 merged all plugins plus `x6-common`/`x6-geometry` into core; `@antv/x6-plugin-history` was declared but never imported). Closes #446.

## Upstream packaging workaround

`@antv/x6@3.1.7` declares `"type": "module"` over a CJS `main` build with no `exports` map ([antvis/X6#5048](https://github.com/antvis/X6/issues/5048)), which crashes Node-resolution consumers (Vitest). A `pnpm patch` (`patches/@antv__x6@3.1.7.patch`) flips `type` to `commonjs` — the root-cause fix; redirecting `main` to the `es/` build was tested and rejected (`ERR_UNSUPPORTED_DIR_IMPORT`: the ESM build itself uses extensionless directory imports). Consequences, documented in `package.json` `comments`:
- **x6 is exact-pinned at 3.1.7** — the patch is version-keyed; bumping invalidates it. Unpin + drop the patch when upstream ships a fix.
- One deep type import (`@antv/x6/lib/view/markup`) because v3 fails to barrel-export `MarkupJSONMarkup` (type-only, erased at compile time).

## Source migration

- Plugin imports moved to core in `infra-x6-graph.adapter`, `infra-x6-selection.adapter`; leftover bare plugin import removed in `app-dfd-orchestrator.service`.
- `Edge.Properties` → `EdgeProperties`, `Markup.JSONMarkup` → `MarkupJSONMarkup` (v3 removed namespace types).

## v3 behavior fixes (found by verification, each with regression tests)

- **`Cell.getData()` returns `undefined`** for data-less cells (v2: `{}`): guarded the one unguarded dereference (`dfd-styling.service`) that permanently broke the icon-picker panel; audited all ~48 other call sites (safe).
- **Clipboard clones carried ephemeral tool/glow state** (latent in v2, rendered by v3's view scheduler): pasted cells are now sanitized at the paste seam, and SVG/PNG/JPEG exports strip interactive tooling via the v3 Export plugin's `beforeSerialize` hook — exports were previously contaminated with selection artwork.

## Validation

- Unit: 5995/5995 (305 files); build + lint:all clean; final whole-branch review clean.
- E2E (DFD scope, 67 tests): 52 passing including icon-picker (recovered by the getData fix), interactions, history, autosave, controls. Manual smoke: clipboard, snapline, export (clean SVGs verified), two-user collaboration sync all pass.
- v3's `panning` default flip is neutralized by our explicit config; selection-vs-panning conflict has no surface (panning is Shift-gated).
- Remaining E2E failures are dispositioned, none v3-related: VRT baselines stale since #676 + capture instability (#830), stroke-color test vs palette gating (#831), svgo config warning (#832), and 2 tests gated on backend seed data absent from the dev environment (`Seed TM - Full Fields`).

During this work two pre-existing main bugs were found and fixed separately: #828 (vite override vs @angular/build 22.1.2 dev-server crash) and #829 (stale E2E login locator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UVtkhfoKshZypZVAghX4Z