### PR TITLE
feat: show allowable min/max range alongside defaults in the add-quota dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmi-ux",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "type": "module",
   "scripts": {
     "prepare": "git config core.hooksPath .husky 2>/dev/null || true",

--- a/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html
+++ b/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html
@@ -65,16 +65,38 @@
             <mat-label [transloco]="'admin.quotas.requestsPerMinute'"
               >Requests per minute</mat-label
             >
-            <input matInput type="number" formControlName="max_requests_per_minute" min="1" />
-            <mat-hint>Default: {{ defaultUserAPIQuota.max_requests_per_minute }}</mat-hint>
+            <input
+              matInput
+              type="number"
+              formControlName="max_requests_per_minute"
+              [min]="quotaLimits.max_requests_per_minute.min"
+              [max]="quotaLimits.max_requests_per_minute.max"
+            />
+            <mat-hint>{{
+              'admin.quotas.hint.defaultAndRange' | transloco: hintParams.max_requests_per_minute
+            }}</mat-hint>
+            <mat-error>{{
+              'admin.quotas.hint.outOfRange' | transloco: hintParams.max_requests_per_minute
+            }}</mat-error>
           </mat-form-field>
 
           <mat-form-field appearance="outline">
             <mat-label [transloco]="'admin.quotas.requestsPerHour'"
               >Requests per hour (optional)</mat-label
             >
-            <input matInput type="number" formControlName="max_requests_per_hour" min="1" />
-            <mat-hint>Default: {{ defaultUserAPIQuota.max_requests_per_hour }}</mat-hint>
+            <input
+              matInput
+              type="number"
+              formControlName="max_requests_per_hour"
+              [min]="quotaLimits.max_requests_per_hour.min"
+              [max]="quotaLimits.max_requests_per_hour.max"
+            />
+            <mat-hint>{{
+              'admin.quotas.hint.defaultAndRange' | transloco: hintParams.max_requests_per_hour
+            }}</mat-hint>
+            <mat-error>{{
+              'admin.quotas.hint.outOfRange' | transloco: hintParams.max_requests_per_hour
+            }}</mat-error>
           </mat-form-field>
         </div>
 
@@ -83,14 +105,36 @@
         <div class="quota-fields">
           <mat-form-field appearance="outline">
             <mat-label [transloco]="'admin.quotas.maxSubscriptions'">Max subscriptions</mat-label>
-            <input matInput type="number" formControlName="max_subscriptions" min="1" />
-            <mat-hint>Default: {{ defaultWebhookQuota.max_subscriptions }}</mat-hint>
+            <input
+              matInput
+              type="number"
+              formControlName="max_subscriptions"
+              [min]="quotaLimits.max_subscriptions.min"
+              [max]="quotaLimits.max_subscriptions.max"
+            />
+            <mat-hint>{{
+              'admin.quotas.hint.defaultAndRange' | transloco: hintParams.max_subscriptions
+            }}</mat-hint>
+            <mat-error>{{
+              'admin.quotas.hint.outOfRange' | transloco: hintParams.max_subscriptions
+            }}</mat-error>
           </mat-form-field>
 
           <mat-form-field appearance="outline">
             <mat-label [transloco]="'admin.quotas.eventsPerMinute'">Events per minute</mat-label>
-            <input matInput type="number" formControlName="max_events_per_minute" min="1" />
-            <mat-hint>Default: {{ defaultWebhookQuota.max_events_per_minute }}</mat-hint>
+            <input
+              matInput
+              type="number"
+              formControlName="max_events_per_minute"
+              [min]="quotaLimits.max_events_per_minute.min"
+              [max]="quotaLimits.max_events_per_minute.max"
+            />
+            <mat-hint>{{
+              'admin.quotas.hint.defaultAndRange' | transloco: hintParams.max_events_per_minute
+            }}</mat-hint>
+            <mat-error>{{
+              'admin.quotas.hint.outOfRange' | transloco: hintParams.max_events_per_minute
+            }}</mat-error>
           </mat-form-field>
 
           <mat-form-field appearance="outline">
@@ -101,11 +145,17 @@
               matInput
               type="number"
               formControlName="max_subscription_requests_per_minute"
-              min="1"
+              [min]="quotaLimits.max_subscription_requests_per_minute.min"
+              [max]="quotaLimits.max_subscription_requests_per_minute.max"
             />
-            <mat-hint
-              >Default: {{ defaultWebhookQuota.max_subscription_requests_per_minute }}</mat-hint
-            >
+            <mat-hint>{{
+              'admin.quotas.hint.defaultAndRange'
+                | transloco: hintParams.max_subscription_requests_per_minute
+            }}</mat-hint>
+            <mat-error>{{
+              'admin.quotas.hint.outOfRange'
+                | transloco: hintParams.max_subscription_requests_per_minute
+            }}</mat-error>
           </mat-form-field>
 
           <mat-form-field appearance="outline">
@@ -116,11 +166,17 @@
               matInput
               type="number"
               formControlName="max_subscription_requests_per_day"
-              min="1"
+              [min]="quotaLimits.max_subscription_requests_per_day.min"
+              [max]="quotaLimits.max_subscription_requests_per_day.max"
             />
-            <mat-hint
-              >Default: {{ defaultWebhookQuota.max_subscription_requests_per_day }}</mat-hint
-            >
+            <mat-hint>{{
+              'admin.quotas.hint.defaultAndRange'
+                | transloco: hintParams.max_subscription_requests_per_day
+            }}</mat-hint>
+            <mat-error>{{
+              'admin.quotas.hint.outOfRange'
+                | transloco: hintParams.max_subscription_requests_per_day
+            }}</mat-error>
           </mat-form-field>
         </div>
       </form>

--- a/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.spec.ts
+++ b/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.spec.ts
@@ -13,6 +13,7 @@ import { FormBuilder } from '@angular/forms';
 import { of, throwError } from 'rxjs';
 
 import { AddQuotaDialogComponent } from './add-quota-dialog.component';
+import { DEFAULT_WEBHOOK_QUOTA, QUOTA_LIMITS } from '@app/types/quota.types';
 import type { AdminUser } from '@app/types/user.types';
 
 describe('AddQuotaDialogComponent', () => {
@@ -77,6 +78,38 @@ describe('AddQuotaDialogComponent', () => {
       component.quotaForm.patchValue({ max_requests_per_minute: 0 });
 
       expect(component.quotaForm.get('max_requests_per_minute')?.hasError('min')).toBe(true);
+    });
+
+    it('is invalid when a quota exceeds the spec maximum', () => {
+      const component = build();
+      component.quotaForm.patchValue({
+        max_requests_per_minute: QUOTA_LIMITS.max_requests_per_minute.max + 1,
+        max_subscriptions: QUOTA_LIMITS.max_subscriptions.max + 1,
+      });
+
+      expect(component.quotaForm.get('max_requests_per_minute')?.hasError('max')).toBe(true);
+      expect(component.quotaForm.get('max_subscriptions')?.hasError('max')).toBe(true);
+    });
+
+    it('accepts the spec boundary values', () => {
+      const component = build();
+      component.quotaForm.patchValue({
+        max_requests_per_minute: QUOTA_LIMITS.max_requests_per_minute.max,
+        max_requests_per_hour: QUOTA_LIMITS.max_requests_per_hour.min,
+      });
+
+      expect(component.quotaForm.get('max_requests_per_minute')?.valid).toBe(true);
+      expect(component.quotaForm.get('max_requests_per_hour')?.valid).toBe(true);
+    });
+
+    it('exposes default and range params for hints', () => {
+      const component = build();
+
+      expect(component.hintParams.max_events_per_minute).toEqual({
+        default: DEFAULT_WEBHOOK_QUOTA.max_events_per_minute,
+        min: QUOTA_LIMITS.max_events_per_minute.min,
+        max: QUOTA_LIMITS.max_events_per_minute.max,
+      });
     });
   });
 

--- a/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.ts
+++ b/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.ts
@@ -14,7 +14,28 @@ import {
 import { QuotaService } from '@app/core/services/quota.service';
 import { LoggerService } from '@app/core/services/logger.service';
 import { AdminUser } from '@app/types/user.types';
-import { DEFAULT_USER_API_QUOTA, DEFAULT_WEBHOOK_QUOTA } from '@app/types/quota.types';
+import {
+  DEFAULT_USER_API_QUOTA,
+  DEFAULT_WEBHOOK_QUOTA,
+  QUOTA_LIMITS,
+} from '@app/types/quota.types';
+
+const QUOTA_DEFAULTS: Record<keyof typeof QUOTA_LIMITS, number> = {
+  ...DEFAULT_USER_API_QUOTA,
+  ...DEFAULT_WEBHOOK_QUOTA,
+};
+
+/** Transloco params per quota field: client default plus spec-sourced range. */
+const QUOTA_HINT_PARAMS = Object.fromEntries(
+  Object.entries(QUOTA_LIMITS).map(([field, range]) => [
+    field,
+    {
+      default: QUOTA_DEFAULTS[field as keyof typeof QUOTA_LIMITS],
+      min: range.min,
+      max: range.max,
+    },
+  ]),
+) as Record<keyof typeof QUOTA_LIMITS, { default: number; min: number; max: number }>;
 
 /**
  * Add Quota Dialog Component
@@ -53,6 +74,8 @@ export class AddQuotaDialogComponent implements OnInit {
 
   readonly defaultUserAPIQuota = DEFAULT_USER_API_QUOTA;
   readonly defaultWebhookQuota = DEFAULT_WEBHOOK_QUOTA;
+  readonly quotaLimits = QUOTA_LIMITS;
+  readonly hintParams = QUOTA_HINT_PARAMS;
 
   // SEM@65afaf0b87a37250bf4e27116c95afdfd3ffc43f: initialize user search and quota forms with default values (pure)
   constructor(
@@ -69,25 +92,51 @@ export class AddQuotaDialogComponent implements OnInit {
       // User API Quotas
       max_requests_per_minute: [
         this.defaultUserAPIQuota.max_requests_per_minute,
-        [Validators.required, Validators.min(1)],
+        [
+          Validators.required,
+          Validators.min(QUOTA_LIMITS.max_requests_per_minute.min),
+          Validators.max(QUOTA_LIMITS.max_requests_per_minute.max),
+        ],
       ],
-      max_requests_per_hour: [this.defaultUserAPIQuota.max_requests_per_hour, Validators.min(1)],
+      max_requests_per_hour: [
+        this.defaultUserAPIQuota.max_requests_per_hour,
+        [
+          Validators.min(QUOTA_LIMITS.max_requests_per_hour.min),
+          Validators.max(QUOTA_LIMITS.max_requests_per_hour.max),
+        ],
+      ],
       // Webhook Quotas
       max_subscriptions: [
         this.defaultWebhookQuota.max_subscriptions,
-        [Validators.required, Validators.min(1)],
+        [
+          Validators.required,
+          Validators.min(QUOTA_LIMITS.max_subscriptions.min),
+          Validators.max(QUOTA_LIMITS.max_subscriptions.max),
+        ],
       ],
       max_events_per_minute: [
         this.defaultWebhookQuota.max_events_per_minute,
-        [Validators.required, Validators.min(1)],
+        [
+          Validators.required,
+          Validators.min(QUOTA_LIMITS.max_events_per_minute.min),
+          Validators.max(QUOTA_LIMITS.max_events_per_minute.max),
+        ],
       ],
       max_subscription_requests_per_minute: [
         this.defaultWebhookQuota.max_subscription_requests_per_minute,
-        [Validators.required, Validators.min(1)],
+        [
+          Validators.required,
+          Validators.min(QUOTA_LIMITS.max_subscription_requests_per_minute.min),
+          Validators.max(QUOTA_LIMITS.max_subscription_requests_per_minute.max),
+        ],
       ],
       max_subscription_requests_per_day: [
         this.defaultWebhookQuota.max_subscription_requests_per_day,
-        [Validators.required, Validators.min(1)],
+        [
+          Validators.required,
+          Validators.min(QUOTA_LIMITS.max_subscription_requests_per_day.min),
+          Validators.max(QUOTA_LIMITS.max_subscription_requests_per_day.max),
+        ],
       ],
     });
   }

--- a/src/app/types/quota.types.ts
+++ b/src/app/types/quota.types.ts
@@ -63,6 +63,22 @@ export const DEFAULT_WEBHOOK_QUOTA = {
 } as const;
 
 /**
+ * Allowable ranges per quota field, transcribed from the OpenAPI spec
+ * (UserQuotaUpdate / WebhookQuotaUpdate schemas in tmi-openapi.json) because
+ * the minimum/maximum constraints do not survive type codegen.
+ * Duplicated client-side and can drift — ericfitz/tmi#649 asks the server to
+ * expose defaults/ranges at runtime; if that lands, read them instead.
+ */
+export const QUOTA_LIMITS = {
+  max_requests_per_minute: { min: 1, max: 10000 },
+  max_requests_per_hour: { min: 1, max: 600000 },
+  max_subscriptions: { min: 1, max: 100 },
+  max_events_per_minute: { min: 1, max: 1000 },
+  max_subscription_requests_per_minute: { min: 1, max: 100 },
+  max_subscription_requests_per_day: { min: 1, max: 10000 },
+} as const;
+
+/**
  * Response from GET /admin/quotas/users
  */
 export interface ListUserAPIQuotasResponse extends PaginationMetadata {

--- a/src/assets/i18n/ar-SA.json
+++ b/src/assets/i18n/ar-SA.json
@@ -269,7 +269,11 @@
       "subtitle": "تكوين حدود المعدل والحصص للمستخدمين.",
       "title": "إدارة الحصص",
       "userAPITitle": "حدود معدل API",
-      "webhookTitle": "حدود Webhook"
+      "webhookTitle": "حدود Webhook",
+      "hint": {
+        "defaultAndRange": "الافتراضي: {{default}} (النطاق: {{min}}–{{max}})",
+        "outOfRange": "أدخل قيمة بين {{min}} و{{max}}"
+      }
     },
     "sections": {
       "addons": {

--- a/src/assets/i18n/bn-BD.json
+++ b/src/assets/i18n/bn-BD.json
@@ -291,7 +291,11 @@
       "subtitle": "ব্যবহারকারীদের জন্য রেট লিমিট এবং কোটা কনফিগার করুন",
       "title": "কোটা পরিচালনা করুন",
       "userAPITitle": "API সীমা",
-      "webhookTitle": "Webhook সীমা"
+      "webhookTitle": "Webhook সীমা",
+      "hint": {
+        "defaultAndRange": "ডিফল্ট: {{default}} (পরিসর: {{min}}–{{max}})",
+        "outOfRange": "{{min}} থেকে {{max}} এর মধ্যে একটি মান লিখুন"
+      }
     },
     "sections": {
       "addons": {

--- a/src/assets/i18n/de-DE.json
+++ b/src/assets/i18n/de-DE.json
@@ -269,7 +269,11 @@
       "subtitle": "Ratenlimits und Kontingente für Benutzer konfigurieren.",
       "title": "Kontingente verwalten",
       "userAPITitle": "API-Ratenlimits",
-      "webhookTitle": "Webhook-Limits"
+      "webhookTitle": "Webhook-Limits",
+      "hint": {
+        "defaultAndRange": "Standard: {{default}} (Bereich: {{min}}–{{max}})",
+        "outOfRange": "Wert zwischen {{min}} und {{max}} eingeben"
+      }
     },
     "sections": {
       "addons": {

--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -312,7 +312,11 @@
       "subtitle": "Configure rate limits and quotas for users.",
       "title": "Manage quotas",
       "userAPITitle": "API rate limits",
-      "webhookTitle": "Webhook limits"
+      "webhookTitle": "Webhook limits",
+      "hint": {
+        "defaultAndRange": "Default: {{default}} (range: {{min}}–{{max}})",
+        "outOfRange": "Enter a value between {{min}} and {{max}}"
+      }
     },
     "sections": {
       "addons": {

--- a/src/assets/i18n/en-US.usage.json
+++ b/src/assets/i18n/en-US.usage.json
@@ -2918,6 +2918,20 @@
     "uses": [
       {
         "classes": [],
+        "context": "<h1 [transloco]=\"'admin.title'\">Administration</h1>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/admin.component.html",
+        "line": 4,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<p class=\"admin-subtitle\" [transloco]=\"'admin.subtitle'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/admin.component.html",
+        "line": 5,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "<h1 [transloco]=\"'admin.webhooks.title'\">Manage Webhooks</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
         "line": 4,
@@ -2970,20 +2984,6 @@
         "context": "<span [transloco]=\"'admin.webhooks.deleteTooltip'\">Delete</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
         "line": 95,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'admin.webhooks.triggerEvents'\">Trigger events</span>:",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
-        "line": 104,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'admin.webhooks.subscriptionId'\">Subscription ID</span>:",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
-        "line": 110,
         "partial_match": "medium"
       }
     ]
@@ -4565,7 +4565,7 @@
         "classes": [],
         "context": "<h4 [transloco]=\"'admin.quotas.addDialog.webhookQuotas'\">Webhook Limits</h4>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
-        "line": 82
+        "line": 104
       }
     ]
   },
@@ -4726,15 +4726,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "{{ 'admin.quotas.eventsPerMinute' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
-        "line": 316
+        "context": "<mat-label [transloco]=\"'admin.quotas.eventsPerMinute'\">Events per minute</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 124
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'admin.quotas.eventsPerMinute'\">Events per minute</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
-        "line": 91
+        "context": "{{ 'admin.quotas.eventsPerMinute' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
+        "line": 316
       }
     ]
   },
@@ -4774,6 +4774,103 @@
       }
     ]
   },
+  "admin.quotas.hint.defaultAndRange": {
+    "ambiguous_word": false,
+    "confidence": "high",
+    "ellipsis_candidate": false,
+    "found_by": "fully-qualified",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "placeholder"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "'admin.quotas.hint.defaultAndRange' | transloco: hintParams.max_requests_per_minute",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 76
+      },
+      {
+        "classes": [],
+        "context": "'admin.quotas.hint.defaultAndRange' | transloco: hintParams.max_requests_per_hour",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 95
+      },
+      {
+        "classes": [],
+        "context": "'admin.quotas.hint.defaultAndRange' | transloco: hintParams.max_subscriptions",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 116
+      },
+      {
+        "classes": [],
+        "context": "'admin.quotas.hint.defaultAndRange' | transloco: hintParams.max_events_per_minute",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 133
+      },
+      {
+        "classes": [],
+        "context": "'admin.quotas.hint.defaultAndRange'",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 152
+      },
+      {
+        "classes": [],
+        "context": "'admin.quotas.hint.defaultAndRange'",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 173
+      }
+    ]
+  },
+  "admin.quotas.hint.outOfRange": {
+    "ambiguous_word": false,
+    "confidence": "high",
+    "ellipsis_candidate": false,
+    "found_by": "fully-qualified",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "error",
+      "placeholder"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "'admin.quotas.hint.outOfRange' | transloco: hintParams.max_requests_per_minute",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 79
+      },
+      {
+        "classes": [],
+        "context": "'admin.quotas.hint.outOfRange' | transloco: hintParams.max_requests_per_hour",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 98
+      },
+      {
+        "classes": [],
+        "context": "'admin.quotas.hint.outOfRange' | transloco: hintParams.max_subscriptions",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 119
+      },
+      {
+        "classes": [],
+        "context": "'admin.quotas.hint.outOfRange' | transloco: hintParams.max_events_per_minute",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 136
+      },
+      {
+        "classes": [],
+        "context": "'admin.quotas.hint.outOfRange'",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 156
+      },
+      {
+        "classes": [],
+        "context": "'admin.quotas.hint.outOfRange'",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 177
+      }
+    ]
+  },
   "admin.quotas.maxSubscriptions": {
     "ambiguous_word": false,
     "confidence": "high",
@@ -4786,15 +4883,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'admin.quotas.maxSubscriptions'\">Max subscriptions</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
-        "line": 85
-      },
-      {
-        "classes": [],
         "context": "{{ 'admin.quotas.maxSubscriptions' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
         "line": 291
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'admin.quotas.maxSubscriptions'\">Max subscriptions</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 107
       }
     ]
   },
@@ -4846,15 +4943,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "{{ 'admin.quotas.requestsPerHour' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
-        "line": 114
+        "context": "<mat-label [transloco]=\"'admin.quotas.requestsPerHour'\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 84
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'admin.quotas.requestsPerHour'\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
-        "line": 73
+        "context": "{{ 'admin.quotas.requestsPerHour' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
+        "line": 114
       }
     ]
   },
@@ -4896,7 +4993,7 @@
         "classes": [],
         "context": "<mat-label [transloco]=\"'admin.quotas.subReqPerDay'\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
-        "line": 112
+        "line": 162
       },
       {
         "classes": [],
@@ -4918,15 +5015,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "{{ 'admin.quotas.subReqPerMinute' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
-        "line": 341
+        "context": "<mat-label [transloco]=\"'admin.quotas.subReqPerMinute'\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 141
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'admin.quotas.subReqPerMinute'\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
-        "line": 97
+        "context": "{{ 'admin.quotas.subReqPerMinute' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
+        "line": 341
       }
     ]
   },
@@ -6272,20 +6369,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "<h1 [transloco]=\"'admin.title'\">Administration</h1>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/admin.component.html",
-        "line": 4,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<p class=\"admin-subtitle\" [transloco]=\"'admin.subtitle'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/admin.component.html",
-        "line": 5,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "<h1 [transloco]=\"'admin.webhooks.title'\">Manage Webhooks</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
         "line": 4,
@@ -6338,6 +6421,20 @@
         "context": "<span [transloco]=\"'admin.webhooks.deleteTooltip'\">Delete</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
         "line": 95,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'admin.webhooks.triggerEvents'\">Trigger events</span>:",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
+        "line": 104,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'admin.webhooks.subscriptionId'\">Subscription ID</span>:",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
+        "line": 110,
         "partial_match": "medium"
       }
     ]
@@ -7872,6 +7969,13 @@
     "uses": [
       {
         "classes": [],
+        "context": "const message = this.transloco.translate('admin.addons.confirmDelete', { name: addon.name });",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/addons/admin-addons.component.ts",
+        "line": 206,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "<h1 [transloco]=\"'admin.webhooks.title'\">Manage Webhooks</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
         "line": 4,
@@ -7931,13 +8035,6 @@
         "context": "<span [transloco]=\"'admin.webhooks.triggerEvents'\">Trigger events</span>:",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
         "line": 104,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'admin.webhooks.subscriptionId'\">Subscription ID</span>:",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
-        "line": 110,
         "partial_match": "medium"
       }
     ]
@@ -8036,6 +8133,20 @@
     "uses": [
       {
         "classes": [],
+        "context": "<h1 [transloco]=\"'admin.title'\">Administration</h1>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/admin.component.html",
+        "line": 4,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<p class=\"admin-subtitle\" [transloco]=\"'admin.subtitle'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/admin.component.html",
+        "line": 5,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "<h1 [transloco]=\"'admin.webhooks.title'\">Manage Webhooks</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
         "line": 4,
@@ -8088,20 +8199,6 @@
         "context": "<span [transloco]=\"'admin.webhooks.deleteTooltip'\">Delete</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
         "line": 95,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'admin.webhooks.triggerEvents'\">Trigger events</span>:",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
-        "line": 104,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'admin.webhooks.subscriptionId'\">Subscription ID</span>:",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
-        "line": 110,
         "partial_match": "medium"
       }
     ]
@@ -10040,27 +10137,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "<span class=\"info-label\">{{ 'aiFeedback.autoGeneratedLabel' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
-        "line": 25,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'aiFeedback.thumbsUp' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
-        "line": 30,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'aiFeedback.thumbsDown' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
-        "line": 39,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "<h2 mat-dialog-title>{{ t('aiFeedback.title.' + data.targetType) }}</h2>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.html",
         "line": 2,
@@ -10106,6 +10182,27 @@
         "context": "<mat-option [value]=\"reason\">{{ t('aiFeedback.reason.' + reason) }}</mat-option>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.html",
         "line": 42,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ t('aiFeedback.subreasonLabel') }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.html",
+        "line": 49,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-option [value]=\"sub\">{{ t('aiFeedback.subreason.' + sub) }}</mat-option>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.html",
+        "line": 52,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "? t('aiFeedback.verbatimLabelRequired')",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.html",
+        "line": 63,
         "partial_match": "medium"
       }
     ]
@@ -10532,6 +10629,20 @@
     "uses": [
       {
         "classes": [],
+        "context": "this._snack.open(this._transloco.translate('aiFeedback.snackbarSubmitted'), undefined, {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.ts",
+        "line": 134,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this._snack.open(this._transloco.translate('aiFeedback.snackbarFailed'), undefined, {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.ts",
+        "line": 145,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "<h2 mat-dialog-title>{{ t('aiFeedback.title.' + data.targetType) }}</h2>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.html",
         "line": 2,
@@ -10584,20 +10695,6 @@
         "context": "<mat-label>{{ t('aiFeedback.subreasonLabel') }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.html",
         "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-option [value]=\"sub\">{{ t('aiFeedback.subreason.' + sub) }}</mat-option>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.html",
-        "line": 52,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "? t('aiFeedback.verbatimLabelRequired')",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.html",
-        "line": 63,
         "partial_match": "medium"
       }
     ]
@@ -11178,6 +11275,20 @@
     "uses": [
       {
         "classes": [],
+        "context": "this._snack.open(this._transloco.translate('aiFeedback.snackbarSubmitted'), undefined, {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.ts",
+        "line": 134,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this._snack.open(this._transloco.translate('aiFeedback.snackbarFailed'), undefined, {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.ts",
+        "line": 145,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "<h2 mat-dialog-title>{{ t('aiFeedback.title.' + data.targetType) }}</h2>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.html",
         "line": 2,
@@ -11230,20 +11341,6 @@
         "context": "<mat-label>{{ t('aiFeedback.subreasonLabel') }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.html",
         "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-option [value]=\"sub\">{{ t('aiFeedback.subreason.' + sub) }}</mat-option>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.html",
-        "line": 52,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "? t('aiFeedback.verbatimLabelRequired')",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.html",
-        "line": 63,
         "partial_match": "medium"
       }
     ]
@@ -11861,15 +11958,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "{ header: transloco.translate('assetEditor.type'), proportion: TABLE_PROPORTIONS.assets[1] },",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 263
-      },
-      {
-        "classes": [],
         "context": "<mat-label [transloco]=\"'assetEditor.type'\">Asset Type</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
         "line": 57
+      },
+      {
+        "classes": [],
+        "context": "{ header: transloco.translate('assetEditor.type'), proportion: TABLE_PROPORTIONS.assets[1] },",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 263
       }
     ]
   },
@@ -11887,14 +11984,7 @@
         "classes": [],
         "context": "asset.type ? ('assetEditor.types.' + asset.type | transloco) : ''",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 531,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{ header: transloco.translate('assetEditor.type'), proportion: TABLE_PROPORTIONS.assets[1] },",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 263,
+        "line": 533,
         "partial_match": "medium"
       },
       {
@@ -11952,6 +12042,13 @@
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
         "line": 79,
         "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "placeholder=\"{{ 'assetEditor.chipPlaceholder' | transloco }}\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
+        "line": 101,
+        "partial_match": "medium"
       }
     ]
   },
@@ -11969,7 +12066,7 @@
         "classes": [],
         "context": "asset.type ? ('assetEditor.types.' + asset.type | transloco) : ''",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 531,
+        "line": 533,
         "partial_match": "medium"
       },
       {
@@ -12051,7 +12148,7 @@
         "classes": [],
         "context": "asset.type ? ('assetEditor.types.' + asset.type | transloco) : ''",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 531,
+        "line": 533,
         "partial_match": "medium"
       },
       {
@@ -12140,7 +12237,7 @@
         "classes": [],
         "context": "asset.type ? ('assetEditor.types.' + asset.type | transloco) : ''",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 531,
+        "line": 533,
         "partial_match": "medium"
       },
       {
@@ -12213,16 +12310,9 @@
     "uses": [
       {
         "classes": [],
-        "context": "{ header: transloco.translate('assetEditor.type'), proportion: TABLE_PROPORTIONS.assets[1] },",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 263,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "asset.type ? ('assetEditor.types.' + asset.type | transloco) : ''",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 531,
+        "line": 533,
         "partial_match": "medium"
       },
       {
@@ -12280,6 +12370,13 @@
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
         "line": 79,
         "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "placeholder=\"{{ 'assetEditor.chipPlaceholder' | transloco }}\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
+        "line": 101,
+        "partial_match": "medium"
       }
     ]
   },
@@ -12297,7 +12394,7 @@
         "classes": [],
         "context": "asset.type ? ('assetEditor.types.' + asset.type | transloco) : ''",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 531,
+        "line": 533,
         "partial_match": "medium"
       },
       {
@@ -12445,88 +12542,6 @@
       },
       {
         "classes": [],
-        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 78,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 652,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 882,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1087,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1284,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1501,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1914,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'auditTrail.rollback.confirmTitle' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
-        "line": 3,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "auditTrail.changeTypes.restored": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "if (key === 'auditTrail.rollback.confirmationValue') return 'rollback';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.spec.ts",
-        "line": 46,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'auditTrail.rollback.confirmationValue',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.spec.ts",
-        "line": 120,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "{{ 'auditTrail.rollback.confirmTitle' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
         "line": 3,
@@ -12579,6 +12594,88 @@
         "context": "[placeholder]=\"'auditTrail.rollback.confirmationValue' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
         "line": 53,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "auditTrail.changeTypes.restored": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 80,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 654,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 884,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1089,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1286,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1503,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1916,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "if (key === 'auditTrail.rollback.confirmationValue') return 'rollback';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.spec.ts",
+        "line": 46,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'auditTrail.rollback.confirmationValue',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.spec.ts",
+        "line": 120,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'auditTrail.rollback.confirmTitle' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
+        "line": 3,
         "partial_match": "medium"
       }
     ]
@@ -12735,6 +12832,13 @@
       },
       {
         "classes": [],
+        "context": "return this.transloco.translate('auditTrail.rollback.confirmationValue');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.ts",
+        "line": 48,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "{{ 'auditTrail.rollback.confirmTitle' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
         "line": 3,
@@ -12780,13 +12884,6 @@
         "context": "<mat-label>{{ 'auditTrail.rollback.confirmationField' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
         "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[placeholder]=\"'auditTrail.rollback.confirmationValue' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
-        "line": 53,
         "partial_match": "medium"
       }
     ]
@@ -13078,6 +13175,88 @@
     "uses": [
       {
         "classes": [],
+        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 80,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 654,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 884,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1089,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1286,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1503,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1916,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "if (key === 'auditTrail.rollback.confirmationValue') return 'rollback';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.spec.ts",
+        "line": 46,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'auditTrail.rollback.confirmationValue',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.spec.ts",
+        "line": 120,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'auditTrail.rollback.confirmTitle' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
+        "line": 3,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "auditTrail.rollback.success": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
         "context": "if (key === 'auditTrail.rollback.confirmationValue') return 'rollback';",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.spec.ts",
         "line": 46,
@@ -13144,88 +13323,6 @@
         "context": "[placeholder]=\"'auditTrail.rollback.confirmationValue' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
         "line": 53,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "auditTrail.rollback.success": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 78,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 652,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 882,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1087,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1284,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1501,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1914,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "if (key === 'auditTrail.rollback.confirmationValue') return 'rollback';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.spec.ts",
-        "line": 46,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'auditTrail.rollback.confirmationValue',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.spec.ts",
-        "line": 120,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "return this.transloco.translate('auditTrail.rollback.confirmationValue');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.ts",
-        "line": 48,
         "partial_match": "medium"
       }
     ]
@@ -13363,43 +13460,43 @@
         "classes": [],
         "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 78
+        "line": 80
       },
       {
         "classes": [],
         "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 652
+        "line": 654
       },
       {
         "classes": [],
         "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 882
+        "line": 884
       },
       {
         "classes": [],
         "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1087
+        "line": 1089
       },
       {
         "classes": [],
         "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1284
+        "line": 1286
       },
       {
         "classes": [],
         "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1501
+        "line": 1503
       },
       {
         "classes": [],
         "context": "<span>{{ 'auditTrail.title' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1914
+        "line": 1916
       },
       {
         "classes": [
@@ -13967,30 +14064,180 @@
     "uses": [
       {
         "classes": [],
-        "context": "[matTooltip]=\"'chat.title' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 25,
+        "context": "key === 'chat.messageStatus.gathering' ? 'Gathering context' : key;",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.spec.ts",
+        "line": 256,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[attr.aria-label]=\"'chat.title' | transloco\"",
+        "context": "{{ t('chat.newSession') }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-session-panel/chat-session-panel.component.html",
+        "line": 5,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ t('chat.sourceSummary.title', { count: sourceSnapshot.length }) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-session-panel/chat-session-panel.component.html",
+        "line": 13,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<p>{{ t('chat.noSessions') }}</p>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-session-panel/chat-session-panel.component.html",
+        "line": 35,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"t('chat.saveSessionAsNote')\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-session-panel/chat-session-panel.component.html",
+        "line": 56,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"t('chat.deleteSession')\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-session-panel/chat-session-panel.component.html",
+        "line": 66,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<h3>{{ t('chat.emptyState.title') }}</h3>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
+        "line": 6,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<p>{{ t('chat.emptyState.description') }}</p>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
+        "line": 7,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "aria-label=\"{{ t('chat.emptyState.title') }}\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
+        "line": 11,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "(click)=\"onSuggestedPrompt(t('chat.suggestedPrompts.summary'))\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
+        "line": 16,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "chat.messageStatus.loading_history": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "key === 'chat.messageStatus.gathering' ? 'Gathering context' : key;",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.spec.ts",
+        "line": 256,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ t('chat.newSession') }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-session-panel/chat-session-panel.component.html",
+        "line": 5,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ t('chat.sourceSummary.title', { count: sourceSnapshot.length }) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-session-panel/chat-session-panel.component.html",
+        "line": 13,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<p>{{ t('chat.noSessions') }}</p>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-session-panel/chat-session-panel.component.html",
+        "line": 35,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"t('chat.saveSessionAsNote')\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-session-panel/chat-session-panel.component.html",
+        "line": 56,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"t('chat.deleteSession')\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-session-panel/chat-session-panel.component.html",
+        "line": 66,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<h3>{{ t('chat.emptyState.title') }}</h3>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
+        "line": 6,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<p>{{ t('chat.emptyState.description') }}</p>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
+        "line": 7,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "aria-label=\"{{ t('chat.emptyState.title') }}\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
+        "line": 11,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "(click)=\"onSuggestedPrompt(t('chat.suggestedPrompts.summary'))\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
+        "line": 16,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "chat.messageStatus.querying_embeddings": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'chat.title' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 26,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<span class=\"toolbar-title\">{{ t('chat.title') }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.html",
-        "line": 4,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"t(sidePanelOpen ? 'chat.hideSidePanel' : 'chat.showSidePanel')\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.html",
-        "line": 8,
+        "context": "[attr.aria-label]=\"'chat.title' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 27,
         "partial_match": "medium"
       },
       {
@@ -14002,42 +14249,56 @@
       },
       {
         "classes": [],
-        "context": "this.transloco.translate('chat.savedAsNote'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.ts",
-        "line": 226,
+        "context": "<h3>{{ t('chat.emptyState.title') }}</h3>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
+        "line": 6,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "this.transloco.translate('chat.savedAsNoteView'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.ts",
-        "line": 227,
+        "context": "<p>{{ t('chat.emptyState.description') }}</p>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
+        "line": 7,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "this.snackBar.open(this.transloco.translate('chat.saveAsNoteError'), '', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.ts",
-        "line": 239,
+        "context": "aria-label=\"{{ t('chat.emptyState.title') }}\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
+        "line": 11,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "this.addErrorMessage(this.transloco.translate('chat.errors.rateLimited', { minutes }));",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.ts",
-        "line": 445,
+        "context": "(click)=\"onSuggestedPrompt(t('chat.suggestedPrompts.summary'))\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
+        "line": 16,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "this.addErrorMessage(this.transloco.translate('chat.errors.serverBusy'));",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.ts",
-        "line": 447,
+        "context": "(keydown.enter)=\"onSuggestedPrompt(t('chat.suggestedPrompts.summary'))\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
+        "line": 17,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "(keydown.space)=\"onSuggestedPrompt(t('chat.suggestedPrompts.summary'))\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
+        "line": 18,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ t('chat.suggestedPrompts.summary') }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
+        "line": 20,
         "partial_match": "medium"
       }
     ]
   },
-  "chat.messageStatus.loading_history": {
+  "chat.messageStatus.waiting_for_llm": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -14115,170 +14376,6 @@
         "context": "(keydown.enter)=\"onSuggestedPrompt(t('chat.suggestedPrompts.threats'))\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
         "line": 26,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "chat.messageStatus.querying_embeddings": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'chat.title' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 25,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'chat.title' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 26,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "key === 'chat.messageStatus.gathering' ? 'Gathering context' : key;",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.spec.ts",
-        "line": 256,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(groups[0].labelKey).toBe('chat.sourceSummary.assets');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-session-panel/chat-session-panel.component.spec.ts",
-        "line": 56,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<h3>{{ t('chat.emptyState.title') }}</h3>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
-        "line": 6,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<p>{{ t('chat.emptyState.description') }}</p>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
-        "line": 7,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "aria-label=\"{{ t('chat.emptyState.title') }}\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
-        "line": 11,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "(click)=\"onSuggestedPrompt(t('chat.suggestedPrompts.summary'))\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
-        "line": 16,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "(keydown.enter)=\"onSuggestedPrompt(t('chat.suggestedPrompts.summary'))\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
-        "line": 17,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "(keydown.space)=\"onSuggestedPrompt(t('chat.suggestedPrompts.summary'))\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
-        "line": 18,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "chat.messageStatus.waiting_for_llm": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'chat.title' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 25,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'chat.title' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 26,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "key === 'chat.messageStatus.gathering' ? 'Gathering context' : key;",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.spec.ts",
-        "line": 256,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ t('chat.newSession') }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-session-panel/chat-session-panel.component.html",
-        "line": 5,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ t('chat.sourceSummary.title', { count: sourceSnapshot.length }) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-session-panel/chat-session-panel.component.html",
-        "line": 13,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<p>{{ t('chat.noSessions') }}</p>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-session-panel/chat-session-panel.component.html",
-        "line": 35,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"t('chat.saveSessionAsNote')\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-session-panel/chat-session-panel.component.html",
-        "line": 56,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"t('chat.deleteSession')\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-session-panel/chat-session-panel.component.html",
-        "line": 66,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<h3>{{ t('chat.emptyState.title') }}</h3>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
-        "line": 6,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<p>{{ t('chat.emptyState.description') }}</p>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-messages/chat-messages.component.html",
-        "line": 7,
         "partial_match": "medium"
       }
     ]
@@ -14445,12 +14542,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "this.transloco.translate('chat.savedAsNote'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.ts",
-        "line": 226
-      },
-      {
-        "classes": [],
         "context": "'chat.savedAsNote',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.spec.ts",
         "line": 520
@@ -14460,6 +14551,12 @@
         "context": "'chat.savedAsNote',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.spec.ts",
         "line": 851
+      },
+      {
+        "classes": [],
+        "context": "this.transloco.translate('chat.savedAsNote'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.ts",
+        "line": 226
       }
     ]
   },
@@ -14475,6 +14572,12 @@
     "uses": [
       {
         "classes": [],
+        "context": "this.transloco.translate('chat.savedAsNoteView'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.ts",
+        "line": 227
+      },
+      {
+        "classes": [],
         "context": "'chat.savedAsNoteView',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.spec.ts",
         "line": 521
@@ -14484,12 +14587,6 @@
         "context": "'chat.savedAsNoteView',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.spec.ts",
         "line": 852
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('chat.savedAsNoteView'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.ts",
-        "line": 227
       }
     ]
   },
@@ -14863,24 +14960,24 @@
     ],
     "uses": [
       {
+        "classes": [],
+        "context": "[matTooltip]=\"'chat.title' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 26
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'chat.title' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 27
+      },
+      {
         "classes": [
           "toolbar-title"
         ],
         "context": "<span class=\"toolbar-title\">{{ t('chat.title') }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.html",
         "line": 4
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'chat.title' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 25
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'chat.title' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 26
       }
     ]
   },
@@ -15380,6 +15477,13 @@
       },
       {
         "classes": [],
+        "context": "return this.transloco.translate('collaboration.justNow');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 517,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "'collaboration.isRequestingPresenterPrivileges' | transloco",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/presenter-request-snackbar/presenter-request-snackbar.component.ts",
         "line": 41,
@@ -15390,13 +15494,6 @@
         "context": "[matTooltip]=\"'collaboration.approvePresenterRequest' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/presenter-request-snackbar/presenter-request-snackbar.component.ts",
         "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'collaboration.denyPresenterRequest' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/presenter-request-snackbar/presenter-request-snackbar.component.ts",
-        "line": 63,
         "partial_match": "medium"
       }
     ]
@@ -15599,15 +15696,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "error: 'collaboration.soloTransition.error',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.ts",
-        "line": 734
-      },
-      {
-        "classes": [],
         "context": "'collaboration.soloTransition.error':",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.spec.ts",
         "line": 149
+      },
+      {
+        "classes": [],
+        "context": "error: 'collaboration.soloTransition.error',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.ts",
+        "line": 734
       }
     ]
   },
@@ -15623,15 +15720,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "left: 'collaboration.soloTransition.left',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.ts",
-        "line": 731
-      },
-      {
-        "classes": [],
         "context": "'collaboration.soloTransition.left':",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.spec.ts",
         "line": 143
+      },
+      {
+        "classes": [],
+        "context": "left: 'collaboration.soloTransition.left',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.ts",
+        "line": 731
       }
     ]
   },
@@ -15701,15 +15798,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "'collaboration.userJoined': `${params?.user || 'User'} joined the collaboration`,",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.spec.ts",
-        "line": 37
-      },
-      {
-        "classes": [],
         "context": "const message = this._transloco.translate('collaboration.userJoined', {",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.ts",
         "line": 426
+      },
+      {
+        "classes": [],
+        "context": "'collaboration.userJoined': `${params?.user || 'User'} joined the collaboration`,",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.spec.ts",
+        "line": 37
       }
     ]
   },
@@ -15725,15 +15822,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "'collaboration.userLeft': `${params?.user || 'User'} left the collaboration`,",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.spec.ts",
-        "line": 38
-      },
-      {
-        "classes": [],
         "context": "const message = this._transloco.translate('collaboration.userLeft', {",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.ts",
         "line": 434
+      },
+      {
+        "classes": [],
+        "context": "'collaboration.userLeft': `${params?.user || 'User'} left the collaboration`,",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.spec.ts",
+        "line": 38
       }
     ]
   },
@@ -15791,12 +15888,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "statusText = this.translocoService.translate('collaboration.websocketStatus.notConnected');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.ts",
-        "line": 444
-      },
-      {
-        "classes": [],
         "context": "'collaboration.websocketStatus.notConnected',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/collaboration-dialog/collaboration-dialog.component.ts",
         "line": 654
@@ -15806,6 +15897,12 @@
         "context": "statusText = this._translocoService.translate('collaboration.websocketStatus.notConnected');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/collaboration-dialog/collaboration-dialog.component.ts",
         "line": 668
+      },
+      {
+        "classes": [],
+        "context": "statusText = this.translocoService.translate('collaboration.websocketStatus.notConnected');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.ts",
+        "line": 444
       }
     ]
   },
@@ -15907,14 +16004,164 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
-        "line": 83
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 58
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 501
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.actions' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 612
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 630
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 730
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.actions' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 835
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 853
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 959
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.actions' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1035
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1053
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1184
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.actions' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1240
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1258
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1357
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.actions' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1454
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1472
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1593
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.actions' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1869
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1887
       },
       {
         "classes": [],
         "context": "{{ 'common.actions' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
         "line": 173
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
+        "line": 46
+      },
+      {
+        "classes": [],
+        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 279
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.actions' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/metadata-dialog/metadata-dialog.component.html",
+        "line": 66
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.actions' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.html",
+        "line": 44
+      },
+      {
+        "classes": [],
+        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
+        "line": 211
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
+        "line": 83
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 46
       },
       {
         "classes": [],
@@ -15930,141 +16177,15 @@
       },
       {
         "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 56
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 499
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.actions' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 610
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 628
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 728
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.actions' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 833
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 851
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 957
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.actions' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1033
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1051
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1182
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.actions' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1238
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1256
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1355
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.actions' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1452
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1470
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1591
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.actions' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1867
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1885
-      },
-      {
-        "classes": [],
-        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 279
-      },
-      {
-        "classes": [],
         "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.html",
         "line": 171
       },
       {
         "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
-        "line": 46
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/addons/admin-addons.component.html",
-        "line": 70
+        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
+        "line": 274
       },
       {
         "classes": [],
@@ -16074,21 +16195,9 @@
       },
       {
         "classes": [],
-        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 211
-      },
-      {
-        "classes": [],
         "context": "{{ 'common.actions' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/metadata-dialog/metadata-dialog.component.html",
-        "line": 66
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.actions' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.html",
-        "line": 44
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
+        "line": 115
       },
       {
         "classes": [],
@@ -16117,12 +16226,6 @@
       {
         "classes": [],
         "context": "{{ 'common.actions' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
-        "line": 115
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.actions' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.html",
         "line": 147
       },
@@ -16146,21 +16249,15 @@
       },
       {
         "classes": [],
-        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
-        "line": 274
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/addons/admin-addons.component.html",
+        "line": 70
       },
       {
         "classes": [],
         "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/manage-credentials-dialog/manage-credentials-dialog.component.ts",
         "line": 111
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 46
       }
     ]
   },
@@ -16195,72 +16292,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 23,
+        "context": "{{ 'common.lastUpdated' | transloco }}:",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
+        "line": 8,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.retry' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 42,
+        "context": "<a [routerLink]=\"['/about']\">{{ 'common.about' | transloco }}</a>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
+        "line": 15,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.objectTypes.survey' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 73,
+        "context": "<a [routerLink]=\"['/about']\">{{ 'common.about' | transloco }}</a>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
+        "line": 138,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.status' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 88,
+        "context": "{{ 'common.done' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
+        "line": 145,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.created' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 101,
+        "context": "this.transloco.translate('common.close'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 583,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.lastModified' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 111,
+        "context": "this.transloco.translate('common.close'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 605,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 122,
+        "context": "this.transloco.translate('common.close'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 967,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 136,
+        "context": "this.snackBar.open(message, this.transloco.translate('common.close'), {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 976,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.retry' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
-        "line": 23,
+        "context": "<mat-label [transloco]=\"'common.name'\">Name</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/create-threat-model-dialog/create-threat-model-dialog.component.ts",
+        "line": 39,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.version' | transloco }} {{ survey.version }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
-        "line": 41,
+        "context": "<mat-label [transloco]=\"'common.description'\">Description</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/create-threat-model-dialog/create-threat-model-dialog.component.ts",
+        "line": 54,
         "partial_match": "medium"
       }
     ]
@@ -16327,7 +16424,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'common.addThreat' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1583
+        "line": 1585
       },
       {
         "classes": [],
@@ -16358,79 +16455,79 @@
         "classes": [],
         "context": "<span>{{ 'common.addons' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 69
+        "line": 71
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.addons' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 507
+        "line": 509
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.addons' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 644
+        "line": 646
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.addons' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 736
+        "line": 738
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.addons' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 872
+        "line": 874
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.addons' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 965
+        "line": 967
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.addons' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1072
+        "line": 1074
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.addons' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1190
+        "line": 1192
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.addons' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1276
+        "line": 1278
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.addons' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1363
+        "line": 1365
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.addons' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1491
+        "line": 1493
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.addons' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1599
+        "line": 1601
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.addons' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1906
+        "line": 1908
       },
       {
         "classes": [],
@@ -16459,6 +16556,12 @@
     "uses": [
       {
         "classes": [],
+        "context": "<mat-option [value]=\"null\">{{ 'common.all' | transloco }}</mat-option>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
+        "line": 83
+      },
+      {
+        "classes": [],
         "context": "<mat-option value=\"\">{{ 'common.all' | transloco }}</mat-option>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/audit-trail-page/audit-trail-page.component.html",
         "line": 35
@@ -16468,12 +16571,6 @@
         "context": "<mat-option value=\"\">{{ 'common.all' | transloco }}</mat-option>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/audit-trail-page/audit-trail-page.component.html",
         "line": 46
-      },
-      {
-        "classes": [],
-        "context": "<mat-option [value]=\"null\">{{ 'common.all' | transloco }}</mat-option>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 83
       }
     ]
   },
@@ -16611,6 +16708,18 @@
     "uses": [
       {
         "classes": [],
+        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 127
+      },
+      {
+        "classes": [],
+        "context": "{{ t('common.cancel') }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.html",
+        "line": 80
+      },
+      {
+        "classes": [],
         "context": "{{ 'common.cancel' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/auth/components/login/login.component.html",
         "line": 117
@@ -16623,15 +16732,51 @@
       },
       {
         "classes": [],
+        "context": "/** Cancel button label (translation key, default: 'common.cancel') */",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/confirm-action-dialog/confirm-action-dialog.types.ts",
+        "line": 21
+      },
+      {
+        "classes": [],
         "context": "{{ 'common.cancel' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/auth/components/identity-link-callback/identity-link-callback.component.html",
         "line": 46
       },
       {
         "classes": [],
-        "context": "<button mat-button mat-dialog-close>{{ 'common.cancel' | transloco }}</button>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/auth/components/step-up-mismatch-dialog/step-up-mismatch-dialog.component.html",
-        "line": 6
+        "context": "return this.data.cancelLabel || 'common.cancel';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/confirm-action-dialog/confirm-action-dialog.component.ts",
+        "line": 68
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 239
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
+        "line": 145
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
+        "line": 166
+      },
+      {
+        "classes": [],
+        "context": "expect(component.cancelLabel).toBe('common.cancel');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/confirm-action-dialog/confirm-action-dialog.component.spec.ts",
+        "line": 91
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
+        "line": 237
       },
       {
         "classes": [],
@@ -16641,9 +16786,15 @@
       },
       {
         "classes": [],
-        "context": "<button mat-button mat-dialog-close>{{ 'common.cancel' | transloco }}</button>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/auth/components/step-up-confirm-dialog/step-up-confirm-dialog.component.html",
-        "line": 6
+        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
+        "line": 146
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
+        "line": 167
       },
       {
         "classes": [],
@@ -16653,9 +16804,105 @@
       },
       {
         "classes": [],
+        "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
+        "line": 80
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.cancel' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
+        "line": 82
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
+        "line": 90
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.cancel' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
+        "line": 92
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/responsible-parties-dialog/responsible-parties-dialog.component.ts",
+        "line": 87
+      },
+      {
+        "classes": [],
+        "context": "{{ t('common.cancel') }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/usability-feedback-dialog/usability-feedback-dialog.component.html",
+        "line": 73
+      },
+      {
+        "classes": [],
+        "context": "<button mat-button mat-dialog-close>{{ 'common.cancel' | transloco }}</button>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/auth/components/step-up-mismatch-dialog/step-up-mismatch-dialog.component.html",
+        "line": 6
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
+        "line": 108
+      },
+      {
+        "classes": [],
+        "context": "<button mat-button mat-dialog-close>{{ 'common.cancel' | transloco }}</button>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/auth/components/step-up-confirm-dialog/step-up-confirm-dialog.component.html",
+        "line": 6
+      },
+      {
+        "classes": [],
         "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/create-credential-dialog/create-credential-dialog.component.ts",
         "line": 132
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/user-picker-dialog/user-picker-dialog.component.ts",
+        "line": 143
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/delete-confirmation-dialog/delete-confirmation-dialog.component.html",
+        "line": 88
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.cancel' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/delete-confirmation-dialog/delete-confirmation-dialog.component.html",
+        "line": 90
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/delete-confirmation-dialog/delete-confirmation-dialog.component.html",
+        "line": 98
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.cancel' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/delete-confirmation-dialog/delete-confirmation-dialog.component.html",
+        "line": 100
+      },
+      {
+        "classes": [],
+        "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 201
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/team-members-dialog/team-members-dialog.component.ts",
+        "line": 78
       },
       {
         "classes": [],
@@ -16684,8 +16931,8 @@
       {
         "classes": [],
         "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 127
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/create-threat-model-dialog/create-threat-model-dialog.component.ts",
+        "line": 94
       },
       {
         "classes": [],
@@ -16695,111 +16942,9 @@
       },
       {
         "classes": [],
-        "context": "/** Cancel button label (translation key, default: 'common.cancel') */",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/confirm-action-dialog/confirm-action-dialog.types.ts",
-        "line": 21
-      },
-      {
-        "classes": [],
-        "context": "return this.data.cancelLabel || 'common.cancel';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/confirm-action-dialog/confirm-action-dialog.component.ts",
-        "line": 68
-      },
-      {
-        "classes": [],
-        "context": "expect(component.cancelLabel).toBe('common.cancel');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/confirm-action-dialog/confirm-action-dialog.component.spec.ts",
-        "line": 91
-      },
-      {
-        "classes": [],
         "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/user-picker-dialog/user-picker-dialog.component.ts",
-        "line": 143
-      },
-      {
-        "classes": [],
-        "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
-        "line": 201
-      },
-      {
-        "classes": [],
-        "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 143
-      },
-      {
-        "classes": [],
-        "context": "{{ t('common.cancel') }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/ai-feedback-dialog/ai-feedback-dialog.component.html",
-        "line": 80
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
-        "line": 145
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
-        "line": 166
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
-        "line": 239
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.cancel' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/components/create-survey-dialog/create-survey-dialog.component.ts",
-        "line": 67
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/responsible-parties-dialog/responsible-parties-dialog.component.ts",
-        "line": 87
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
-        "line": 237
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
-        "line": 108
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/revision-notes-dialog/revision-notes-dialog.component.html",
-        "line": 33
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.cancel' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/revision-notes-dialog/revision-notes-dialog.component.html",
-        "line": 36
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 146
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 167
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/shared/create-automation-user-dialog/create-automation-user-dialog.component.ts",
+        "line": 116
       },
       {
         "classes": [],
@@ -16815,177 +16960,9 @@
       },
       {
         "classes": [],
-        "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/delete-confirmation-dialog/delete-confirmation-dialog.component.html",
-        "line": 88
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.cancel' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/delete-confirmation-dialog/delete-confirmation-dialog.component.html",
-        "line": 90
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/delete-confirmation-dialog/delete-confirmation-dialog.component.html",
-        "line": 98
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.cancel' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/delete-confirmation-dialog/delete-confirmation-dialog.component.html",
-        "line": 100
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/create-threat-model-dialog/create-threat-model-dialog.component.ts",
-        "line": 94
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/team-members-dialog/team-members-dialog.component.ts",
-        "line": 78
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/addons/add-addon-dialog/add-addon-dialog.component.ts",
-        "line": 196
-      },
-      {
-        "classes": [],
-        "context": "{{ t('common.cancel') }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/usability-feedback-dialog/usability-feedback-dialog.component.html",
-        "line": 73
-      },
-      {
-        "classes": [],
         "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
-        "line": 133
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
-        "line": 192
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
-        "line": 80
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.cancel' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
-        "line": 82
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
-        "line": 90
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.cancel' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.component.html",
-        "line": 92
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.cancel' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cwe-picker-dialog/cwe-picker-dialog.component.html",
-        "line": 58
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.cancel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
-        "line": 165
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.cancel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
-        "line": 417
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/export-dialog/export-dialog.component.html",
-        "line": 37
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.cancel' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/export-dialog/export-dialog.component.html",
-        "line": 39
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/settings/add-setting-dialog/add-setting-dialog.component.ts",
-        "line": 150
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco)\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
-        "line": 44
-      },
-      {
-        "classes": [],
-        "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
-        "line": 46
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/shared/create-automation-user-dialog/create-automation-user-dialog.component.ts",
-        "line": 116
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
-        "line": 338
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Close</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
-        "line": 340
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/groups/add-group-dialog/add-group-dialog.component.ts",
-        "line": 105
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.cancel' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
-        "line": 117
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/create-diagram-dialog/create-diagram-dialog.component.html",
-        "line": 38
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.cancel' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/create-diagram-dialog/create-diagram-dialog.component.html",
-        "line": 40
+        "line": 189
       },
       {
         "classes": [],
@@ -17001,6 +16978,36 @@
       },
       {
         "classes": [],
+        "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
+        "line": 143
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/addons/add-addon-dialog/add-addon-dialog.component.ts",
+        "line": 196
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.cancel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
+        "line": 165
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.cancel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
+        "line": 417
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.cancel' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/components/create-survey-dialog/create-survey-dialog.component.ts",
+        "line": 67
+      },
+      {
+        "classes": [],
         "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/data-asset-dialog/data-asset-dialog.component.html",
         "line": 22
@@ -17010,6 +17017,60 @@
         "context": "{{ 'common.cancel' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/data-asset-dialog/data-asset-dialog.component.html",
         "line": 24
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.cancel' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cwe-picker-dialog/cwe-picker-dialog.component.html",
+        "line": 58
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/settings/add-setting-dialog/add-setting-dialog.component.ts",
+        "line": 150
+      },
+      {
+        "classes": [],
+        "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
+        "line": 144
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco)\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
+        "line": 44
+      },
+      {
+        "classes": [],
+        "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
+        "line": 46
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/revision-notes-dialog/revision-notes-dialog.component.html",
+        "line": 33
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.cancel' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/revision-notes-dialog/revision-notes-dialog.component.html",
+        "line": 36
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/export-dialog/export-dialog.component.html",
+        "line": 37
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.cancel' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/export-dialog/export-dialog.component.html",
+        "line": 39
       },
       {
         "classes": [],
@@ -17025,9 +17086,45 @@
       },
       {
         "classes": [],
+        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/groups/add-group-dialog/add-group-dialog.component.ts",
+        "line": 105
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
+        "line": 338
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.cancel'\">Close</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
+        "line": 340
+      },
+      {
+        "classes": [],
         "context": "{{ t('common.cancel') }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/framework-mapping-picker-dialog/framework-mapping-picker-dialog.component.html",
         "line": 28
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
+        "line": 192
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.cancel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/create-diagram-dialog/create-diagram-dialog.component.html",
+        "line": 38
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.cancel' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/create-diagram-dialog/create-diagram-dialog.component.html",
+        "line": 40
       },
       {
         "classes": [],
@@ -17043,15 +17140,15 @@
       },
       {
         "classes": [],
-        "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
-        "line": 144
-      },
-      {
-        "classes": [],
         "context": "'common.cancel',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.ts",
         "line": 653
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.cancel' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 117
       }
     ]
   },
@@ -17085,15 +17182,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "transloco.translate('common.classification'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 311
+        "context": "{{ 'common.classification' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 594
       },
       {
         "classes": [],
-        "context": "{{ 'common.classification' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 592
+        "context": "transloco.translate('common.classification'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 311
       }
     ]
   },
@@ -17110,21 +17207,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "[matTooltip]=\"'common.clear' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 51
-      },
-      {
-        "classes": [],
-        "context": "<button mat-icon-button (click)=\"onClearUser()\" [matTooltip]=\"'common.clear' | transloco\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
-        "line": 48
-      },
-      {
-        "classes": [],
         "context": "<button mat-icon-button (click)=\"onClearUser()\" [matTooltip]=\"'common.clear' | transloco\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/user-picker-dialog/user-picker-dialog.component.ts",
         "line": 116
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.clear' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/icon-picker-panel/icon-picker-panel.component.html",
+        "line": 82
       },
       {
         "classes": [],
@@ -17134,9 +17225,15 @@
       },
       {
         "classes": [],
+        "context": "<button mat-icon-button (click)=\"onClearUser()\" [matTooltip]=\"'common.clear' | transloco\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
+        "line": 48
+      },
+      {
+        "classes": [],
         "context": "[matTooltip]=\"'common.clear' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/icon-picker-panel/icon-picker-panel.component.html",
-        "line": 82
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 51
       }
     ]
   },
@@ -17154,8 +17251,20 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.clearSearch' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 61
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 19
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.clearSearch' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 20
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.clearSearch' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.html",
+        "line": 27
       },
       {
         "classes": [],
@@ -17172,20 +17281,8 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.clearSearch' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 19
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.clearSearch' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 20
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.clearSearch' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.html",
-        "line": 27
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
+        "line": 61
       }
     ]
   },
@@ -17259,15 +17356,135 @@
       },
       {
         "classes": [],
-        "context": "[matTooltip]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 93
+        "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 201
+      },
+      {
+        "classes": [],
+        "context": "transloco.translate('common.close'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/clipboard.util.ts",
+        "line": 62
+      },
+      {
+        "classes": [],
+        "context": "expect(snackBar.open).toHaveBeenCalledWith('common.copiedToClipboard', 'common.close', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/clipboard.util.spec.ts",
+        "line": 149
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.close'\">Close</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 256
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.close'\">Close</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
+        "line": 254
+      },
+      {
+        "classes": [],
+        "context": "<button mat-icon-button (click)=\"close()\" [matTooltip]=\"'common.close' | transloco\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-overlay-viewer/mermaid-overlay-viewer.component.html",
+        "line": 39
       },
       {
         "classes": [],
         "context": "{{ 'common.close' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/auth/components/identity-link-callback/identity-link-callback.component.html",
         "line": 21
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 95
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 12
+      },
+      {
+        "classes": [],
+        "context": "this.translocoService.translate('common.close'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.ts",
+        "line": 379
+      },
+      {
+        "classes": [],
+        "context": "this.translocoService.translate('common.close'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.ts",
+        "line": 389
+      },
+      {
+        "classes": [],
+        "context": "this.translocoService.translate('common.close') || 'Close',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.ts",
+        "line": 426
+      },
+      {
+        "classes": [],
+        "context": "this.translocoService.translate('common.close') || 'Close',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.ts",
+        "line": 435
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/help-dialog/help-dialog.component.html",
+        "line": 76
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.close' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/help-dialog/help-dialog.component.html",
+        "line": 78
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
+        "line": 55
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
+        "line": 14
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco)\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
+        "line": 44
+      },
+      {
+        "classes": [],
+        "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
+        "line": 46
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco)\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
+        "line": 175
+      },
+      {
+        "classes": [],
+        "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
+        "line": 177
+      },
+      {
+        "classes": [],
+        "context": "<button mat-icon-button (click)=\"cancel()\" [matTooltip]=\"'common.close' | transloco\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 51
       },
       {
         "classes": [],
@@ -17280,6 +17497,42 @@
         "context": "[attr.aria-label]=\"'common.close' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 65
+      },
+      {
+        "classes": [],
+        "context": "<button mat-icon-button [matTooltip]=\"t('common.close')\" (click)=\"navigateBack()\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.html",
+        "line": 13
+      },
+      {
+        "classes": [],
+        "context": "this.translocoService.translate('common.close'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.ts",
+        "line": 701
+      },
+      {
+        "classes": [],
+        "context": "this.translocoService.translate('common.close'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.ts",
+        "line": 711
+      },
+      {
+        "classes": [],
+        "context": "this.translocoService.translate('common.close') || 'Close',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.ts",
+        "line": 785
+      },
+      {
+        "classes": [],
+        "context": "this.translocoService.translate('common.close') || 'Close',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.ts",
+        "line": 794
+      },
+      {
+        "classes": [],
+        "context": "this.translocoService.translate('common.close'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.ts",
+        "line": 842
       },
       {
         "classes": [],
@@ -17320,14 +17573,26 @@
       {
         "classes": [],
         "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
-        "line": 201
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
+        "line": 144
       },
       {
         "classes": [],
-        "context": "<span [transloco]=\"'common.close'\">Close</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
-        "line": 256
+        "context": "[matTooltip]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/audit-trail-page/audit-trail-page.component.html",
+        "line": 21
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco)\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
+        "line": 291
+      },
+      {
+        "classes": [],
+        "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
+        "line": 293
       },
       {
         "classes": [],
@@ -17337,27 +17602,63 @@
       },
       {
         "classes": [],
-        "context": "<button mat-icon-button (click)=\"close()\" [matTooltip]=\"'common.close' | transloco\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-overlay-viewer/mermaid-overlay-viewer.component.html",
-        "line": 39
+        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.html",
+        "line": 95
       },
       {
         "classes": [],
-        "context": "transloco.translate('common.close'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/clipboard.util.ts",
-        "line": 62
+        "context": "{{ 'common.close' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.html",
+        "line": 97
       },
       {
         "classes": [],
-        "context": "expect(snackBar.open).toHaveBeenCalledWith('common.copiedToClipboard', 'common.close', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/clipboard.util.spec.ts",
-        "line": 149
+        "context": "'common.close',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.ts",
+        "line": 655
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/admin.component.html",
+        "line": 14
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
+        "line": 176
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.close' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
+        "line": 178
+      },
+      {
+        "classes": [],
+        "context": "<button mat-icon-button (click)=\"onClose()\" [attr.aria-label]=\"'common.close' | transloco\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.html",
+        "line": 5
       },
       {
         "classes": [],
         "context": "<button mat-icon-button (click)=\"onClose()\" [matTooltip]=\"'common.close' | transloco\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
         "line": 6
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
+        "line": 234
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.close' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
+        "line": 236
       },
       {
         "classes": [],
@@ -17397,110 +17698,8 @@
       },
       {
         "classes": [],
-        "context": "<span [transloco]=\"'common.close'\">Close</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
-        "line": 254
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/help-dialog/help-dialog.component.html",
-        "line": 76
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.close' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/help-dialog/help-dialog.component.html",
-        "line": 78
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
-        "line": 14
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 12
-      },
-      {
-        "classes": [],
-        "context": "this.translocoService.translate('common.close'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.ts",
-        "line": 379
-      },
-      {
-        "classes": [],
-        "context": "this.translocoService.translate('common.close'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.ts",
-        "line": 389
-      },
-      {
-        "classes": [],
-        "context": "this.translocoService.translate('common.close') || 'Close',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.ts",
-        "line": 426
-      },
-      {
-        "classes": [],
-        "context": "this.translocoService.translate('common.close') || 'Close',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.ts",
-        "line": 435
-      },
-      {
-        "classes": [],
-        "context": "<button mat-icon-button [matTooltip]=\"t('common.close')\" (click)=\"navigateBack()\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/chat/components/chat-page/chat-page.component.html",
-        "line": 13
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
-        "line": 13
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
-        "line": 55
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/admin.component.html",
-        "line": 14
-      },
-      {
-        "classes": [],
         "context": "[matTooltip]=\"'common.close' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 14
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/settings/admin-settings.component.html",
-        "line": 14
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
-        "line": 234
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.close' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/history-dialog/history-dialog.component.html",
-        "line": 236
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
         "line": 14
       },
       {
@@ -17508,180 +17707,6 @@
         "context": "<button mat-icon-button (click)=\"onClose()\" [attr.aria-label]=\"'common.close' | transloco\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/addons/admin-addons.component.html",
         "line": 10
-      },
-      {
-        "classes": [],
-        "context": "<button mat-icon-button (click)=\"onClose()\" [attr.aria-label]=\"'common.close' | transloco\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.html",
-        "line": 5
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
-        "line": 176
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.close' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
-        "line": 178
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/groups/admin-groups.component.html",
-        "line": 12
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.html",
-        "line": 12
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.html",
-        "line": 95
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.close' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.html",
-        "line": 97
-      },
-      {
-        "classes": [],
-        "context": "'common.close',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.ts",
-        "line": 655
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.close'\">Close</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/manage-credentials-dialog/manage-credentials-dialog.component.ts",
-        "line": 143
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco)\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
-        "line": 175
-      },
-      {
-        "classes": [],
-        "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
-        "line": 177
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/components/template-builder/template-builder.component.html",
-        "line": 49
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/collaboration-dialog/collaboration-dialog.component.html",
-        "line": 217
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.close' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/collaboration-dialog/collaboration-dialog.component.html",
-        "line": 219
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.close'\">Close</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/groups/group-members-dialog/group-members-dialog.component.html",
-        "line": 153
-      },
-      {
-        "classes": [],
-        "context": "this.translocoService.translate('common.close'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.ts",
-        "line": 701
-      },
-      {
-        "classes": [],
-        "context": "this.translocoService.translate('common.close'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.ts",
-        "line": 711
-      },
-      {
-        "classes": [],
-        "context": "this.translocoService.translate('common.close') || 'Close',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.ts",
-        "line": 785
-      },
-      {
-        "classes": [],
-        "context": "this.translocoService.translate('common.close') || 'Close',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.ts",
-        "line": 794
-      },
-      {
-        "classes": [],
-        "context": "this.translocoService.translate('common.close'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.ts",
-        "line": 842
-      },
-      {
-        "classes": [],
-        "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
-        "line": 144
-      },
-      {
-        "classes": [],
-        "context": "<button mat-icon-button (click)=\"cancel()\" [matTooltip]=\"'common.close' | transloco\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 51
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/audit-trail-page/audit-trail-page.component.html",
-        "line": 21
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco)\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
-        "line": 291
-      },
-      {
-        "classes": [],
-        "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
-        "line": 293
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco)\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
-        "line": 44
-      },
-      {
-        "classes": [],
-        "context": "{{ isReadOnly ? ('common.close' | transloco) : ('common.cancel' | transloco) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
-        "line": 46
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/clipboard-dialog/clipboard-dialog.component.html",
-        "line": 40
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.close' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/clipboard-dialog/clipboard-dialog.component.html",
-        "line": 42
       },
       {
         "classes": [],
@@ -17710,6 +17735,36 @@
       {
         "classes": [],
         "context": "[attr.aria-label]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.html",
+        "line": 12
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/components/template-builder/template-builder.component.html",
+        "line": 49
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
+        "line": 413
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
+        "line": 13
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.close'\">Close</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/manage-credentials-dialog/manage-credentials-dialog.component.ts",
+        "line": 143
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/data-asset-dialog/data-asset-dialog.component.html",
         "line": 42
       },
@@ -17721,9 +17776,33 @@
       },
       {
         "classes": [],
+        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/collaboration-dialog/collaboration-dialog.component.html",
+        "line": 217
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.close' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/collaboration-dialog/collaboration-dialog.component.html",
+        "line": 219
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/clipboard-dialog/clipboard-dialog.component.html",
+        "line": 40
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.close' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/clipboard-dialog/clipboard-dialog.component.html",
+        "line": 42
+      },
+      {
+        "classes": [],
         "context": "[matTooltip]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
-        "line": 413
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
+        "line": 14
       },
       {
         "classes": [],
@@ -17736,6 +17815,24 @@
         "context": "{{ 'common.close' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/graph-data-dialog/graph-data-dialog.component.html",
         "line": 33
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/settings/admin-settings.component.html",
+        "line": 14
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/groups/admin-groups.component.html",
+        "line": 12
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.close'\">Close</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/groups/group-members-dialog/group-members-dialog.component.html",
+        "line": 153
       }
     ]
   },
@@ -17749,6 +17846,12 @@
       "general"
     ],
     "uses": [
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.confirm'\">Confirm</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/user-picker-dialog/user-picker-dialog.component.ts",
+        "line": 152
+      },
       {
         "classes": [],
         "context": "/** Confirm button label (translation key, default: 'common.confirm') */",
@@ -17766,12 +17869,6 @@
         "context": "expect(component.confirmLabel).toBe('common.confirm');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/confirm-action-dialog/confirm-action-dialog.component.spec.ts",
         "line": 74
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.confirm'\">Confirm</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/user-picker-dialog/user-picker-dialog.component.ts",
-        "line": 152
       }
     ]
   },
@@ -17793,12 +17890,6 @@
       },
       {
         "classes": [],
-        "context": "expect(mockTransloco.translate).toHaveBeenCalledWith('common.confirmDelete', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.spec.ts",
-        "line": 210
-      },
-      {
-        "classes": [],
         "context": "const message = this.translocoService.translate('common.confirmDelete', {",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/components/template-builder/template-builder.component.ts",
         "line": 565
@@ -17808,6 +17899,12 @@
         "context": "expect(mockTransloco.translate).toHaveBeenCalledWith('common.confirmDelete', {",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/components/template-builder/template-builder.component.spec.ts",
         "line": 191
+      },
+      {
+        "classes": [],
+        "context": "expect(mockTransloco.translate).toHaveBeenCalledWith('common.confirmDelete', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.spec.ts",
+        "line": 210
       }
     ]
   },
@@ -17853,27 +17950,27 @@
       },
       {
         "classes": [],
-        "context": "expect(snackBar.open).toHaveBeenCalledWith('common.copiedToClipboard', 'common.close', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/clipboard.util.spec.ts",
-        "line": 149
-      },
-      {
-        "classes": [],
         "context": "this.snackBar.open(this.translocoService.translate('common.copiedToClipboard'), '', {",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-viewer/mermaid-viewer.component.ts",
         "line": 183
       },
       {
         "classes": [],
-        "context": "this.translocoService.translate('common.copiedToClipboard'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.ts",
-        "line": 841
+        "context": "expect(snackBar.open).toHaveBeenCalledWith('common.copiedToClipboard', 'common.close', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/clipboard.util.spec.ts",
+        "line": 149
       },
       {
         "classes": [],
         "context": "this._translocoService.translate('common.copiedToClipboard'),",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 163
+      },
+      {
+        "classes": [],
+        "context": "this.translocoService.translate('common.copiedToClipboard'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.ts",
+        "line": 841
       }
     ]
   },
@@ -17897,8 +17994,8 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.copy' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
-        "line": 187
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
+        "line": 179
       },
       {
         "classes": [],
@@ -17908,15 +18005,15 @@
       },
       {
         "classes": [],
-        "context": "[matTooltip]=\"'common.copy' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
-        "line": 179
-      },
-      {
-        "classes": [],
         "context": "<button mat-icon-button (click)=\"copyVector()\" [matTooltip]=\"'common.copy' | transloco\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
         "line": 83
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.copy' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
+        "line": 187
       }
     ]
   },
@@ -17935,14 +18032,32 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.copyToClipboard' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/credential-secret-dialog/credential-secret-dialog.component.ts",
-        "line": 49
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 419
       },
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.copyToClipboard' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/credential-secret-dialog/credential-secret-dialog.component.ts",
-        "line": 65
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
+        "line": 344
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.copyToClipboard' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-overlay-viewer/mermaid-overlay-viewer.component.html",
+        "line": 35
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.copyToClipboard' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-viewer/mermaid-viewer.component.html",
+        "line": 22
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'common.copyToClipboard' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-viewer/mermaid-viewer.component.html",
+        "line": 66
       },
       {
         "classes": [],
@@ -17977,44 +18092,14 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.copyToClipboard' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 417
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/credential-secret-dialog/credential-secret-dialog.component.ts",
+        "line": 49
       },
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.copyToClipboard' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-viewer/mermaid-viewer.component.html",
-        "line": 22
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ 'common.copyToClipboard' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-viewer/mermaid-viewer.component.html",
-        "line": 66
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.copyToClipboard' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
-        "line": 344
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.copyToClipboard' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-overlay-viewer/mermaid-overlay-viewer.component.html",
-        "line": 35
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.copyToClipboard' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/graph-data-dialog/graph-data-dialog.component.html",
-        "line": 22
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.copyToClipboard' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/graph-data-dialog/graph-data-dialog.component.html",
-        "line": 25
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/credential-secret-dialog/credential-secret-dialog.component.ts",
+        "line": 65
       },
       {
         "classes": [],
@@ -18027,6 +18112,18 @@
         "context": "{{ 'common.copyToClipboard' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/clipboard-dialog/clipboard-dialog.component.html",
         "line": 34
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.copyToClipboard' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/graph-data-dialog/graph-data-dialog.component.html",
+        "line": 22
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.copyToClipboard' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/graph-data-dialog/graph-data-dialog.component.html",
+        "line": 25
       }
     ]
   },
@@ -18067,18 +18164,6 @@
       },
       {
         "classes": [],
-        "context": "mode === 'create' ? ('common.create' | transloco) : ('common.save' | transloco)",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
-        "line": 189
-      },
-      {
-        "classes": [],
-        "context": "{{ mode === 'create' ? ('common.create' | transloco) : ('common.save' | transloco) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
-        "line": 192
-      },
-      {
-        "classes": [],
         "context": "{{ mode === 'create' ? ('common.create' | transloco) : ('common.save' | transloco) }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
         "line": 155
@@ -18094,6 +18179,18 @@
         "context": "{{ mode === 'create' ? ('common.create' | transloco) : ('common.save' | transloco) }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
         "line": 308
+      },
+      {
+        "classes": [],
+        "context": "mode === 'create' ? ('common.create' | transloco) : ('common.save' | transloco)",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
+        "line": 189
+      },
+      {
+        "classes": [],
+        "context": "{{ mode === 'create' ? ('common.create' | transloco) : ('common.save' | transloco) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
+        "line": 192
       }
     ]
   },
@@ -18197,7 +18294,7 @@
         "classes": [],
         "context": "{{ 'common.criticality' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 568
+        "line": 570
       },
       {
         "classes": [],
@@ -18220,8 +18317,8 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.cut' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
-        "line": 113
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
+        "line": 67
       },
       {
         "classes": [],
@@ -18232,8 +18329,8 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.cut' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 67
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 113
       },
       {
         "classes": [],
@@ -18276,24 +18373,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "[matTooltip]=\"'common.delete' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/user-preferences-dialog.component.ts",
-        "line": 512
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ 'common.delete' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.html",
-        "line": 239
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.delete' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/manage-credentials-dialog/manage-credentials-dialog.component.ts",
-        "line": 116
-      },
-      {
-        "classes": [],
         "context": "confirmLabel: 'common.delete',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/confirm-action-dialog/confirm-action-dialog.component.spec.ts",
         "line": 81
@@ -18307,14 +18386,8 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.delete' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 454
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.delete' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 565
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/user-preferences-dialog.component.ts",
+        "line": 512
       },
       {
         "classes": [],
@@ -18325,38 +18398,14 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.delete' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.html",
-        "line": 51
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.delete' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/metadata-dialog/metadata-dialog.component.html",
         "line": 74
       },
       {
         "classes": [],
-        "context": "<span>{{ 'common.delete' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 520
-      },
-      {
-        "classes": [],
         "context": "[matTooltip]=\"'common.delete' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
-        "line": 209
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.delete' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
-        "line": 296
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.delete' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
-        "line": 298
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.html",
+        "line": 51
       },
       {
         "classes": [],
@@ -18380,37 +18429,85 @@
         "classes": [],
         "context": "<span>{{ 'common.delete' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 658
+        "line": 660
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.delete' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 888
+        "line": 890
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.delete' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1093
+        "line": 1095
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.delete' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1290
+        "line": 1292
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.delete' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1515
+        "line": 1517
       },
       {
         "classes": [],
         "context": "<span>{{ 'common.delete' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1920
+        "line": 1922
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.delete' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
+        "line": 209
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'common.delete' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 520
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.delete' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
+        "line": 296
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.delete' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
+        "line": 298
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.delete' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
+        "line": 454
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.delete' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
+        "line": 565
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'common.delete' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.html",
+        "line": 239
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.delete' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/manage-credentials-dialog/manage-credentials-dialog.component.ts",
+        "line": 116
       }
     ]
   },
@@ -18655,9 +18752,21 @@
     "uses": [
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'common.description'\">Description</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/create-threat-model-dialog/create-threat-model-dialog.component.ts",
-        "line": 54
+        "context": "<mat-label>{{ 'common.description' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
+        "line": 110
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.description' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.html",
+        "line": 27
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'common.description' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 39
       },
       {
         "classes": [],
@@ -18667,63 +18776,21 @@
       },
       {
         "classes": [],
-        "context": "<mat-label>{{ 'common.description' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
-        "line": 110
+        "context": "<mat-label [transloco]=\"'common.description'\">Description</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
+        "line": 92
       },
       {
         "classes": [],
         "context": "<mat-label [transloco]=\"'common.description'\">Description</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 125
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.description' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 553
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.description' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 803
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.description' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1003
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.description' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1228
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.description' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1407
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.description' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1833
-      },
-      {
-        "classes": [],
-        "context": "<mat-label [transloco]=\"'common.description'\">Description</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/create-threat-model-dialog/create-threat-model-dialog.component.ts",
         "line": 54
       },
       {
         "classes": [],
-        "context": "{{ 'common.description' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.html",
-        "line": 27
+        "context": "<mat-label [transloco]=\"'common.description'\">Description</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 94
       },
       {
         "classes": [],
@@ -18751,27 +18818,57 @@
       },
       {
         "classes": [],
-        "context": "<mat-label>{{ 'common.description' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
-        "line": 39
+        "context": "<mat-label [transloco]=\"'common.description'\">Description</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
+        "line": 54
       },
       {
         "classes": [],
         "context": "<mat-label [transloco]=\"'common.description'\">Description</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
-        "line": 94
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 127
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'common.description'\">Description</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
-        "line": 92
+        "context": "{{ 'common.description' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 555
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.description' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 805
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.description' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1005
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.description' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1230
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.description' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1409
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.description' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1835
       },
       {
         "classes": [],
         "context": "<mat-label>{{ 'common.description' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
-        "line": 39
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
+        "line": 219
       },
       {
         "classes": [],
@@ -18782,8 +18879,8 @@
       {
         "classes": [],
         "context": "<mat-label>{{ 'common.description' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
-        "line": 219
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
+        "line": 39
       },
       {
         "classes": [],
@@ -18829,24 +18926,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "config.actionLabel || this._transloco.translate('common.dismiss'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.ts",
-        "line": 242
-      },
-      {
-        "classes": [],
-        "context": "'common.dismiss': 'Dismiss',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.spec.ts",
-        "line": 39
-      },
-      {
-        "classes": [],
-        "context": "'common.dismiss': 'Dismiss',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.spec.ts",
-        "line": 151
-      },
-      {
-        "classes": [],
         "context": "this.transloco.translate('common.dismiss'),",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.ts",
         "line": 442
@@ -18856,24 +18935,6 @@
         "context": "this.transloco.translate('common.dismiss'),",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.ts",
         "line": 450
-      },
-      {
-        "classes": [],
-        "context": "this.snackBar.open(message, this.transloco.translate('common.dismiss'), {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.ts",
-        "line": 409
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('common.dismiss'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.ts",
-        "line": 418
-      },
-      {
-        "classes": [],
-        "context": "this.translocoService.translate('common.dismiss'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/components/template-builder/template-builder.component.ts",
-        "line": 583
       },
       {
         "classes": [],
@@ -18895,9 +18956,45 @@
       },
       {
         "classes": [],
+        "context": "this.translocoService.translate('common.dismiss'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/components/template-builder/template-builder.component.ts",
+        "line": 583
+      },
+      {
+        "classes": [],
+        "context": "this.snackBar.open(message, this.transloco.translate('common.dismiss'), {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.ts",
+        "line": 409
+      },
+      {
+        "classes": [],
+        "context": "this.transloco.translate('common.dismiss'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.ts",
+        "line": 418
+      },
+      {
+        "classes": [],
         "context": "this.transloco.translate('common.dismiss'),",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/audit/views/system-audit-view.component.ts",
         "line": 230
+      },
+      {
+        "classes": [],
+        "context": "'common.dismiss': 'Dismiss',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.spec.ts",
+        "line": 39
+      },
+      {
+        "classes": [],
+        "context": "'common.dismiss': 'Dismiss',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.spec.ts",
+        "line": 151
+      },
+      {
+        "classes": [],
+        "context": "config.actionLabel || this._transloco.translate('common.dismiss'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.ts",
+        "line": 242
       }
     ]
   },
@@ -18919,18 +19016,6 @@
       },
       {
         "classes": [],
-        "context": "[transloco]=\"'common.done'\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/credential-secret-dialog/credential-secret-dialog.component.ts",
-        "line": 79
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.done' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
-        "line": 81
-      },
-      {
-        "classes": [],
         "context": "{{ 'common.done' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
         "line": 178
@@ -18940,6 +19025,18 @@
         "context": "[transloco]=\"'common.done'\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
         "line": 280
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.done' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
+        "line": 81
+      },
+      {
+        "classes": [],
+        "context": "[transloco]=\"'common.done'\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/credential-secret-dialog/credential-secret-dialog.component.ts",
+        "line": 79
       }
     ]
   },
@@ -18965,7 +19062,7 @@
         "classes": [],
         "context": "<span>{{ 'common.download' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1264
+        "line": 1266
       }
     ]
   },
@@ -18982,32 +19079,14 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.edit' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 181
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.edit' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 128
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.edit' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
-        "line": 201
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.edit' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
-        "line": 200
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.edit' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
         "line": 178
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.edit' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 181
       },
       {
         "classes": [],
@@ -19024,8 +19103,26 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.edit' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 128
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.edit' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 200
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.edit' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
         "line": 123
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.edit' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
+        "line": 201
       }
     ]
   },
@@ -19164,6 +19261,12 @@
       {
         "classes": [],
         "context": "<span>{{ 'common.exportAsSvg' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-overlay-viewer/mermaid-overlay-viewer.component.html",
+        "line": 48
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'common.exportAsSvg' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-viewer/mermaid-viewer.component.html",
         "line": 39
       },
@@ -19172,12 +19275,6 @@
         "context": "<span>{{ 'common.exportAsSvg' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-viewer/mermaid-viewer.component.html",
         "line": 58
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ 'common.exportAsSvg' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-overlay-viewer/mermaid-overlay-viewer.component.html",
-        "line": 48
       }
     ]
   },
@@ -19230,6 +19327,48 @@
       {
         "classes": [],
         "context": "[attr.aria-label]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
+        "line": 14,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
+        "line": 83,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.copyToClipboard' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
+        "line": 116,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.copyToClipboard' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
+        "line": 117,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.copyToClipboard' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
+        "line": 131,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.copyToClipboard' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
+        "line": 132,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
         "line": 23,
         "partial_match": "medium"
@@ -19253,48 +19392,6 @@
         "context": "{{ 'common.status' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
         "line": 88,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.created' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 101,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.lastModified' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 111,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 122,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 136,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.retry' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
-        "line": 23,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.version' | transloco }} {{ survey.version }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
-        "line": 41,
         "partial_match": "medium"
       }
     ]
@@ -19339,6 +19436,62 @@
     "uses": [
       {
         "classes": [],
+        "context": "<mat-label [transloco]=\"'common.name'\">Name</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 44,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'common.description'\">Description</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 61,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'common.team'\">Team</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 74,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-option>{{ 'common.loading' | transloco }}</mat-option>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 77,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'common.uri'\">URI</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 103,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'common.status'\">Status</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 114,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 127,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.create'\">Create</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 136,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "[attr.aria-label]=\"'common.close' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
         "line": 23,
@@ -19349,62 +19502,6 @@
         "context": "{{ 'common.retry' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
         "line": 42,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.objectTypes.survey' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 73,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.status' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 88,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.created' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 101,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.lastModified' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 111,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 122,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 136,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span class=\"profile-label\" [transloco]=\"'common.name'\">Name</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/user-preferences-dialog.component.ts",
-        "line": 102,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span class=\"profile-label\" [transloco]=\"'common.emailLabel'\">Email</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/user-preferences-dialog.component.ts",
-        "line": 109,
         "partial_match": "medium"
       }
     ]
@@ -19422,20 +19519,14 @@
       {
         "classes": [],
         "context": "{{ 'common.includeInReport' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
-        "line": 132
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.includeInReport' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
         "line": 59
       },
       {
         "classes": [],
         "context": "{{ 'common.includeInReport' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
-        "line": 51
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
+        "line": 132
       },
       {
         "classes": [],
@@ -19454,6 +19545,12 @@
         "context": "{{ 'common.includeInReport' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
         "line": 241
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.includeInReport' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
+        "line": 51
       },
       {
         "classes": [],
@@ -19500,6 +19597,12 @@
       {
         "classes": [],
         "context": "{{ 'common.includeInTimmyChat' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
+        "line": 163
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.includeInTimmyChat' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
         "line": 136
       },
@@ -19508,12 +19611,6 @@
         "context": "{{ 'common.includeInTimmyChat' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
         "line": 60
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.includeInTimmyChat' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
-        "line": 163
       }
     ]
   },
@@ -19537,7 +19634,7 @@
         "classes": [],
         "context": "<mat-label [transloco]=\"'common.issueUri'\">Issue URI</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 323
+        "line": 325
       },
       {
         "classes": [],
@@ -19562,7 +19659,7 @@
         "classes": [],
         "context": ": ('common.issueUriOpenHint' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 348
+        "line": 350
       },
       {
         "classes": [],
@@ -19616,11 +19713,11 @@
       },
       {
         "classes": [
-          "info-label"
+          "date-label"
         ],
-        "context": "<span class=\"info-label\">{{ 'common.lastModified' | transloco }}:</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
-        "line": 72
+        "context": "<span class=\"date-label\">{{ 'common.lastModified' | transloco }}:</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
+        "line": 335
       },
       {
         "classes": [
@@ -19628,7 +19725,7 @@
         ],
         "context": "<span class=\"summary-label\">{{ 'common.lastModified' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 396
+        "line": 398
       },
       {
         "classes": [
@@ -19636,7 +19733,29 @@
         ],
         "context": "<span class=\"info-label\">{{ 'common.lastModified' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 424
+        "line": 426
+      },
+      {
+        "classes": [
+          "info-label"
+        ],
+        "context": "<span class=\"info-label\">{{ 'common.lastModified' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
+        "line": 320
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.lastModified' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.html",
+        "line": 162
+      },
+      {
+        "classes": [
+          "info-label"
+        ],
+        "context": "<span class=\"info-label\">{{ 'common.lastModified' | transloco }}:</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
+        "line": 72
       },
       {
         "classes": [
@@ -19653,28 +19772,6 @@
         "context": "<span class=\"info-label\">{{ 'common.lastModified' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
         "line": 18
-      },
-      {
-        "classes": [
-          "info-label"
-        ],
-        "context": "<span class=\"info-label\">{{ 'common.lastModified' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
-        "line": 320
-      },
-      {
-        "classes": [
-          "date-label"
-        ],
-        "context": "<span class=\"date-label\">{{ 'common.lastModified' | transloco }}:</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 335
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.lastModified' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.html",
-        "line": 162
       }
     ]
   },
@@ -19729,15 +19826,15 @@
       },
       {
         "classes": [],
-        "context": "<mat-option>{{ 'common.loading' | transloco }}</mat-option>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/project-picker/project-picker.component.ts",
-        "line": 46
-      },
-      {
-        "classes": [],
         "context": "<mat-option disabled>{{ 'common.loading' | transloco }}</mat-option>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
         "line": 112
+      },
+      {
+        "classes": [],
+        "context": "<mat-option>{{ 'common.loading' | transloco }}</mat-option>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/project-picker/project-picker.component.ts",
+        "line": 46
       }
     ]
   },
@@ -19838,44 +19935,50 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.manageMetadata' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
+        "line": 302
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.manageMetadata' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 49
+        "line": 51
       },
       {
         "classes": [],
         "context": "? ('common.manageMetadata' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 619
+        "line": 621
       },
       {
         "classes": [],
         "context": "? ('common.manageMetadata' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 842
+        "line": 844
       },
       {
         "classes": [],
         "context": "? ('common.manageMetadata' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1042
+        "line": 1044
       },
       {
         "classes": [],
         "context": "? ('common.manageMetadata' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1247
+        "line": 1249
       },
       {
         "classes": [],
         "context": "? ('common.manageMetadata' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1461
+        "line": 1463
       },
       {
         "classes": [],
         "context": "? ('common.manageMetadata' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1876
+        "line": 1878
       },
       {
         "classes": [],
@@ -19894,12 +19997,6 @@
         "context": "canEdit ? ('common.manageMetadata' | transloco) : ('common.viewMetadata' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 25
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.manageMetadata' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
-        "line": 302
       }
     ]
   },
@@ -20020,13 +20117,13 @@
         "classes": [],
         "context": "{{ 'common.mitigated' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1674
+        "line": 1676
       },
       {
         "classes": [],
         "context": "{{ 'common.mitigated' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1800
+        "line": 1802
       },
       {
         "classes": [],
@@ -20091,6 +20188,12 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.moreActions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 189
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.moreActions' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 144
       },
@@ -20103,20 +20206,14 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.moreActions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 186
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.moreActions' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
         "line": 139
       },
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.moreActions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 189
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 186
       }
     ]
   },
@@ -20140,49 +20237,55 @@
         "classes": [],
         "context": "<mat-label [transloco]=\"'common.name'\">Name</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 103
+        "line": 105
       },
       {
         "classes": [],
         "context": "{{ 'common.name' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 543
+        "line": 545
       },
       {
         "classes": [],
         "context": "{{ 'common.name' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 793
+        "line": 795
       },
       {
         "classes": [],
         "context": "{{ 'common.name' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 993
+        "line": 995
       },
       {
         "classes": [],
         "context": "{{ 'common.name' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1218
+        "line": 1220
       },
       {
         "classes": [],
         "context": "{{ 'common.name' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1397
+        "line": 1399
       },
       {
         "classes": [],
         "context": "{{ 'common.name' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1774
+        "line": 1776
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'common.name'\">Name</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/create-threat-model-dialog/create-threat-model-dialog.component.ts",
-        "line": 39
+        "context": "{{ 'common.name' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 195
+      },
+      {
+        "classes": [],
+        "context": "<th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'common.name' | transloco }}</th>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.html",
+        "line": 101
       },
       {
         "classes": [],
@@ -20192,9 +20295,15 @@
       },
       {
         "classes": [],
-        "context": "{{ 'common.name' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 195
+        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.name' | transloco }}</th>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/manage-credentials-dialog/manage-credentials-dialog.component.ts",
+        "line": 77
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'common.name' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 18
       },
       {
         "classes": [],
@@ -20222,39 +20331,9 @@
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'common.name'\">Name</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
-        "line": 37
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'common.name' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
-        "line": 18
-      },
-      {
-        "classes": [],
-        "context": "<mat-label [transloco]=\"'common.name'\">Name</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
-        "line": 81
-      },
-      {
-        "classes": [],
-        "context": "<th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'common.name' | transloco }}</th>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.html",
-        "line": 101
-      },
-      {
-        "classes": [],
         "context": "<mat-label>{{ 'common.name' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
         "line": 87
-      },
-      {
-        "classes": [],
-        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.name' | transloco }}</th>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/manage-credentials-dialog/manage-credentials-dialog.component.ts",
-        "line": 77
       },
       {
         "classes": [
@@ -20263,6 +20342,24 @@
         "context": "<span class=\"info-label\" [transloco]=\"'common.name'\">Name</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 38
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'common.name'\">Name</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
+        "line": 37
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'common.name'\">Name</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/create-threat-model-dialog/create-threat-model-dialog.component.ts",
+        "line": 39
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'common.name'\">Name</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 81
       }
     ]
   },
@@ -20279,86 +20376,86 @@
       {
         "classes": [],
         "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1989
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 2011
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 2033
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 2055
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 2077
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 2099
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 2121
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 2143
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 2165
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 2187
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 2209
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 2231
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 2253
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
         "line": 265
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1987
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 2009
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 2031
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 2053
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 2075
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 2097
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 2119
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 2141
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 2163
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 2185
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 2207
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 2229
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.noAddonsAvailable'\">No addons available</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 2251
       },
       {
         "classes": [],
@@ -20535,14 +20632,28 @@
       {
         "classes": [],
         "context": "<mat-option [value]=\"null\">{{ 'common.none' | transloco }}</mat-option>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
-        "line": 136
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
+        "line": 95
+      },
+      {
+        "classes": [],
+        "context": "<mat-option value=\"\">{{ 'common.none' | transloco }}</mat-option>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/components/template-builder/template-builder.component.html",
+        "line": 502
       },
       {
         "classes": [],
         "context": "<mat-option [value]=\"null\">{{ 'common.none' | transloco }}</mat-option>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
-        "line": 95
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 136
+      },
+      {
+        "classes": [
+          "muted"
+        ],
+        "context": "<span class=\"muted\" [transloco]=\"'common.none'\">None</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.html",
+        "line": 129
       },
       {
         "classes": [],
@@ -20563,54 +20674,34 @@
         "line": 137
       },
       {
-        "classes": [
-          "muted"
-        ],
-        "context": "<span class=\"muted\" [transloco]=\"'common.none'\">None</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.html",
-        "line": 129
+        "classes": [],
+        "context": "expect(component.getSeverityLabel(null)).toBe('common.none');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.spec.ts",
+        "line": 99
       },
       {
         "classes": [],
-        "context": "<mat-option value=\"\">{{ 'common.none' | transloco }}</mat-option>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/components/template-builder/template-builder.component.html",
-        "line": 502
-      },
-      {
-        "classes": [],
-        "context": "<mat-option [value]=\"null\">{{ 'common.none' | transloco }}</mat-option>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 217
+        "context": "return this.translocoService.translate('common.none');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.ts",
+        "line": 96
       },
       {
         "classes": [],
         "context": "<mat-option [value]=\"null\">{{ 'common.none' | transloco }}</mat-option>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 264
+        "line": 219
+      },
+      {
+        "classes": [],
+        "context": "<mat-option [value]=\"null\">{{ 'common.none' | transloco }}</mat-option>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 266
       },
       {
         "classes": [],
         "context": "{{ 'common.none' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1824
-      },
-      {
-        "classes": [],
-        "context": "<mat-option [value]=\"\">{{ 'common.none' | transloco }}</mat-option>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
-        "line": 59
-      },
-      {
-        "classes": [],
-        "context": "this.severityLabel = 'common.none';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 377
-      },
-      {
-        "classes": [],
-        "context": "this.severityLabel = 'common.none';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 383
+        "line": 1826
       },
       {
         "classes": [],
@@ -20632,21 +20723,27 @@
       },
       {
         "classes": [],
+        "context": "this.severityLabel = 'common.none';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 377
+      },
+      {
+        "classes": [],
+        "context": "this.severityLabel = 'common.none';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 383
+      },
+      {
+        "classes": [],
         "context": "<mat-option [value]=\"null\">{{ 'common.none' | transloco }}</mat-option>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
         "line": 133
       },
       {
         "classes": [],
-        "context": "expect(component.getSeverityLabel(null)).toBe('common.none');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.spec.ts",
-        "line": 99
-      },
-      {
-        "classes": [],
-        "context": "return this.translocoService.translate('common.none');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.ts",
-        "line": 96
+        "context": "<mat-option [value]=\"\">{{ 'common.none' | transloco }}</mat-option>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
+        "line": 59
       }
     ]
   },
@@ -20686,21 +20783,9 @@
       },
       {
         "classes": [],
-        "context": "expect(component.getObjectTypeKey('asset')).toBe('common.objectTypes.asset');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/audit-trail-page/audit-trail-page.component.spec.ts",
-        "line": 420
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'common.objectTypes.asset' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 204
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'common.objectTypes.asset' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
-        "line": 77
+        "context": "objectName: `${this.transloco.translate('common.objectTypes.asset')}: ${asset.name} (${asset.id})`,",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 3050
       },
       {
         "classes": [],
@@ -20710,15 +20795,27 @@
       },
       {
         "classes": [],
-        "context": "'common.objectTypes.asset',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.ts",
-        "line": 648
+        "context": "<mat-label>{{ 'common.objectTypes.asset' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 204
       },
       {
         "classes": [],
-        "context": "objectName: `${this.transloco.translate('common.objectTypes.asset')}: ${asset.name} (${asset.id})`,",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 3044
+        "context": "expect(component.getObjectTypeKey('asset')).toBe('common.objectTypes.asset');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/audit-trail-page/audit-trail-page.component.spec.ts",
+        "line": 420
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'common.objectTypes.asset' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
+        "line": 77
+      },
+      {
+        "classes": [],
+        "context": "'common.objectTypes.asset',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.ts",
+        "line": 648
       }
     ]
   },
@@ -20734,21 +20831,21 @@
     "uses": [
       {
         "classes": [],
+        "context": "{{ threatModel.asset_count }} {{ 'common.objectTypes.assets' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
+        "line": 408
+      },
+      {
+        "classes": [],
         "context": "[transloco]=\"'common.objectTypes.assets'\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 481
+        "line": 483
       },
       {
         "classes": [],
         "context": "cursor = drawSubSectionHeading(ctx, cursor, transloco.translate('common.objectTypes.assets'));",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
         "line": 259
-      },
-      {
-        "classes": [],
-        "context": "{{ threatModel.asset_count }} {{ 'common.objectTypes.assets' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 408
       }
     ]
   },
@@ -20846,48 +20943,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "{{ 'common.lastUpdated' | transloco }}:",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
-        "line": 8,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<a [routerLink]=\"['/about']\">{{ 'common.about' | transloco }}</a>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
-        "line": 14,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<a [routerLink]=\"['/about']\">{{ 'common.about' | transloco }}</a>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
-        "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<a [routerLink]=\"['/about']\">{{ 'common.about' | transloco }}</a>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
-        "line": 68,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<a [routerLink]=\"['/about']\">{{ 'common.about' | transloco }}</a>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
-        "line": 74,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.done' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
-        "line": 81,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "[attr.aria-label]=\"'common.close' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
         "line": 23,
@@ -20912,6 +20967,48 @@
         "context": "{{ 'common.status' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
         "line": 88,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.created' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 101,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.lastModified' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 111,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 122,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 136,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.retry' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
+        "line": 23,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.version' | transloco }} {{ survey.version }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
+        "line": 41,
         "partial_match": "medium"
       }
     ]
@@ -20954,7 +21051,7 @@
         "classes": [],
         "context": "objectName: `${this.transloco.translate('common.objectTypes.diagram')}: ${diagram.name} (${diagram.id})`,",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 2081
+        "line": 2087
       },
       {
         "classes": [],
@@ -20969,18 +21066,18 @@
         "line": 301
       },
       {
+        "classes": [],
+        "context": "expect(component.getObjectTypeKey('diagram')).toBe('common.objectTypes.diagram');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/audit-trail-page/audit-trail-page.component.spec.ts",
+        "line": 412
+      },
+      {
         "classes": [
           "title-prefix"
         ],
         "context": "<span class=\"title-prefix\">{{ 'common.objectTypes.diagram' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
         "line": 22
-      },
-      {
-        "classes": [],
-        "context": "expect(component.getObjectTypeKey('diagram')).toBe('common.objectTypes.diagram');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/audit-trail-page/audit-trail-page.component.spec.ts",
-        "line": 412
       }
     ]
   },
@@ -21014,6 +21111,12 @@
     "uses": [
       {
         "classes": [],
+        "context": "objectName: `${this.transloco.translate('common.objectTypes.document')}: ${document.name} (${document.id})`,",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 1888
+      },
+      {
+        "classes": [],
         "context": "document: 'common.objectTypes.document',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.types.ts",
         "line": 44
@@ -21033,8 +21136,8 @@
       {
         "classes": [],
         "context": "document: 'common.objectTypes.document',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/addons/admin-addons.component.ts",
-        "line": 252
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.ts",
+        "line": 304
       },
       {
         "classes": [],
@@ -21044,15 +21147,9 @@
       },
       {
         "classes": [],
-        "context": "objectName: `${this.transloco.translate('common.objectTypes.document')}: ${document.name} (${document.id})`,",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 1882
-      },
-      {
-        "classes": [],
         "context": "document: 'common.objectTypes.document',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.ts",
-        "line": 304
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/addons/admin-addons.component.ts",
+        "line": 252
       }
     ]
   },
@@ -21074,15 +21171,15 @@
       },
       {
         "classes": [],
-        "context": "[transloco]=\"'common.objectTypes.documents'\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 710
-      },
-      {
-        "classes": [],
         "context": "cursor = drawSubSectionHeading(ctx, cursor, transloco.translate('common.objectTypes.documents'));",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
         "line": 368
+      },
+      {
+        "classes": [],
+        "context": "[transloco]=\"'common.objectTypes.documents'\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 712
       }
     ]
   },
@@ -21139,6 +21236,12 @@
         "line": 253
       },
       {
+        "classes": [],
+        "context": "objectName: `${this.transloco.translate('common.objectTypes.note')}: ${note.name} (${note.id})`,",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 1848
+      },
+      {
         "classes": [
           "title-prefix"
         ],
@@ -21148,21 +21251,15 @@
       },
       {
         "classes": [],
-        "context": "objectName: `${this.transloco.translate('common.objectTypes.note')}: ${note.name} (${note.id})`,",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 1842
+        "context": "note: 'common.objectTypes.note',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.ts",
+        "line": 305
       },
       {
         "classes": [],
         "context": "expect(component.getObjectTypeKey('note')).toBe('common.objectTypes.note');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/audit-trail-page/audit-trail-page.component.spec.ts",
         "line": 428
-      },
-      {
-        "classes": [],
-        "context": "note: 'common.objectTypes.note',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.ts",
-        "line": 305
       }
     ]
   },
@@ -21178,15 +21275,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "[transloco]=\"'common.objectTypes.notes'\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1164
-      },
-      {
-        "classes": [],
         "context": "{{ threatModel.note_count }} {{ 'common.objectTypes.notes' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 430
+      },
+      {
+        "classes": [],
+        "context": "[transloco]=\"'common.objectTypes.notes'\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1166
       },
       {
         "classes": [],
@@ -21310,7 +21407,7 @@
         "classes": [],
         "context": "<span>{{ 'common.objectTypes.report' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 74
+        "line": 76
       }
     ]
   },
@@ -21416,7 +21513,7 @@
         "classes": [],
         "context": "[transloco]=\"'common.objectTypes.repositories'\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 939
+        "line": 941
       }
     ]
   },
@@ -21433,8 +21530,8 @@
       {
         "classes": [],
         "context": "repository: 'common.objectTypes.repository',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.types.ts",
-        "line": 45
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/addons/admin-addons.component.ts",
+        "line": 254
       },
       {
         "classes": [],
@@ -21450,9 +21547,15 @@
       },
       {
         "classes": [],
+        "context": "repository: 'common.objectTypes.repository',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.types.ts",
+        "line": 45
+      },
+      {
+        "classes": [],
         "context": "objectName: `${this.transloco.translate('common.objectTypes.repository')}: ${repository.name} (${repository.id})`,",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 1512
+        "line": 1518
       },
       {
         "classes": [],
@@ -21465,12 +21568,6 @@
         "context": "expect(component.getObjectTypeKey('repository')).toBe('common.objectTypes.repository');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/audit-trail-page/audit-trail-page.component.spec.ts",
         "line": 432
-      },
-      {
-        "classes": [],
-        "context": "repository: 'common.objectTypes.repository',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/addons/admin-addons.component.ts",
-        "line": 254
       }
     ]
   },
@@ -21489,14 +21586,6 @@
         "context": "{{ 'common.objectTypes.survey' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
         "line": 73
-      },
-      {
-        "classes": [
-          "info-label"
-        ],
-        "context": "<span class=\"info-label\">{{ 'common.objectTypes.survey' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
-        "line": 284
       },
       {
         "classes": [],
@@ -21539,6 +21628,14 @@
         "context": "survey: 'common.objectTypes.survey',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.ts",
         "line": 308
+      },
+      {
+        "classes": [
+          "info-label"
+        ],
+        "context": "<span class=\"info-label\">{{ 'common.objectTypes.survey' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
+        "line": 284
       }
     ]
   },
@@ -21572,72 +21669,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 23,
+        "context": "{{ 'common.lastUpdated' | transloco }}:",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
+        "line": 8,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.retry' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 42,
+        "context": "<a [routerLink]=\"['/about']\">{{ 'common.about' | transloco }}</a>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
+        "line": 15,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.objectTypes.survey' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 73,
+        "context": "<a [routerLink]=\"['/about']\">{{ 'common.about' | transloco }}</a>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
+        "line": 138,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.status' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 88,
+        "context": "{{ 'common.done' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/privacy/privacy.component.html",
+        "line": 145,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.created' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 101,
+        "context": "{{ 'common.lastUpdated' | transloco }}:",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
+        "line": 8,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.lastModified' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 111,
+        "context": "<a [routerLink]=\"['/about']\">{{ 'common.about' | transloco }}</a>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
+        "line": 14,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 122,
+        "context": "<a [routerLink]=\"['/about']\">{{ 'common.about' | transloco }}</a>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
+        "line": 49,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 136,
+        "context": "<a [routerLink]=\"['/about']\">{{ 'common.about' | transloco }}</a>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
+        "line": 68,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.retry' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
-        "line": 23,
+        "context": "<a [routerLink]=\"['/about']\">{{ 'common.about' | transloco }}</a>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
+        "line": 74,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.version' | transloco }} {{ survey.version }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
-        "line": 41,
+        "context": "{{ 'common.done' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
+        "line": 81,
         "partial_match": "medium"
       }
     ]
@@ -21654,72 +21751,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 23,
+        "context": "{{ 'common.other' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
+        "line": 114,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.retry' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 42,
+        "context": "{{ 'common.fonts' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
+        "line": 128,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.objectTypes.survey' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 73,
+        "context": "{{ 'common.done' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
+        "line": 178,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.status' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 88,
+        "context": "{ value: 'all', label: this.transloco.translate('common.allStatuses') },",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 149,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.created' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 101,
+        "context": "<mat-label [transloco]=\"'common.name'\">Name</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 44,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.lastModified' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 111,
+        "context": "<mat-label [transloco]=\"'common.description'\">Description</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 61,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 122,
+        "context": "<mat-label [transloco]=\"'common.team'\">Team</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 74,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 136,
+        "context": "<mat-option>{{ 'common.loading' | transloco }}</mat-option>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 77,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.retry' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
-        "line": 23,
+        "context": "<mat-label [transloco]=\"'common.uri'\">URI</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 103,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.version' | transloco }} {{ survey.version }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
-        "line": 41,
+        "context": "<mat-label [transloco]=\"'common.status'\">Status</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 114,
         "partial_match": "medium"
       }
     ]
@@ -21810,16 +21907,16 @@
       },
       {
         "classes": [],
-        "context": "{{ 'common.retry' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
-        "line": 23,
+        "context": "this.transloco.translate('common.close'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 583,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.version' | transloco }} {{ survey.version }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
-        "line": 41,
+        "context": "this.transloco.translate('common.close'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 605,
         "partial_match": "medium"
       }
     ]
@@ -21855,14 +21952,14 @@
       {
         "classes": [],
         "context": "threat: 'common.objectTypes.threat',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.ts",
-        "line": 303
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/addons/admin-addons.component.ts",
+        "line": 251
       },
       {
         "classes": [],
         "context": "objectName: `${this.transloco.translate('common.objectTypes.threat')}: ${threat.name} (${threat.id})`,",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 2122
+        "line": 2128
       },
       {
         "classes": [
@@ -21874,15 +21971,15 @@
       },
       {
         "classes": [],
-        "context": "expect(component.getObjectTypeKey('threat')).toBe('common.objectTypes.threat');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/audit-trail-page/audit-trail-page.component.spec.ts",
-        "line": 416
+        "context": "threat: 'common.objectTypes.threat',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.ts",
+        "line": 303
       },
       {
         "classes": [],
-        "context": "threat: 'common.objectTypes.threat',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/addons/admin-addons.component.ts",
-        "line": 251
+        "context": "expect(component.getObjectTypeKey('threat')).toBe('common.objectTypes.threat');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/audit-trail-page/audit-trail-page.component.spec.ts",
+        "line": 416
       }
     ]
   },
@@ -21897,6 +21994,14 @@
     ],
     "uses": [
       {
+        "classes": [
+          "info-label"
+        ],
+        "context": "<span class=\"info-label\">{{ 'common.objectTypes.threatModel' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
+        "line": 328
+      },
+      {
         "classes": [],
         "context": "threat_model: 'common.objectTypes.threatModel',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/rollback-confirmation-dialog/rollback-confirmation-dialog.types.ts",
@@ -21904,9 +22009,9 @@
       },
       {
         "classes": [],
-        "context": "threatModel: 'common.objectTypes.threatModel',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/delete-confirmation-dialog/delete-confirmation-dialog.types.ts",
-        "line": 67
+        "context": "threat_model: 'common.objectTypes.threatModel',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/addons/admin-addons.component.ts",
+        "line": 248
       },
       {
         "classes": [],
@@ -21916,9 +22021,29 @@
       },
       {
         "classes": [],
+        "context": "threatModel: 'common.objectTypes.threatModel',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/delete-confirmation-dialog/delete-confirmation-dialog.types.ts",
+        "line": 67
+      },
+      {
+        "classes": [
+          "title-prefix"
+        ],
+        "context": "<span class=\"title-prefix\">{{ 'common.objectTypes.threatModel' | transloco }}:</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
+        "line": 17
+      },
+      {
+        "classes": [],
+        "context": "expect(component.getObjectTypeKey('threat_model')).toBe('common.objectTypes.threatModel');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/audit-trail-page/audit-trail-page.component.spec.ts",
+        "line": 408
+      },
+      {
+        "classes": [],
         "context": "objectName: `${this.transloco.translate('common.objectTypes.threatModel')}: ${this.threatModel.name} (${this.threatModel.id})`,",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 2035
+        "line": 2041
       },
       {
         "classes": [
@@ -21933,34 +22058,6 @@
         "context": "threat_model: 'common.objectTypes.threatModel',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.ts",
         "line": 300
-      },
-      {
-        "classes": [],
-        "context": "threat_model: 'common.objectTypes.threatModel',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/addons/admin-addons.component.ts",
-        "line": 248
-      },
-      {
-        "classes": [],
-        "context": "expect(component.getObjectTypeKey('threat_model')).toBe('common.objectTypes.threatModel');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/audit-trail-page/audit-trail-page.component.spec.ts",
-        "line": 408
-      },
-      {
-        "classes": [
-          "title-prefix"
-        ],
-        "context": "<span class=\"title-prefix\">{{ 'common.objectTypes.threatModel' | transloco }}:</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
-        "line": 17
-      },
-      {
-        "classes": [
-          "info-label"
-        ],
-        "context": "<span class=\"info-label\">{{ 'common.objectTypes.threatModel' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
-        "line": 328
       }
     ]
   },
@@ -21976,72 +22073,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "{ value: 'all', label: this.transloco.translate('common.allStatuses') },",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
-        "line": 149,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'common.search' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 5,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.clearSearch' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 19,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.clearSearch' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 20,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'common.status' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 29,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<h2>{{ 'common.error' | transloco }}</h2>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 170,
+        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 23,
         "partial_match": "medium"
       },
       {
         "classes": [],
         "context": "{{ 'common.retry' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 173,
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 42,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'common.name' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 195,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.owner' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 205,
+        "context": "{{ 'common.objectTypes.survey' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 73,
         "partial_match": "medium"
       },
       {
         "classes": [],
         "context": "{{ 'common.status' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 215,
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 88,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.created' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 101,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.lastModified' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 111,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 122,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 136,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.retry' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
+        "line": 23,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.version' | transloco }} {{ survey.version }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
+        "line": 41,
         "partial_match": "medium"
       }
     ]
@@ -22067,7 +22164,13 @@
         "classes": [],
         "context": "[transloco]=\"'common.objectTypes.threats'\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1573
+        "line": 1575
+      },
+      {
+        "classes": [],
+        "context": "cursor = drawSubSectionHeading(ctx, cursor, transloco.translate('common.objectTypes.threats'));",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 683
       },
       {
         "classes": [],
@@ -22080,12 +22183,6 @@
         "context": "Add {{ 'common.objectTypes.threats' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.html",
         "line": 87
-      },
-      {
-        "classes": [],
-        "context": "cursor = drawSubSectionHeading(ctx, cursor, transloco.translate('common.objectTypes.threats'));",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 683
       }
     ]
   },
@@ -22101,6 +22198,18 @@
     "uses": [
       {
         "classes": [],
+        "context": "[attr.aria-label]=\"'common.ok' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/validation-error-dialog/validation-error-dialog.component.html",
+        "line": 13
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.ok' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/validation-error-dialog/validation-error-dialog.component.html",
+        "line": 15
+      },
+      {
+        "classes": [],
         "context": "{{ 'common.ok' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/auth/components/unauthorized/unauthorized.component.html",
         "line": 24
@@ -22110,6 +22219,12 @@
         "context": "[transloco]=\"'common.ok'\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/hmac-secret-dialog/hmac-secret-dialog.component.html",
         "line": 24
+      },
+      {
+        "classes": [],
+        "context": "{{ t('common.ok') }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/framework-mapping-picker-dialog/framework-mapping-picker-dialog.component.html",
+        "line": 37
       },
       {
         "classes": [],
@@ -22128,24 +22243,6 @@
         "context": "<span [transloco]=\"'common.ok'\">OK</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 204
-      },
-      {
-        "classes": [],
-        "context": "{{ t('common.ok') }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/framework-mapping-picker-dialog/framework-mapping-picker-dialog.component.html",
-        "line": 37
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.ok' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/validation-error-dialog/validation-error-dialog.component.html",
-        "line": 13
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.ok' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/validation-error-dialog/validation-error-dialog.component.html",
-        "line": 15
       }
     ]
   },
@@ -22163,7 +22260,7 @@
         "classes": [],
         "context": "[attr.aria-label]=\"'common.openInNewTab' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 352
+        "line": 354
       },
       {
         "classes": [],
@@ -22210,14 +22307,14 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.paste' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
-        "line": 131
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
+        "line": 85
       },
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.paste' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 85
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 131
       },
       {
         "classes": [],
@@ -22247,7 +22344,7 @@
         "classes": [],
         "context": "<span>{{ 'common.permissions' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 86
+        "line": 88
       },
       {
         "classes": [],
@@ -22269,15 +22366,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "<mat-label>{{ 'common.priority' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 274
-      },
-      {
-        "classes": [],
         "context": "label: transloco.translate('common.priority'),",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
         "line": 605
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'common.priority' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 274
       }
     ]
   },
@@ -22295,17 +22392,17 @@
         "classes": [
           "info-label"
         ],
-        "context": "<span class=\"info-label\">{{ 'common.project' | transloco }}:</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 152
+        "context": "<span class=\"info-label\">{{ 'common.project' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/response-detail/response-detail.component.html",
+        "line": 90
       },
       {
         "classes": [
           "info-label"
         ],
-        "context": "<span class=\"info-label\">{{ 'common.project' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/response-detail/response-detail.component.html",
-        "line": 90
+        "context": "<span class=\"info-label\">{{ 'common.project' | transloco }}:</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 154
       }
     ]
   },
@@ -22319,55 +22416,6 @@
       "general"
     ],
     "uses": [
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
-        "line": 14,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
-        "line": 83,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.copyToClipboard' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
-        "line": 116,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.copyToClipboard' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
-        "line": 117,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.copyToClipboard' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
-        "line": 131,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.copyToClipboard' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
-        "line": 132,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'common.cancel'\">Cancel</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/add-webhook-dialog/add-webhook-dialog.component.ts",
-        "line": 153,
-        "partial_match": "medium"
-      },
       {
         "classes": [],
         "context": "[attr.aria-label]=\"'common.close' | transloco\"",
@@ -22387,6 +22435,55 @@
         "context": "{{ 'common.objectTypes.survey' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
         "line": 73,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.status' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 88,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.created' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 101,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.lastModified' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 111,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 122,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.actions' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 136,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.retry' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
+        "line": 23,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.version' | transloco }} {{ survey.version }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
+        "line": 41,
         "partial_match": "medium"
       }
     ]
@@ -22418,24 +22515,6 @@
       {
         "classes": [],
         "context": "[attr.aria-label]=\"'common.readOnly' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 8
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.readOnly' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
-        "line": 10
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.readOnly' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
-        "line": 16
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.readOnly' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/metadata-dialog/metadata-dialog.component.html",
         "line": 11
       },
@@ -22448,8 +22527,14 @@
       {
         "classes": [],
         "context": "[attr.aria-label]=\"'common.readOnly' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
-        "line": 84
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
+        "line": 12
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.readOnly' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
+        "line": 8
       },
       {
         "classes": [],
@@ -22460,8 +22545,20 @@
       {
         "classes": [],
         "context": "[attr.aria-label]=\"'common.readOnly' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
-        "line": 12
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
+        "line": 84
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.readOnly' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
+        "line": 16
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.readOnly' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
+        "line": 10
       }
     ]
   },
@@ -22484,8 +22581,8 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.readOnlyTooltip' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
-        "line": 9
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 15
       },
       {
         "classes": [],
@@ -22496,13 +22593,31 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.readOnlyTooltip' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 15
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
+        "line": 9
       },
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.readOnlyTooltip' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
+        "line": 12
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.readOnlyTooltip' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/metadata-dialog/metadata-dialog.component.html",
+        "line": 10
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.readOnlyTooltip' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
+        "line": 13
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'common.readOnlyTooltip' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 12
       },
       {
@@ -22514,38 +22629,20 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.readOnlyTooltip' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
-        "line": 13
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.readOnlyTooltip' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
         "line": 13
       },
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.readOnlyTooltip' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/metadata-dialog/metadata-dialog.component.html",
-        "line": 10
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.readOnlyTooltip' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 12
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
+        "line": 83
       },
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.readOnlyTooltip' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
         "line": 11
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.readOnlyTooltip' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
-        "line": 83
       }
     ]
   },
@@ -22570,14 +22667,14 @@
       {
         "classes": [],
         "context": "{{ 'common.retry' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 173
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
+        "line": 23
       },
       {
         "classes": [],
         "context": "{{ 'common.retry' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
-        "line": 23
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 173
       },
       {
         "classes": [],
@@ -22590,12 +22687,6 @@
         "context": "{{ 'common.retry' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.html",
         "line": 71
-      },
-      {
-        "classes": [],
-        "context": "'common.retry': 'Retry',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.spec.ts",
-        "line": 40
       },
       {
         "classes": [],
@@ -22620,6 +22711,12 @@
         "context": "actionLabel = this._transloco.translate('common.retry');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.ts",
         "line": 375
+      },
+      {
+        "classes": [],
+        "context": "'common.retry': 'Retry',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.spec.ts",
+        "line": 40
       }
     ]
   },
@@ -22683,15 +22780,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "'common.roles.writer' | transloco",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
-        "line": 257
-      },
-      {
-        "classes": [],
         "context": "? ('common.roles.writer' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/collaboration-dialog/collaboration-dialog.component.html",
         "line": 47
+      },
+      {
+        "classes": [],
+        "context": "'common.roles.writer' | transloco",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
+        "line": 257
       }
     ]
   },
@@ -22709,8 +22806,8 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.save' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/components/template-builder/template-builder.component.html",
-        "line": 36
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-overlay-viewer/mermaid-overlay-viewer.component.html",
+        "line": 28
       },
       {
         "classes": [],
@@ -22726,15 +22823,9 @@
       },
       {
         "classes": [],
-        "context": "<span [transloco]=\"'common.save'\">Save</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/responsible-parties-dialog/responsible-parties-dialog.component.ts",
-        "line": 100
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.save' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-overlay-viewer/mermaid-overlay-viewer.component.html",
-        "line": 28
+        "context": "<button mat-icon-button [matMenuTriggerFor]=\"saveMenu\" [matTooltip]=\"'common.save' | transloco\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-viewer/mermaid-viewer.component.html",
+        "line": 16
       },
       {
         "classes": [],
@@ -22744,21 +22835,39 @@
       },
       {
         "classes": [],
+        "context": "<span [transloco]=\"'common.save'\">Save</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/responsible-parties-dialog/responsible-parties-dialog.component.ts",
+        "line": 100
+      },
+      {
+        "classes": [],
         "context": "{{ 'common.save' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
         "line": 145
       },
       {
         "classes": [],
-        "context": "<button mat-icon-button [matMenuTriggerFor]=\"saveMenu\" [matTooltip]=\"'common.save' | transloco\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-viewer/mermaid-viewer.component.html",
-        "line": 16
+        "context": "[matTooltip]=\"'common.save' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
+        "line": 385
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.save' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/data-asset-dialog/data-asset-dialog.component.html",
+        "line": 31
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.save' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/data-asset-dialog/data-asset-dialog.component.html",
+        "line": 33
       },
       {
         "classes": [],
         "context": "<span [transloco]=\"'common.save'\">Save</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/add-quota-dialog/add-quota-dialog.component.html",
-        "line": 146
+        "line": 202
       },
       {
         "classes": [],
@@ -22780,15 +22889,15 @@
       },
       {
         "classes": [],
-        "context": "[attr.aria-label]=\"'common.save' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
-        "line": 350
+        "context": "[matTooltip]=\"'common.save' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/components/template-builder/template-builder.component.html",
+        "line": 36
       },
       {
         "classes": [],
-        "context": "<span [transloco]=\"'common.save'\">Save</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
-        "line": 352
+        "context": "[matTooltip]=\"'common.save' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
+        "line": 37
       },
       {
         "classes": [],
@@ -22799,62 +22908,8 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'common.save' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
-        "line": 37
-      },
-      {
-        "classes": [],
-        "context": "{{ (isEditMode ? 'common.save' : 'cvssCalculator.apply') | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
-        "line": 127
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.save' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/metadata-dialog/metadata-dialog.component.html",
-        "line": 124
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.save' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/metadata-dialog/metadata-dialog.component.html",
-        "line": 126
-      },
-      {
-        "classes": [],
-        "context": "mode === 'create' ? ('common.create' | transloco) : ('common.save' | transloco)",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
-        "line": 305
-      },
-      {
-        "classes": [],
-        "context": "{{ mode === 'create' ? ('common.create' | transloco) : ('common.save' | transloco) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
-        "line": 308
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.save' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/data-asset-dialog/data-asset-dialog.component.html",
-        "line": 31
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.save' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/data-asset-dialog/data-asset-dialog.component.html",
-        "line": 33
-      },
-      {
-        "classes": [],
-        "context": "mode === 'create' ? ('common.create' | transloco) : ('common.save' | transloco)",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
-        "line": 189
-      },
-      {
-        "classes": [],
-        "context": "{{ mode === 'create' ? ('common.create' | transloco) : ('common.save' | transloco) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
-        "line": 192
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 36
       },
       {
         "classes": [],
@@ -22870,9 +22925,15 @@
       },
       {
         "classes": [],
-        "context": "[matTooltip]=\"'common.save' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/dfd.component.html",
-        "line": 385
+        "context": "[attr.aria-label]=\"'common.save' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/metadata-dialog/metadata-dialog.component.html",
+        "line": 124
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.save' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/metadata-dialog/metadata-dialog.component.html",
+        "line": 126
       },
       {
         "classes": [],
@@ -22882,9 +22943,45 @@
       },
       {
         "classes": [],
-        "context": "[matTooltip]=\"'common.save' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 36
+        "context": "[attr.aria-label]=\"'common.save' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
+        "line": 350
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'common.save'\">Save</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
+        "line": 352
+      },
+      {
+        "classes": [],
+        "context": "mode === 'create' ? ('common.create' | transloco) : ('common.save' | transloco)",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
+        "line": 305
+      },
+      {
+        "classes": [],
+        "context": "{{ mode === 'create' ? ('common.create' | transloco) : ('common.save' | transloco) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
+        "line": 308
+      },
+      {
+        "classes": [],
+        "context": "mode === 'create' ? ('common.create' | transloco) : ('common.save' | transloco)",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
+        "line": 189
+      },
+      {
+        "classes": [],
+        "context": "{{ mode === 'create' ? ('common.create' | transloco) : ('common.save' | transloco) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
+        "line": 192
+      },
+      {
+        "classes": [],
+        "context": "{{ (isEditMode ? 'common.save' : 'cvssCalculator.apply') | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 127
       }
     ]
   },
@@ -22973,18 +23070,18 @@
         "line": 593
       },
       {
-        "classes": [],
-        "context": "<mat-label>{{ 'common.score' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 261
-      },
-      {
         "classes": [
           "score-label"
         ],
         "context": "<span class=\"score-label\"> {{ 'common.score' | transloco }}: </span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
         "line": 89
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'common.score' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 261
       }
     ]
   },
@@ -23108,7 +23205,7 @@
         "classes": [],
         "context": "{{ 'common.sensitivity' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 578
+        "line": 580
       },
       {
         "classes": [],
@@ -23184,21 +23281,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "label: transloco.translate('common.severity'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 587
-      },
-      {
-        "classes": [],
         "context": "<mat-label>{{ 'common.severity' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1630
+        "line": 1632
       },
       {
         "classes": [],
         "context": "{{ 'common.severity' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1812
+        "line": 1814
       },
       {
         "classes": [],
@@ -23214,15 +23305,21 @@
       },
       {
         "classes": [],
+        "context": "'common.severity',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.ts",
+        "line": 651
+      },
+      {
+        "classes": [],
         "context": "<mat-label>{{ 'common.severity' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
         "line": 127
       },
       {
         "classes": [],
-        "context": "'common.severity',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.ts",
-        "line": 651
+        "context": "label: transloco.translate('common.severity'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 587
       }
     ]
   },
@@ -23252,6 +23349,12 @@
       },
       {
         "classes": [],
+        "context": "<mat-label [transloco]=\"'common.status'\">Status</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 114
+      },
+      {
+        "classes": [],
         "context": "<mat-label>{{ 'common.status' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 95
@@ -23266,70 +23369,6 @@
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'common.status'\">Status</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 114
-      },
-      {
-        "classes": [],
-        "context": "<mat-label [transloco]=\"'common.status'\">Status</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
-        "line": 134
-      },
-      {
-        "classes": [],
-        "context": "<mat-label [transloco]=\"'common.status'\">Status</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
-        "line": 130
-      },
-      {
-        "classes": [
-          "summary-label"
-        ],
-        "context": "<span class=\"summary-label\">{{ 'common.status' | transloco }}:</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 171
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'common.status' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 215
-      },
-      {
-        "classes": [
-          "info-label"
-        ],
-        "context": "<span class=\"info-label\">{{ 'common.status' | transloco }}:</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 230
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'common.status' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1645
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.status' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1784
-      },
-      {
-        "classes": [],
-        "context": "<mat-label [transloco]=\"'common.status'\">Status</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
-        "line": 93
-      },
-      {
-        "classes": [],
-        "context": "label: transloco.translate('common.status'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 599
-      },
-      {
-        "classes": [],
         "context": "<mat-label>{{ 'common.status' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
         "line": 29
@@ -23341,12 +23380,30 @@
         "line": 215
       },
       {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'common.status'\">Status</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 134
+      },
+      {
         "classes": [
           "info-label"
         ],
         "context": "<span class=\"info-label\">{{ 'common.status' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
         "line": 259
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'common.status'\">Status</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
+        "line": 130
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'common.status'\">Status</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
+        "line": 93
       },
       {
         "classes": [],
@@ -23359,6 +23416,40 @@
         "context": "{{ 'common.status' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
         "line": 200
+      },
+      {
+        "classes": [
+          "summary-label"
+        ],
+        "context": "<span class=\"summary-label\">{{ 'common.status' | transloco }}:</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 173
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'common.status' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 217
+      },
+      {
+        "classes": [
+          "info-label"
+        ],
+        "context": "<span class=\"info-label\">{{ 'common.status' | transloco }}:</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 232
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'common.status' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1647
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.status' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1786
       },
       {
         "classes": [],
@@ -23377,6 +23468,12 @@
         "context": "<mat-label>{{ 'common.status' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 129
+      },
+      {
+        "classes": [],
+        "context": "label: transloco.translate('common.status'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 599
       }
     ]
   },
@@ -23477,12 +23574,6 @@
       {
         "classes": [],
         "context": "<mat-label>{{ 'common.threatDescription' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 220
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'common.threatDescription' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
         "line": 90
       },
@@ -23491,6 +23582,12 @@
         "context": "'common.threatDescription',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.ts",
         "line": 649
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'common.threatDescription' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 220
       }
     ]
   },
@@ -23567,12 +23664,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "label: transloco.translate('common.threatType'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 611
-      },
-      {
-        "classes": [],
         "context": "<mat-label>{{ 'common.threatType' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
         "line": 110
@@ -23582,6 +23673,12 @@
         "context": "'common.threatType',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.ts",
         "line": 650
+      },
+      {
+        "classes": [],
+        "context": "label: transloco.translate('common.threatType'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 611
       }
     ]
   },
@@ -23656,18 +23753,18 @@
     ],
     "uses": [
       {
+        "classes": [],
+        "context": "{{ 'common.type' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
+        "line": 112
+      },
+      {
         "classes": [
           "info-label"
         ],
         "context": "<span class=\"info-label\" [transloco]=\"'common.type'\">Type</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/invoke-addon-dialog/invoke-addon-dialog.component.html",
         "line": 26
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.type' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/permissions-dialog/permissions-dialog.component.ts",
-        "line": 112
       }
     ]
   },
@@ -23701,15 +23798,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "this.translocoService.translate('common.unsavedChangesWarning') ||",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.ts",
-        "line": 341
-      },
-      {
-        "classes": [],
         "context": "const confirmed = confirm(this.translocoService.translate('common.unsavedChangesWarning'));",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.ts",
         "line": 283
+      },
+      {
+        "classes": [],
+        "context": "this.translocoService.translate('common.unsavedChangesWarning') ||",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.ts",
+        "line": 341
       },
       {
         "classes": [],
@@ -23782,7 +23879,7 @@
         "classes": [],
         "context": "{{ 'common.validation.invalidUrl' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 335
+        "line": 337
       }
     ]
   },
@@ -23800,15 +23897,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "{{ 'common.validation.maxLength' | transloco: { max: maxNameLength } }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 32
+        "context": "'common.validation.maxLength' | transloco: { max: 256 }",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
+        "line": 86
       },
       {
         "classes": [],
-        "context": "{{ 'common.validation.maxLength' | transloco: { max: maxContentLength } }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 124
+        "context": "'common.validation.maxLength' | transloco: { max: 2048 }",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
+        "line": 101
       },
       {
         "classes": [],
@@ -23821,18 +23918,6 @@
         "context": "'common.validation.maxLength' | transloco: { max: 2048 }",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
         "line": 103
-      },
-      {
-        "classes": [],
-        "context": "'common.validation.maxLength' | transloco: { max: 256 }",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
-        "line": 86
-      },
-      {
-        "classes": [],
-        "context": "'common.validation.maxLength' | transloco: { max: 2048 }",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
-        "line": 101
       },
       {
         "classes": [],
@@ -23854,6 +23939,18 @@
       },
       {
         "classes": [],
+        "context": "{{ 'common.validation.maxLength' | transloco: { max: 100 } }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 121
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.maxLength' | transloco: { max: 500 } }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 139
+      },
+      {
+        "classes": [],
         "context": "{{ 'common.validation.maxLength' | transloco: { max: maxNameLength } }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
         "line": 101
@@ -23872,15 +23969,45 @@
       },
       {
         "classes": [],
-        "context": "{{ 'common.validation.maxLength' | transloco: { max: 100 } }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 119
+        "context": "{{ 'common.validation.maxLength' | transloco: { max: maxNameLength } }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
+        "line": 32
       },
       {
         "classes": [],
-        "context": "{{ 'common.validation.maxLength' | transloco: { max: 500 } }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 137
+        "context": "{{ 'common.validation.maxLength' | transloco: { max: maxContentLength } }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
+        "line": 124
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.maxLength' | transloco: { max: 100 } }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
+        "line": 32
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.maxLength' | transloco: { max: 256 } }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
+        "line": 74
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.maxLength' | transloco: { max: 1024 } }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
+        "line": 105
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.maxLength' | transloco: { max: 2048 } }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
+        "line": 230
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.maxLength' | transloco: { max: 100 } }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/create-diagram-dialog/create-diagram-dialog.component.html",
+        "line": 26
       },
       {
         "classes": [],
@@ -23911,30 +24038,6 @@
         "context": "{{ 'common.validation.maxLength' | transloco: { max: 500 } }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
         "line": 101
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.maxLength' | transloco: { max: 256 } }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
-        "line": 74
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.maxLength' | transloco: { max: 1024 } }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
-        "line": 105
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.maxLength' | transloco: { max: 2048 } }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
-        "line": 230
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.maxLength' | transloco: { max: 100 } }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
-        "line": 32
       },
       {
         "classes": [],
@@ -23989,17 +24092,266 @@
         "context": "{{ 'common.validation.maxLength' | transloco: { max: 256 } }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
         "line": 121
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.maxLength' | transloco: { max: 100 } }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/create-diagram-dialog/create-diagram-dialog.component.html",
-        "line": 26
       }
     ]
   },
   "common.validation.nameRequired": {
     "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "{{ 'common.other' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
+        "line": 114,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.fonts' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
+        "line": 128,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.done' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.html",
+        "line": 178,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{ value: 'all', label: this.transloco.translate('common.allStatuses') },",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 149,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 23,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.retry' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 42,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.objectTypes.survey' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 73,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.status' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 88,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.created' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 101,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.lastModified' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 111,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "common.validation.required": {
+    "ambiguous_word": false,
+    "confidence": "high",
+    "ellipsis_candidate": false,
+    "found_by": "fully-qualified",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "error",
+      "label",
+      "placeholder"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "<mat-error>{{ 'common.validation.required' | transloco }}</mat-error>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 84
+      },
+      {
+        "classes": [],
+        "context": "<mat-error>{{ 'common.validation.required' | transloco }}</mat-error>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 119
+      },
+      {
+        "classes": [],
+        "context": "<mat-error>{{ 'common.validation.required' | transloco }}</mat-error>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
+        "line": 82
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 26
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 176
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
+        "line": 27
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
+        "line": 119
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 115
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 384
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
+        "line": 96
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
+        "line": 223
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
+        "line": 28
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
+        "line": 69
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
+        "line": 100
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 190
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/create-diagram-dialog/create-diagram-dialog.component.html",
+        "line": 20
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
+        "line": 26
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
+        "line": 27
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
+        "line": 65
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
+        "line": 87
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.validation.required' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
+        "line": 62
+      }
+    ]
+  },
+  "common.version": {
+    "ambiguous_word": false,
+    "confidence": "high",
+    "ellipsis_candidate": false,
+    "found_by": "fully-qualified",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "description",
+      "page-title"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "{{ 'common.version' | transloco }} {{ survey.version }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
+        "line": 41
+      },
+      {
+        "classes": [],
+        "context": "{{ 'common.version' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.html",
+        "line": 139
+      },
+      {
+        "classes": [
+          "info-label"
+        ],
+        "context": "<span class=\"info-label\">{{ 'common.version' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
+        "line": 290
+      }
+    ]
+  },
+  "common.view": {
+    "ambiguous_word": true,
     "confidence": "medium",
     "ellipsis_candidate": false,
     "found_by": "leaf",
@@ -24080,261 +24432,6 @@
       }
     ]
   },
-  "common.validation.required": {
-    "ambiguous_word": false,
-    "confidence": "high",
-    "ellipsis_candidate": false,
-    "found_by": "fully-qualified",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "error",
-      "label",
-      "placeholder"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 27
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 119
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
-        "line": 96
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
-        "line": 223
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
-        "line": 26
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 190
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/create-diagram-dialog/create-diagram-dialog.component.html",
-        "line": 20
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 113
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 382
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
-        "line": 26
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
-        "line": 176
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/asset-editor-dialog/asset-editor-dialog.component.html",
-        "line": 28
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.html",
-        "line": 62
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
-        "line": 27
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
-        "line": 65
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
-        "line": 87
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
-        "line": 69
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.validation.required' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
-        "line": 100
-      },
-      {
-        "classes": [],
-        "context": "<mat-error>{{ 'common.validation.required' | transloco }}</mat-error>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
-        "line": 84
-      },
-      {
-        "classes": [],
-        "context": "<mat-error>{{ 'common.validation.required' | transloco }}</mat-error>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
-        "line": 119
-      },
-      {
-        "classes": [],
-        "context": "<mat-error>{{ 'common.validation.required' | transloco }}</mat-error>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
-        "line": 82
-      }
-    ]
-  },
-  "common.version": {
-    "ambiguous_word": false,
-    "confidence": "high",
-    "ellipsis_candidate": false,
-    "found_by": "fully-qualified",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "description",
-      "page-title"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "{{ 'common.version' | transloco }} {{ survey.version }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/survey-list/survey-list.component.html",
-        "line": 41
-      },
-      {
-        "classes": [
-          "info-label"
-        ],
-        "context": "<span class=\"info-label\">{{ 'common.version' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
-        "line": 290
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.version' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/surveys/admin-surveys.component.html",
-        "line": 139
-      }
-    ]
-  },
-  "common.view": {
-    "ambiguous_word": true,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'common.close' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 23,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.retry' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 42,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.objectTypes.survey' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 73,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.status' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 88,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.created' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 101,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'common.lastModified' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 111,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'common.actions' | transloco }}</th>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 122,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'common.actions' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
-        "line": 136,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('common.close'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 583,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('common.close'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 605,
-        "partial_match": "medium"
-      }
-    ]
-  },
   "common.viewMetadata": {
     "ambiguous_word": true,
     "confidence": "high",
@@ -24351,37 +24448,37 @@
         "classes": [],
         "context": ": ('common.viewMetadata' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 620
+        "line": 622
       },
       {
         "classes": [],
         "context": ": ('common.viewMetadata' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 843
+        "line": 845
       },
       {
         "classes": [],
         "context": ": ('common.viewMetadata' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1043
+        "line": 1045
       },
       {
         "classes": [],
         "context": ": ('common.viewMetadata' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1248
+        "line": 1250
       },
       {
         "classes": [],
         "context": ": ('common.viewMetadata' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1462
+        "line": 1464
       },
       {
         "classes": [],
         "context": ": ('common.viewMetadata' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1877
+        "line": 1879
       },
       {
         "classes": [],
@@ -24875,16 +24972,16 @@
     "uses": [
       {
         "classes": [],
-        "context": "{{ 'cvssCalculator.openCalculator' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 431,
+        "context": "nameKey: 'cvssCalculator.title',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
+        "line": 56,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "nameKey: 'cvssCalculator.title',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
-        "line": 56,
+        "context": "{{ 'cvssCalculator.openCalculator' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 431,
         "partial_match": "medium"
       },
       {
@@ -24964,6 +25061,48 @@
       },
       {
         "classes": [],
+        "context": "{{ 'cvssCalculator.openCalculator' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 431,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'cvssCalculator.title' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 3,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'cvssCalculator.version' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 10,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span class=\"vector-label\"> {{ 'cvssCalculator.vectorString' | transloco }}: </span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 78,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'cvssCalculator.pasteVectorPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 105,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ (isEditMode ? 'common.save' : 'cvssCalculator.apply') | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 127,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "base: 'cvssCalculator.metricGroups.base',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 46,
@@ -24981,48 +25120,6 @@
         "context": "threat: 'cvssCalculator.metricGroups.threat',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 50,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 52,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 190,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorDuplicateVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 197,
         "partial_match": "medium"
       }
     ]
@@ -25046,6 +25143,48 @@
       },
       {
         "classes": [],
+        "context": "{{ 'cvssCalculator.openCalculator' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 431,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(component.vectorPasteError).toBe('cvssCalculator.vectorUnsupportedVersion');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 406,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(component.vectorPasteError).toBe('cvssCalculator.vectorDuplicateVersion');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 414,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(component.vectorPasteError).toBe('cvssCalculator.vectorInvalid');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 422,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'cvssCalculator.metricsConfigured',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 444,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'cvssCalculator.metricsConfigured',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 460,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "base: 'cvssCalculator.metricGroups.base',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 46,
@@ -25063,48 +25202,6 @@
         "context": "threat: 'cvssCalculator.metricGroups.threat',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 50,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 52,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 190,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorDuplicateVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 197,
         "partial_match": "medium"
       }
     ]
@@ -25121,9 +25218,51 @@
     "uses": [
       {
         "classes": [],
+        "context": "nameKey: 'cvssCalculator.title',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
+        "line": 56,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "{{ 'cvssCalculator.openCalculator' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 431,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'cvssCalculator.title' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 3,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'cvssCalculator.version' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 10,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span class=\"vector-label\"> {{ 'cvssCalculator.vectorString' | transloco }}: </span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 78,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'cvssCalculator.pasteVectorPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 105,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ (isEditMode ? 'common.save' : 'cvssCalculator.apply') | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 127,
         "partial_match": "medium"
       },
       {
@@ -25145,299 +25284,11 @@
         "context": "threat: 'cvssCalculator.metricGroups.threat',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 50,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 52,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 190,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorDuplicateVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 197,
         "partial_match": "medium"
       }
     ]
   },
   "cvssCalculator.metricDescriptions.E": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "nameKey: 'cvssCalculator.title',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
-        "line": 56,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'cvssCalculator.openCalculator' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 431,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "base: 'cvssCalculator.metricGroups.base',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 46,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 47,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "threat: 'cvssCalculator.metricGroups.threat',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 50,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 52,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 190,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "cvssCalculator.metricDescriptions.IR": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "nameKey: 'cvssCalculator.title',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
-        "line": 56,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "base: 'cvssCalculator.metricGroups.base',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 46,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 47,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "threat: 'cvssCalculator.metricGroups.threat',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 50,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 52,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 190,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorDuplicateVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 197,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "cvssCalculator.metricDescriptions.MAC": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "nameKey: 'cvssCalculator.title',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
-        "line": 56,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'cvssCalculator.openCalculator' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 431,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "base: 'cvssCalculator.metricGroups.base',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 46,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 47,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "threat: 'cvssCalculator.metricGroups.threat',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 50,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 52,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 190,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "cvssCalculator.metricDescriptions.MAT": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -25519,7 +25370,7 @@
       }
     ]
   },
-  "cvssCalculator.metricDescriptions.MAV": {
+  "cvssCalculator.metricDescriptions.IR": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -25529,6 +25380,13 @@
       "general"
     ],
     "uses": [
+      {
+        "classes": [],
+        "context": "nameKey: 'cvssCalculator.title',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
+        "line": 56,
+        "partial_match": "medium"
+      },
       {
         "classes": [],
         "context": "{{ 'cvssCalculator.openCalculator' | transloco }}",
@@ -25591,181 +25449,10 @@
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 190,
         "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorDuplicateVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 197,
-        "partial_match": "medium"
       }
     ]
   },
-  "cvssCalculator.metricDescriptions.MPR": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "nameKey: 'cvssCalculator.title',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
-        "line": 56,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "base: 'cvssCalculator.metricGroups.base',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 46,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 47,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "threat: 'cvssCalculator.metricGroups.threat',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 50,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 52,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 190,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorDuplicateVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 197,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "cvssCalculator.metricDescriptions.MSA": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "nameKey: 'cvssCalculator.title',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
-        "line": 56,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "base: 'cvssCalculator.metricGroups.base',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 46,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 47,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "threat: 'cvssCalculator.metricGroups.threat',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 50,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 52,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 190,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorDuplicateVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 197,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "cvssCalculator.metricDescriptions.MSC": {
+  "cvssCalculator.metricDescriptions.MAC": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -25847,7 +25534,89 @@
       }
     ]
   },
-  "cvssCalculator.metricDescriptions.MSI": {
+  "cvssCalculator.metricDescriptions.MAT": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "nameKey: 'cvssCalculator.title',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
+        "line": 56,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(component.vectorPasteError).toBe('cvssCalculator.vectorUnsupportedVersion');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 406,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(component.vectorPasteError).toBe('cvssCalculator.vectorDuplicateVersion');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 414,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(component.vectorPasteError).toBe('cvssCalculator.vectorInvalid');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 422,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'cvssCalculator.metricsConfigured',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 444,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'cvssCalculator.metricsConfigured',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 460,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "base: 'cvssCalculator.metricGroups.base',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 46,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 47,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "threat: 'cvssCalculator.metricGroups.threat',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 48,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 49,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "cvssCalculator.metricDescriptions.MAV": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -25869,6 +25638,334 @@
         "context": "{{ 'cvssCalculator.openCalculator' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 431,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "base: 'cvssCalculator.metricGroups.base',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 46,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 47,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "threat: 'cvssCalculator.metricGroups.threat',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 48,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 49,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 50,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 52,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 53,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 190,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "cvssCalculator.metricDescriptions.MPR": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "nameKey: 'cvssCalculator.title',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
+        "line": 56,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'cvssCalculator.openCalculator' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 431,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "base: 'cvssCalculator.metricGroups.base',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 46,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 47,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "threat: 'cvssCalculator.metricGroups.threat',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 48,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 49,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 50,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 52,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 53,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 190,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "cvssCalculator.metricDescriptions.MSA": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "nameKey: 'cvssCalculator.title',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
+        "line": 56,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'cvssCalculator.title' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 3,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'cvssCalculator.version' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 10,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span class=\"vector-label\"> {{ 'cvssCalculator.vectorString' | transloco }}: </span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 78,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'cvssCalculator.pasteVectorPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 105,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ (isEditMode ? 'common.save' : 'cvssCalculator.apply') | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 127,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "base: 'cvssCalculator.metricGroups.base',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 46,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 47,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "threat: 'cvssCalculator.metricGroups.threat',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 48,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 49,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "cvssCalculator.metricDescriptions.MSC": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "nameKey: 'cvssCalculator.title',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
+        "line": 56,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "base: 'cvssCalculator.metricGroups.base',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 46,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 47,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "threat: 'cvssCalculator.metricGroups.threat',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 48,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 49,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 50,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 52,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 53,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 190,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.vectorPasteError = 'cvssCalculator.vectorDuplicateVersion';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 197,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "cvssCalculator.metricDescriptions.MSI": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "{{ 'cvssCalculator.openCalculator' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 431,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "nameKey: 'cvssCalculator.title',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
+        "line": 56,
         "partial_match": "medium"
       },
       {
@@ -25948,6 +26045,88 @@
       },
       {
         "classes": [],
+        "context": "{{ 'cvssCalculator.openCalculator' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 431,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "base: 'cvssCalculator.metricGroups.base',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 46,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 47,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "threat: 'cvssCalculator.metricGroups.threat',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 48,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 49,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 50,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 52,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 53,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 190,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "cvssCalculator.metricDescriptions.MVA": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "nameKey: 'cvssCalculator.title',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
+        "line": 56,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "base: 'cvssCalculator.metricGroups.base',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 46,
@@ -26011,7 +26190,89 @@
       }
     ]
   },
-  "cvssCalculator.metricDescriptions.MVA": {
+  "cvssCalculator.metricDescriptions.MVC": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "nameKey: 'cvssCalculator.title',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
+        "line": 56,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "base: 'cvssCalculator.metricGroups.base',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 46,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 47,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "threat: 'cvssCalculator.metricGroups.threat',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 48,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 49,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 50,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 52,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 53,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 190,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.vectorPasteError = 'cvssCalculator.vectorDuplicateVersion';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 197,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "cvssCalculator.metricDescriptions.MVI": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -26089,170 +26350,6 @@
         "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 190,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "cvssCalculator.metricDescriptions.MVC": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "base: 'cvssCalculator.metricGroups.base',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 46,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 47,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "threat: 'cvssCalculator.metricGroups.threat',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 50,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 52,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 190,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorDuplicateVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 197,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorInvalid';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 210,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "cvssCalculator.metricDescriptions.MVI": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "nameKey: 'cvssCalculator.title',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
-        "line": 56,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "base: 'cvssCalculator.metricGroups.base',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 46,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 47,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "threat: 'cvssCalculator.metricGroups.threat',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 50,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 52,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 190,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorDuplicateVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 197,
         "partial_match": "medium"
       }
     ]
@@ -26440,13 +26537,6 @@
       },
       {
         "classes": [],
-        "context": "{{ 'cvssCalculator.openCalculator' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 431,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "base: 'cvssCalculator.metricGroups.base',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 46,
@@ -26499,6 +26589,13 @@
         "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 190,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.vectorPasteError = 'cvssCalculator.vectorDuplicateVersion';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 197,
         "partial_match": "medium"
       }
     ]
@@ -26522,6 +26619,13 @@
       },
       {
         "classes": [],
+        "context": "{{ 'cvssCalculator.openCalculator' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 431,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "base: 'cvssCalculator.metricGroups.base',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 46,
@@ -26575,17 +26679,92 @@
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 190,
         "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorDuplicateVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 197,
-        "partial_match": "medium"
       }
     ]
   },
   "cvssCalculator.metricDescriptions.SA": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "nameKey: 'cvssCalculator.title',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
+        "line": 56,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'cvssCalculator.title' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 3,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'cvssCalculator.version' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 10,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span class=\"vector-label\"> {{ 'cvssCalculator.vectorString' | transloco }}: </span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 78,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'cvssCalculator.pasteVectorPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 105,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ (isEditMode ? 'common.save' : 'cvssCalculator.apply') | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 127,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "base: 'cvssCalculator.metricGroups.base',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 46,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 47,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "threat: 'cvssCalculator.metricGroups.threat',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 48,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 49,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "cvssCalculator.metricDescriptions.SC": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -26667,88 +26846,6 @@
       }
     ]
   },
-  "cvssCalculator.metricDescriptions.SC": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "nameKey: 'cvssCalculator.title',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
-        "line": 56,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "base: 'cvssCalculator.metricGroups.base',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 46,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 47,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "threat: 'cvssCalculator.metricGroups.threat',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 50,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 52,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 190,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorDuplicateVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 197,
-        "partial_match": "medium"
-      }
-    ]
-  },
   "cvssCalculator.metricDescriptions.SI": {
     "ambiguous_word": false,
     "confidence": "medium",
@@ -26768,65 +26865,65 @@
       },
       {
         "classes": [],
-        "context": "base: 'cvssCalculator.metricGroups.base',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 46,
+        "context": "{{ 'cvssCalculator.title' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 3,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 47,
+        "context": "{{ 'cvssCalculator.version' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 10,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "threat: 'cvssCalculator.metricGroups.threat',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 48,
+        "context": "<span class=\"vector-label\"> {{ 'cvssCalculator.vectorString' | transloco }}: </span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 78,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 49,
+        "context": "[placeholder]=\"'cvssCalculator.pasteVectorPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 105,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 50,
+        "context": "{{ (isEditMode ? 'common.save' : 'cvssCalculator.apply') | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
+        "line": 127,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 52,
+        "context": "expect(component.vectorPasteError).toBe('cvssCalculator.vectorUnsupportedVersion');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 406,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 53,
+        "context": "expect(component.vectorPasteError).toBe('cvssCalculator.vectorDuplicateVersion');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 414,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 190,
+        "context": "expect(component.vectorPasteError).toBe('cvssCalculator.vectorInvalid');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 422,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorDuplicateVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 197,
+        "context": "'cvssCalculator.metricsConfigured',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 444,
         "partial_match": "medium"
       }
     ]
@@ -27178,88 +27275,6 @@
       },
       {
         "classes": [],
-        "context": "{{ 'cvssCalculator.title' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
-        "line": 3,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'cvssCalculator.version' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
-        "line": 10,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span class=\"vector-label\"> {{ 'cvssCalculator.vectorString' | transloco }}: </span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
-        "line": 78,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[placeholder]=\"'cvssCalculator.pasteVectorPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
-        "line": 105,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ (isEditMode ? 'common.save' : 'cvssCalculator.apply') | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.html",
-        "line": 127,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "base: 'cvssCalculator.metricGroups.base',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 46,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 47,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "threat: 'cvssCalculator.metricGroups.threat',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 49,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "cvssCalculator.metricDescriptions.VI": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "nameKey: 'cvssCalculator.title',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
-        "line": 56,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "{{ 'cvssCalculator.openCalculator' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
         "line": 431,
@@ -27319,6 +27334,88 @@
         "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 190,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "cvssCalculator.metricDescriptions.VI": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "nameKey: 'cvssCalculator.title',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/about/about.component.ts",
+        "line": 56,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "base: 'cvssCalculator.metricGroups.base',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 46,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "temporal: 'cvssCalculator.metricGroups.temporal',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 47,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "threat: 'cvssCalculator.metricGroups.threat',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 48,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 49,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 50,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 52,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 53,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 190,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.vectorPasteError = 'cvssCalculator.vectorDuplicateVersion';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
+        "line": 197,
         "partial_match": "medium"
       }
     ]
@@ -27593,15 +27690,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "expect(component.vectorPasteError).toBe('cvssCalculator.vectorInvalid');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
-        "line": 422
-      },
-      {
-        "classes": [],
         "context": "this.vectorPasteError = 'cvssCalculator.vectorInvalid';",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 210
+      },
+      {
+        "classes": [],
+        "context": "expect(component.vectorPasteError).toBe('cvssCalculator.vectorInvalid');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 422
       }
     ]
   },
@@ -27631,6 +27728,41 @@
       },
       {
         "classes": [],
+        "context": "expect(component.vectorPasteError).toBe('cvssCalculator.vectorUnsupportedVersion');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 406,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(component.vectorPasteError).toBe('cvssCalculator.vectorDuplicateVersion');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 414,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(component.vectorPasteError).toBe('cvssCalculator.vectorInvalid');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 422,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'cvssCalculator.metricsConfigured',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 444,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'cvssCalculator.metricsConfigured',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.spec.ts",
+        "line": 460,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "base: 'cvssCalculator.metricGroups.base',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 46,
@@ -27648,41 +27780,6 @@
         "context": "threat: 'cvssCalculator.metricGroups.threat',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "environmental: 'cvssCalculator.metricGroups.environmental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'environmental-base': 'cvssCalculator.metricGroups.environmentalBase',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 50,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'cvssCalculator.metricGroups.environmentalSecurityRequirement',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 52,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "supplemental: 'cvssCalculator.metricGroups.supplemental',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.vectorPasteError = 'cvssCalculator.vectorUnsupportedVersion';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
-        "line": 190,
         "partial_match": "medium"
       }
     ]
@@ -27955,14 +28052,14 @@
       {
         "classes": [],
         "context": "<mat-label>{{ 'dashboard.createdAfter' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 108
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
+        "line": 205
       },
       {
         "classes": [],
         "context": "<mat-label>{{ 'dashboard.createdAfter' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 205
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 108
       }
     ]
   },
@@ -28100,14 +28197,14 @@
       {
         "classes": [],
         "context": "<mat-label>{{ 'dashboard.modifiedAfter' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 134
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
+        "line": 236
       },
       {
         "classes": [],
         "context": "<mat-label>{{ 'dashboard.modifiedAfter' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 236
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 134
       }
     ]
   },
@@ -28124,14 +28221,14 @@
       {
         "classes": [],
         "context": "<mat-label>{{ 'dashboard.modifiedBefore' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 147
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
+        "line": 251
       },
       {
         "classes": [],
         "context": "<mat-label>{{ 'dashboard.modifiedBefore' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 251
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 147
       }
     ]
   },
@@ -28149,14 +28246,14 @@
       {
         "classes": [],
         "context": ": ('dashboard.moreFilters' | transloco)",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 118
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 70
       },
       {
         "classes": [],
         "context": ": ('dashboard.moreFilters' | transloco)",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 70
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
+        "line": 118
       }
     ]
   },
@@ -28227,6 +28324,12 @@
       {
         "classes": [],
         "context": "<mat-label>{{ 'dashboard.ownerFilter' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 97
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'dashboard.ownerFilter' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 82
       },
@@ -28235,12 +28338,6 @@
         "context": "<mat-label>{{ 'dashboard.ownerFilter' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 169
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'dashboard.ownerFilter' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 97
       }
     ]
   },
@@ -28257,12 +28354,6 @@
       {
         "classes": [],
         "context": "[placeholder]=\"'dashboard.ownerPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 102
-      },
-      {
-        "classes": [],
-        "context": "[placeholder]=\"'dashboard.ownerPlaceholder' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 88
       },
@@ -28271,6 +28362,12 @@
         "context": "[placeholder]=\"'dashboard.ownerPlaceholder' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 175
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'dashboard.ownerPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 102
       }
     ]
   },
@@ -28442,6 +28539,62 @@
     "uses": [
       {
         "classes": [],
+        "context": "? ('dashboard.lessFilters' | transloco)",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 69,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": ": ('dashboard.moreFilters' | transloco)",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 70,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'dashboard.ownerFilter' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 97,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'dashboard.ownerPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 102,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'dashboard.createdAfter' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 108,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'dashboard.createdBefore' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 121,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'dashboard.modifiedAfter' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 134,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'dashboard.modifiedBefore' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 147,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "? ('dashboard.viewAsCards' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 16,
@@ -28452,62 +28605,6 @@
         "context": ": ('dashboard.viewAsList' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 17,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'dashboard.searchLabel' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 46,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[placeholder]=\"'dashboard.searchPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'dashboard.securityReviewerFilter' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 71,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[placeholder]=\"'dashboard.securityReviewerPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 77,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'dashboard.ownerFilter' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 82,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[placeholder]=\"'dashboard.ownerPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 88,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "? ('dashboard.lessFilters' | transloco)",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 117,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": ": ('dashboard.moreFilters' | transloco)",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 118,
         "partial_match": "medium"
       }
     ]
@@ -30192,88 +30289,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "<span class=\"popover-title\">{{ 'dfd.portLabel.title' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/port-label-popover/port-label-popover.component.html",
-        "line": 3,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'dfd.portLabel.textLabel' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/port-label-popover/port-label-popover.component.html",
-        "line": 11,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[placeholder]=\"'dfd.portLabel.textPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/port-label-popover/port-label-popover.component.html",
-        "line": 16,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<div class=\"position-label\">{{ 'dfd.portLabel.positionLabel' | transloco }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/port-label-popover/port-label-popover.component.html",
-        "line": 22,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'dfd.portLabel.position.outside' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/port-label-popover/port-label-popover.component.html",
-        "line": 32,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'dfd.portLabel.position.inside' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/port-label-popover/port-label-popover.component.html",
-        "line": 35,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'dfd.portLabel.position.top' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/port-label-popover/port-label-popover.component.html",
-        "line": 43,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'dfd.portLabel.position.left' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/port-label-popover/port-label-popover.component.html",
-        "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'dfd.portLabel.position.right' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/port-label-popover/port-label-popover.component.html",
-        "line": 51,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'dfd.portLabel.position.bottom' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/port-label-popover/port-label-popover.component.html",
-        "line": 56,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "dfd.stylePanel.labelPosition.middle-left": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
         "context": "<div class=\"section-label\">{{ 'dfd.stylePanel.defaultColors' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/color-picker/color-picker.component.html",
         "line": 4,
@@ -30340,6 +30355,88 @@
         "context": "<div class=\"position-label\">{{ 'dfd.portLabel.positionLabel' | transloco }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/port-label-popover/port-label-popover.component.html",
         "line": 22,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "dfd.stylePanel.labelPosition.middle-left": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "<span class=\"panel-title\">{{ 'dfd.iconPicker.title' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/icon-picker-panel/icon-picker-panel.component.html",
+        "line": 4,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'dfd.iconPicker.selectShape' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/icon-picker-panel/icon-picker-panel.component.html",
+        "line": 10,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'dfd.iconPicker.notAvailable' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/icon-picker-panel/icon-picker-panel.component.html",
+        "line": 14,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'dfd.iconPicker.remove' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/icon-picker-panel/icon-picker-panel.component.html",
+        "line": 31,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'dfd.iconPicker.placement' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/icon-picker-panel/icon-picker-panel.component.html",
+        "line": 42,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "(currentArch ? 'dfd.iconPicker.searchToChange' : 'dfd.iconPicker.searchPlaceholder')",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/icon-picker-panel/icon-picker-panel.component.html",
+        "line": 70,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'dfd.iconPicker.emptyStatePrompt' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/icon-picker-panel/icon-picker-panel.component.html",
+        "line": 97,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'dfd.iconPicker.emptyStateTryExamples' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/icon-picker-panel/icon-picker-panel.component.html",
+        "line": 100,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'dfd.iconPicker.statusMatches' | transloco: { count: 0 } }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/icon-picker-panel/icon-picker-panel.component.html",
+        "line": 106,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'dfd.iconPicker.statusMatches' | transloco: { count: matchCount } }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/components/icon-picker-panel/icon-picker-panel.component.html",
+        "line": 153,
         "partial_match": "medium"
       }
     ]
@@ -31233,14 +31330,14 @@
       {
         "classes": [],
         "context": "picker_registration_invalid: 'documentAccess.reason.pickerRegistrationInvalid',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/access-diagnostics-panel/access-diagnostics-panel.component.ts",
-        "line": 21
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/access-diagnostics-coverage.spec.ts",
+        "line": 19
       },
       {
         "classes": [],
         "context": "picker_registration_invalid: 'documentAccess.reason.pickerRegistrationInvalid',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/access-diagnostics-coverage.spec.ts",
-        "line": 19
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/access-diagnostics-panel/access-diagnostics-panel.component.ts",
+        "line": 21
       }
     ]
   },
@@ -31257,14 +31354,14 @@
       {
         "classes": [],
         "context": "source_not_found: 'documentAccess.reason.sourceNotFound',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/access-diagnostics-coverage.spec.ts",
-        "line": 21
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/access-diagnostics-panel/access-diagnostics-panel.component.ts",
+        "line": 23
       },
       {
         "classes": [],
         "context": "source_not_found: 'documentAccess.reason.sourceNotFound',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/access-diagnostics-panel/access-diagnostics-panel.component.ts",
-        "line": 23
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/access-diagnostics-coverage.spec.ts",
+        "line": 21
       }
     ]
   },
@@ -31278,12 +31375,6 @@
       "general"
     ],
     "uses": [
-      {
-        "classes": [],
-        "context": "token_not_linked: 'documentAccess.reason.tokenNotLinked',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/access-diagnostics-coverage.spec.ts",
-        "line": 16
-      },
       {
         "classes": [],
         "context": "token_not_linked: 'documentAccess.reason.tokenNotLinked',",
@@ -31307,6 +31398,12 @@
         "context": "expect(mockTransloco.translate).toHaveBeenCalledWith('documentAccess.reason.tokenNotLinked', {",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/access-diagnostics-panel/access-diagnostics-panel.component.spec.ts",
         "line": 98
+      },
+      {
+        "classes": [],
+        "context": "token_not_linked: 'documentAccess.reason.tokenNotLinked',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/access-diagnostics-coverage.spec.ts",
+        "line": 16
       }
     ]
   },
@@ -31347,14 +31444,14 @@
       {
         "classes": [],
         "context": "token_transient_failure: 'documentAccess.reason.tokenTransientFailure',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/access-diagnostics-panel/access-diagnostics-panel.component.ts",
-        "line": 20
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/access-diagnostics-coverage.spec.ts",
+        "line": 18
       },
       {
         "classes": [],
         "context": "token_transient_failure: 'documentAccess.reason.tokenTransientFailure',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/access-diagnostics-coverage.spec.ts",
-        "line": 18
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/access-diagnostics-panel/access-diagnostics-panel.component.ts",
+        "line": 20
       }
     ]
   },
@@ -31395,12 +31492,6 @@
       {
         "classes": [],
         "context": "link_account: 'documentAccess.remediation.linkAccount',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/access-diagnostics-coverage.spec.ts",
-        "line": 27
-      },
-      {
-        "classes": [],
-        "context": "link_account: 'documentAccess.remediation.linkAccount',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/access-diagnostics-panel/remediation-card/remediation-card.component.ts",
         "line": 25
       },
@@ -31409,6 +31500,12 @@
         "context": "await expect(firstValueFrom(c.label)).resolves.toBe('documentAccess.remediation.linkAccount');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/access-diagnostics-panel/remediation-card/remediation-card.component.spec.ts",
         "line": 60
+      },
+      {
+        "classes": [],
+        "context": "link_account: 'documentAccess.remediation.linkAccount',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/access-diagnostics-coverage.spec.ts",
+        "line": 27
       }
     ]
   },
@@ -31473,14 +31570,14 @@
       {
         "classes": [],
         "context": "repick_file: 'documentAccess.remediation.repickFile',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/access-diagnostics-coverage.spec.ts",
-        "line": 29
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/access-diagnostics-panel/remediation-card/remediation-card.component.ts",
+        "line": 27
       },
       {
         "classes": [],
         "context": "repick_file: 'documentAccess.remediation.repickFile',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/access-diagnostics-panel/remediation-card/remediation-card.component.ts",
-        "line": 27
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/access-diagnostics-coverage.spec.ts",
+        "line": 29
       }
     ]
   },
@@ -32065,9 +32162,9 @@
       },
       {
         "classes": [],
-        "context": "? 'documentEditor.source.pickActionMicrosoft'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.ts",
-        "line": 430,
+        "context": "<p class=\"post-create-hint\" [transloco]=\"'documentEditor.postCreate.hint'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.html",
+        "line": 27,
         "partial_match": "medium"
       }
     ]
@@ -32320,6 +32417,12 @@
     "uses": [
       {
         "classes": [],
+        "context": ": transloco.translate('documentSources.callback.error', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.ts",
+        "line": 134
+      },
+      {
+        "classes": [],
         "context": "expect(msg).toBe('documentSources.callback.error');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.spec.ts",
         "line": 164
@@ -32329,12 +32432,6 @@
         "context": "expect(mockTransloco.translate).toHaveBeenCalledWith('documentSources.callback.error', {",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.spec.ts",
         "line": 165
-      },
-      {
-        "classes": [],
-        "context": ": transloco.translate('documentSources.callback.error', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.ts",
-        "line": 134
       },
       {
         "classes": [],
@@ -32350,9 +32447,9 @@
       },
       {
         "classes": [],
-        "context": "expect(mockSnack.open).toHaveBeenCalledWith('documentSources.callback.error', undefined, {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.spec.ts",
-        "line": 811
+        "context": "this.transloco.translate('documentSources.callback.error', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/content-callback/content-callback.component.ts",
+        "line": 58
       },
       {
         "classes": [],
@@ -32362,9 +32459,9 @@
       },
       {
         "classes": [],
-        "context": "this.transloco.translate('documentSources.callback.error', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/content-callback/content-callback.component.ts",
-        "line": 58
+        "context": "expect(mockSnack.open).toHaveBeenCalledWith('documentSources.callback.error', undefined, {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/document-editor-dialog/document-editor-dialog.component.spec.ts",
+        "line": 811
       }
     ]
   },
@@ -32502,72 +32599,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "key === 'documentSources.googleDrive.name' ? 'Google Drive' : key,",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.spec.ts",
-        "line": 141,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(msg).toBe('documentSources.callback.notConfigured');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.spec.ts",
-        "line": 152,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(mockTransloco.translate).toHaveBeenCalledWith('documentSources.callback.notConfigured', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.spec.ts",
-        "line": 153,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(msg).toBe('documentSources.callback.error');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.spec.ts",
-        "line": 164,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(mockTransloco.translate).toHaveBeenCalledWith('documentSources.callback.error', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.spec.ts",
-        "line": 165,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(mockTransloco.translate).toHaveBeenCalledWith('documentSources.callback.notConfigured', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.spec.ts",
-        "line": 177,
+        "context": "<mat-tab [label]=\"'documentSources.tabTitle' | transloco\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/user-preferences-dialog.component.ts",
+        "line": 434,
         "partial_match": "medium"
       },
       {
         "classes": [],
         "context": "displayNameKey: 'documentSources.googleDrive.name',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-providers.service.spec.ts",
-        "line": 78,
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
+        "line": 46,
         "partial_match": "medium"
       },
       {
         "classes": [],
         "context": "displayNameKey: 'documentSources.googleDrive.name',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-provider-registry.ts",
-        "line": 23,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "displayNameKey: 'documentSources.googleDrive.name',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-provider-registry.ts",
-        "line": 31,
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
+        "line": 104,
         "partial_match": "medium"
       },
       {
         "classes": [],
         "context": "displayNameKey: 'documentSources.microsoft.name',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-provider-registry.ts",
-        "line": 39,
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
+        "line": 122,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "displayNameKey: 'documentSources.microsoft.name',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
+        "line": 139,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "displayNameKey: 'documentSources.googleDrive.name',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
+        "line": 177,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "key === 'documentSources.googleDrive.name' ? 'Google Drive' : key,",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
+        "line": 222,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'documentSources.callback.notConfigured',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
+        "line": 227,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'documentSources.callback.notConfigured',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
+        "line": 232,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "key === 'documentSources.googleDrive.name' ? 'Google Drive' : key,",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
+        "line": 241,
         "partial_match": "medium"
       }
     ]
@@ -32657,6 +32754,30 @@
       {
         "classes": [],
         "context": "displayNameKey: 'documentSources.googleDrive.name',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-providers.service.spec.ts",
+        "line": 78
+      },
+      {
+        "classes": [],
+        "context": "displayNameKey: 'documentSources.googleDrive.name',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-provider-registry.ts",
+        "line": 23
+      },
+      {
+        "classes": [],
+        "context": "displayNameKey: 'documentSources.googleDrive.name',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-provider-registry.ts",
+        "line": 31
+      },
+      {
+        "classes": [],
+        "context": "key === 'documentSources.googleDrive.name' ? 'Google Drive' : key,",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.spec.ts",
+        "line": 141
+      },
+      {
+        "classes": [],
+        "context": "displayNameKey: 'documentSources.googleDrive.name',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
         "line": 46
       },
@@ -32683,30 +32804,6 @@
         "context": "key === 'documentSources.googleDrive.name' ? 'Google Drive' : key,",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
         "line": 241
-      },
-      {
-        "classes": [],
-        "context": "displayNameKey: 'documentSources.googleDrive.name',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-providers.service.spec.ts",
-        "line": 78
-      },
-      {
-        "classes": [],
-        "context": "displayNameKey: 'documentSources.googleDrive.name',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-provider-registry.ts",
-        "line": 23
-      },
-      {
-        "classes": [],
-        "context": "displayNameKey: 'documentSources.googleDrive.name',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-provider-registry.ts",
-        "line": 31
-      },
-      {
-        "classes": [],
-        "context": "key === 'documentSources.googleDrive.name' ? 'Google Drive' : key,",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.spec.ts",
-        "line": 141
       },
       {
         "classes": [],
@@ -32904,44 +33001,44 @@
       },
       {
         "classes": [],
-        "context": "? transloco.translate('documentSources.callback.notConfigured', { source: sourceName })",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.ts",
-        "line": 133,
+        "context": "key === 'documentSources.googleDrive.name' ? 'Google Drive' : key,",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.spec.ts",
+        "line": 141,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": ": transloco.translate('documentSources.callback.error', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.ts",
-        "line": 134,
+        "context": "expect(msg).toBe('documentSources.callback.notConfigured');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.spec.ts",
+        "line": 152,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "expect(mockTransloco.translate).toHaveBeenCalledWith('documentSources.googleDrive.name');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/access-diagnostics-panel/access-diagnostics-panel.component.spec.ts",
-        "line": 97,
+        "context": "expect(mockTransloco.translate).toHaveBeenCalledWith('documentSources.callback.notConfigured', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.spec.ts",
+        "line": 153,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "source: 'documentSources.googleDrive.name',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/access-diagnostics-panel/access-diagnostics-panel.component.spec.ts",
-        "line": 99,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'documentSources.callback.notConfigured',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/access-diagnostics-panel/remediation-card/remediation-card.component.spec.ts",
-        "line": 150,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(mockSnack.open).toHaveBeenCalledWith('documentSources.callback.error', undefined, {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/access-diagnostics-panel/remediation-card/remediation-card.component.spec.ts",
+        "context": "expect(msg).toBe('documentSources.callback.error');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.spec.ts",
         "line": 164,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(mockTransloco.translate).toHaveBeenCalledWith('documentSources.callback.error', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.spec.ts",
+        "line": 165,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(mockTransloco.translate).toHaveBeenCalledWith('documentSources.callback.notConfigured', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.spec.ts",
+        "line": 177,
         "partial_match": "medium"
       }
     ]
@@ -32958,9 +33055,51 @@
     "uses": [
       {
         "classes": [],
+        "context": "displayNameKey: 'documentSources.googleDrive.name',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-providers.service.spec.ts",
+        "line": 78,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "displayNameKey: 'documentSources.googleDrive.name',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-provider-registry.ts",
+        "line": 23,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "displayNameKey: 'documentSources.googleDrive.name',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-provider-registry.ts",
+        "line": 31,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "displayNameKey: 'documentSources.microsoft.name',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-provider-registry.ts",
+        "line": 39,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "<mat-tab [label]=\"'documentSources.tabTitle' | transloco\">",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/user-preferences-dialog.component.ts",
         "line": 434,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "? transloco.translate('documentSources.callback.notConfigured', { source: sourceName })",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.ts",
+        "line": 133,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": ": transloco.translate('documentSources.callback.error', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/services/content-token.service.ts",
+        "line": 134,
         "partial_match": "medium"
       },
       {
@@ -32982,48 +33121,6 @@
         "context": "displayNameKey: 'documentSources.microsoft.name',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
         "line": 122,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "displayNameKey: 'documentSources.microsoft.name',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
-        "line": 139,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "displayNameKey: 'documentSources.googleDrive.name',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
-        "line": 177,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "key === 'documentSources.googleDrive.name' ? 'Google Drive' : key,",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
-        "line": 222,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'documentSources.callback.notConfigured',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
-        "line": 227,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'documentSources.callback.notConfigured',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
-        "line": 232,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "key === 'documentSources.googleDrive.name' ? 'Google Drive' : key,",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/user-preferences-dialog/connected-accounts-tab/connected-accounts-tab.component.spec.ts",
-        "line": 241,
         "partial_match": "medium"
       }
     ]
@@ -33126,7 +33223,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'documentStatus.accessible' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 782
+        "line": 784
       }
     ]
   },
@@ -33144,7 +33241,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'documentStatus.authRequired' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 761
+        "line": 763
       }
     ]
   },
@@ -33162,7 +33259,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'documentStatus.pendingAccess' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 768
+        "line": 770
       }
     ]
   },
@@ -33180,7 +33277,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'documentStatus.unknown' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 775
+        "line": 777
       }
     ]
   },
@@ -33220,15 +33317,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "message: 'editor.deleteMetadataWarning.message',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/services/dfd-dialog.service.ts",
-        "line": 75
-      },
-      {
-        "classes": [],
         "context": "*     message: 'editor.deleteMetadataWarning.message',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/confirm-action-dialog/confirm-action-dialog.component.ts",
         "line": 26
+      },
+      {
+        "classes": [],
+        "context": "message: 'editor.deleteMetadataWarning.message',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/presentation/services/dfd-dialog.service.ts",
+        "line": 75
       }
     ]
   },
@@ -35199,14 +35296,14 @@
       {
         "classes": [],
         "context": "this.snackBar.open(this.translocoService.translate('mermaidViewer.exportFailed'), '', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-viewer/mermaid-viewer.component.ts",
-        "line": 203
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-overlay-viewer/mermaid-overlay-viewer.component.ts",
+        "line": 222
       },
       {
         "classes": [],
         "context": "this.snackBar.open(this.translocoService.translate('mermaidViewer.exportFailed'), '', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-overlay-viewer/mermaid-overlay-viewer.component.ts",
-        "line": 222
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-viewer/mermaid-viewer.component.ts",
+        "line": 203
       }
     ]
   },
@@ -35291,14 +35388,14 @@
       {
         "classes": [],
         "context": "<button mat-icon-button (click)=\"zoomIn()\" [matTooltip]=\"'mermaidViewer.zoomIn' | transloco\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-overlay-viewer/mermaid-overlay-viewer.component.html",
-        "line": 4
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-viewer/mermaid-viewer.component.html",
+        "line": 3
       },
       {
         "classes": [],
         "context": "<button mat-icon-button (click)=\"zoomIn()\" [matTooltip]=\"'mermaidViewer.zoomIn' | transloco\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-viewer/mermaid-viewer.component.html",
-        "line": 3
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-overlay-viewer/mermaid-overlay-viewer.component.html",
+        "line": 4
       }
     ]
   },
@@ -35316,14 +35413,14 @@
       {
         "classes": [],
         "context": "<button mat-icon-button (click)=\"zoomOut()\" [matTooltip]=\"'mermaidViewer.zoomOut' | transloco\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-viewer/mermaid-viewer.component.html",
-        "line": 6
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-overlay-viewer/mermaid-overlay-viewer.component.html",
+        "line": 7
       },
       {
         "classes": [],
         "context": "<button mat-icon-button (click)=\"zoomOut()\" [matTooltip]=\"'mermaidViewer.zoomOut' | transloco\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-overlay-viewer/mermaid-overlay-viewer.component.html",
-        "line": 7
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/mermaid-viewer/mermaid-viewer.component.html",
+        "line": 6
       }
     ]
   },
@@ -35741,8 +35838,8 @@
       {
         "classes": [],
         "context": "'noteEditor.characterCount'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
-        "line": 151
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
+        "line": 93
       },
       {
         "classes": [],
@@ -35753,8 +35850,8 @@
       {
         "classes": [],
         "context": "'noteEditor.characterCount'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 93
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 151
       }
     ]
   },
@@ -35999,14 +36096,14 @@
       {
         "classes": [],
         "context": "[placeholder]=\"'noteEditor.namePlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
-        "line": 92
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 22
       },
       {
         "classes": [],
         "context": "[placeholder]=\"'noteEditor.namePlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
-        "line": 22
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/note-page/note-page.component.html",
+        "line": 92
       }
     ]
   },
@@ -36023,14 +36120,14 @@
       {
         "classes": [],
         "context": "[matTooltip]=\"'noteEditor.previewMode' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
-        "line": 103
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
+        "line": 56
       },
       {
         "classes": [],
         "context": "[matTooltip]=\"'noteEditor.previewMode' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 56
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 103
       },
       {
         "classes": [],
@@ -36088,72 +36185,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "[matTooltip]=\"'noteEditor.editMode' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 46,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'noteEditor.previewMode' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 56,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'noteEditor.characterCount'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 93,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.showMessage('noteEditor.errors.clipboardAccessDenied', true);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.ts",
-        "line": 189,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.showMessage('noteEditor.copiedToClipboard');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.ts",
-        "line": 198,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.showMessage('noteEditor.errors.clipboardAccessDenied', true);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.ts",
-        "line": 200,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.showMessage('noteEditor.copiedToClipboard');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.ts",
-        "line": 209,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.showMessage('noteEditor.errors.clipboardAccessDenied', true);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.ts",
-        "line": 211,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.showMessage('noteEditor.errors.clipboardAccessDenied', true);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.ts",
-        "line": 235,
+        "context": "expect(editor.messages).toEqual([{ key: 'noteEditor.copiedToClipboard', isError: false }]);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor/note-editor-base.spec.ts",
+        "line": 81,
         "partial_match": "medium"
       },
       {
         "classes": [],
         "context": "expect(editor.messages).toEqual([{ key: 'noteEditor.copiedToClipboard', isError: false }]);",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor/note-editor-base.spec.ts",
-        "line": 81,
+        "line": 94,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{ key: 'noteEditor.errors.clipboardAccessDenied', isError: true },",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor/note-editor-base.spec.ts",
+        "line": 117,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{ key: 'noteEditor.errors.clipboardAccessDenied', isError: true },",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor/note-editor-base.spec.ts",
+        "line": 160,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{ key: 'noteEditor.errors.clipboardAccessDenied', isError: true },",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor/note-editor-base.spec.ts",
+        "line": 212,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'noteEditor.namePlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 22,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'noteEditor.descriptionPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 43,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'noteEditor.editMode' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 94,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'noteEditor.previewMode' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 103,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'noteEditor.characterCount'",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 151,
         "partial_match": "medium"
       }
     ]
@@ -36212,6 +36309,20 @@
     "uses": [
       {
         "classes": [],
+        "context": "{{ 'notes.sharable' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 67,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'notes.sharableTooltip' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
+        "line": 71,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "(totalNotes > 0 ? 'notes.tabWithCount' : 'notes.tab')",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
         "line": 152,
@@ -36243,20 +36354,6 @@
         "context": "{{ 'notes.columns.description' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
         "line": 189,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'notes.sharable' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
-        "line": 67,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'notes.sharableTooltip' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
-        "line": 71,
         "partial_match": "medium"
       },
       {
@@ -36424,16 +36521,37 @@
     "uses": [
       {
         "classes": [],
-        "context": "{{ 'notes.sharable' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
-        "line": 67,
+        "context": "(totalNotes > 0 ? 'notes.tabWithCount' : 'notes.tab')",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 156,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[matTooltip]=\"'notes.sharableTooltip' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/note-editor-dialog/note-editor-dialog.component.html",
-        "line": 71,
+        "context": "{{ 'notes.addNote' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 169,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<div class=\"notes-empty\">{{ 'notes.noNotes' | transloco }}</div>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 176,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<th mat-header-cell *matHeaderCellDef>{{ 'notes.columns.name' | transloco }}</th>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 180,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'notes.columns.description' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 187,
         "partial_match": "medium"
       },
       {
@@ -36469,27 +36587,6 @@
         "context": "{{ 'notes.columns.description' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
         "line": 189,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "(totalNotes > 0 ? 'notes.tabWithCount' : 'notes.tab')",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
-        "line": 156,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'notes.addNote' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
-        "line": 169,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<div class=\"notes-empty\">{{ 'notes.noNotes' | transloco }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
-        "line": 176,
         "partial_match": "medium"
       }
     ]
@@ -36567,14 +36664,14 @@
       {
         "classes": [],
         "context": "(totalNotes > 0 ? 'notes.tabWithCount' : 'notes.tab')",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
-        "line": 156
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
+        "line": 152
       },
       {
         "classes": [],
         "context": "(totalNotes > 0 ? 'notes.tabWithCount' : 'notes.tab')",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
-        "line": 152
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 156
       }
     ]
   },
@@ -36614,15 +36711,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "actionLabel = this._transloco.translate('notifications.actions.login');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.ts",
-        "line": 360
-      },
-      {
-        "classes": [],
         "context": "'notifications.actions.login': 'Login',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.spec.ts",
         "line": 41
+      },
+      {
+        "classes": [],
+        "context": "actionLabel = this._transloco.translate('notifications.actions.login');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.ts",
+        "line": 360
       }
     ]
   },
@@ -36764,15 +36861,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "? this._transloco.translate('notifications.presenter.assigned', { user: displayName })",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.ts",
-        "line": 491
-      },
-      {
-        "classes": [],
         "context": "'notifications.presenter.assigned': `${params?.user || 'User'} is now the presenter`,",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.spec.ts",
         "line": 43
+      },
+      {
+        "classes": [],
+        "context": "? this._transloco.translate('notifications.presenter.assigned', { user: displayName })",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.ts",
+        "line": 491
       }
     ]
   },
@@ -37154,6 +37251,12 @@
     "uses": [
       {
         "classes": [],
+        "context": "'notifications.websocket.connectionError': 'Connection error. Working in offline mode.',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.spec.ts",
+        "line": 44
+      },
+      {
+        "classes": [],
         "context": ": this._transloco.translate('notifications.websocket.connectionError');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.ts",
         "line": 325
@@ -37163,12 +37266,6 @@
         "context": "message = this._transloco.translate('notifications.websocket.connectionError');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.ts",
         "line": 363
-      },
-      {
-        "classes": [],
-        "context": "'notifications.websocket.connectionError': 'Connection error. Working in offline mode.',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dfd/application/services/app-notification.service.spec.ts",
-        "line": 44
       }
     ]
   },
@@ -37299,50 +37396,8 @@
       {
         "classes": [],
         "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 694
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 923
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1128
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1326
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1562
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1960
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 204
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
-        "line": 164
       },
       {
         "classes": [],
@@ -37353,8 +37408,68 @@
       {
         "classes": [],
         "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/groups/admin-groups.component.html",
-        "line": 208
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 696
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 925
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1130
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1328
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1564
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1962
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
+        "line": 679
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/webhooks/admin-webhooks.component.html",
+        "line": 164
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.html",
+        "line": 233
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
+        "line": 242
+      },
+      {
+        "classes": [],
+        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
+        "line": 498
       },
       {
         "classes": [],
@@ -37377,32 +37492,14 @@
       {
         "classes": [],
         "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
-        "line": 242
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/quotas/admin-quotas.component.html",
-        "line": 498
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/groups/admin-groups.component.html",
+        "line": 208
       },
       {
         "classes": [],
         "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
         "line": 205
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/users/admin-users.component.html",
-        "line": 233
-      },
-      {
-        "classes": [],
-        "context": "[attr.aria-label]=\"'pagination.ariaLabel' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 679
       }
     ]
   },
@@ -38246,14 +38343,14 @@
       {
         "classes": [],
         "context": "{{ 'projects.columns.modified' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 161
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 164
       },
       {
         "classes": [],
         "context": "{{ 'projects.columns.modified' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 164
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 161
       }
     ]
   },
@@ -38270,14 +38367,14 @@
       {
         "classes": [],
         "context": "{{ 'projects.columns.name' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 128
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 130
       },
       {
         "classes": [],
         "context": "{{ 'projects.columns.name' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 130
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 128
       }
     ]
   },
@@ -38294,14 +38391,14 @@
       {
         "classes": [],
         "context": "{{ 'projects.columns.status' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 139
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 142
       },
       {
         "classes": [],
         "context": "{{ 'projects.columns.status' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 142
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 139
       }
     ]
   },
@@ -38318,14 +38415,14 @@
       {
         "classes": [],
         "context": "{{ 'projects.columns.team' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 152
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 155
       },
       {
         "classes": [],
         "context": "{{ 'projects.columns.team' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 155
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 152
       }
     ]
   },
@@ -38563,72 +38660,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "<h1 [transloco]=\"'projects.title'\">Manage Projects</h1>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 4,
+        "context": "<h2 mat-dialog-title [transloco]=\"'projects.createDialog.title'\">Create Project</h2>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 39,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<p class=\"subtitle\" [transloco]=\"'projects.subtitle'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 5,
+        "context": "[placeholder]=\"'projects.createDialog.namePlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 48,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'projects.filterNameLabel'\">Filter by Name</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 25,
+        "context": "<mat-error [transloco]=\"'projects.createDialog.nameRequired'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 54,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'projects.filterTeamLabel'\">Filter by Team</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 36,
+        "context": "[placeholder]=\"'projects.createDialog.descriptionPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 65,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'projects.filterStatusLabel'\">Filter by Status</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 68,
+        "context": "<mat-error [transloco]=\"'projects.createDialog.teamRequired'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 87,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'projects.allStatuses' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 75,
+        "context": "[placeholder]=\"'projects.createDialog.uriPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 108,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<span [transloco]=\"'projects.clearFilters'\">Clear Filters</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 93,
+        "context": "[placeholder]=\"'projects.createDialog.statusPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 118,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-card-title [transloco]=\"'projects.listTitle'\">Projects</mat-card-title>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 102,
+        "context": "<h2 mat-dialog-title [transloco]=\"'projects.relatedProjectsDialog.title'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
+        "line": 44,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<span [transloco]=\"'projects.addButton'\">Add Project</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 111,
+        "context": "<div class=\"no-items\">{{ 'projects.relatedProjectsDialog.noRelated' | transloco }}</div>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
+        "line": 50,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'projects.columns.name' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 130,
+        "context": "<span [transloco]=\"'projects.relatedProjectsDialog.addRelated'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
+        "line": 81,
         "partial_match": "medium"
       }
     ]
@@ -38646,14 +38743,14 @@
       {
         "classes": [],
         "context": "<mat-label [transloco]=\"'projects.filterNameLabel'\">Filter by Name</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 23
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 25
       },
       {
         "classes": [],
         "context": "<mat-label [transloco]=\"'projects.filterNameLabel'\">Filter by Name</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 25
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 23
       }
     ]
   },
@@ -38694,14 +38791,14 @@
       {
         "classes": [],
         "context": "<mat-label [transloco]=\"'projects.filterTeamLabel'\">Filter by Team</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 34
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 36
       },
       {
         "classes": [],
         "context": "<mat-label [transloco]=\"'projects.filterTeamLabel'\">Filter by Team</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 36
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 34
       }
     ]
   },
@@ -38790,14 +38887,14 @@
       {
         "classes": [],
         "context": "<span [transloco]=\"'projects.kebab.responsibleParties'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 201
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 198
       },
       {
         "classes": [],
         "context": "<span [transloco]=\"'projects.kebab.responsibleParties'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 198
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 201
       }
     ]
   },
@@ -38993,72 +39090,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "expect(component.getStatusLabel('active')).toBe('projects.status.active');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.spec.ts",
-        "line": 634,
+        "context": "<h2 mat-dialog-title [transloco]=\"'projects.createDialog.title'\">Create Project</h2>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 39,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'projects.filterNameLabel'\">Filter by Name</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 23,
+        "context": "[placeholder]=\"'projects.createDialog.namePlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 48,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'projects.filterTeamLabel'\">Filter by Team</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 34,
+        "context": "<mat-error [transloco]=\"'projects.createDialog.nameRequired'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 54,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'projects.filterStatusLabel'\">Filter by Status</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "context": "[placeholder]=\"'projects.createDialog.descriptionPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 65,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-error [transloco]=\"'projects.createDialog.teamRequired'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 87,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'projects.createDialog.uriPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 108,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'projects.createDialog.statusPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 118,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<h2 mat-dialog-title [transloco]=\"'projects.editDialog.title'\">Edit Project</h2>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
         "line": 66,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'projects.allStatuses' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 73,
+        "context": "[label]=\"'projects.editDialog.detailsTab' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 76,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<span [transloco]=\"'projects.clearFilters'\">Clear Filters</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 91,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'projects.addButton'\">Add Project</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 109,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'projects.columns.name' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 128,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'projects.columns.status' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 142,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'projects.columns.team' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 155,
+        "context": "{{ 'projects.status.' + status | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-project-dialog/edit-project-dialog.component.ts",
+        "line": 139,
         "partial_match": "medium"
       }
     ]
@@ -39157,77 +39254,183 @@
     "uses": [
       {
         "classes": [],
-        "context": "<h2 mat-dialog-title [transloco]=\"'projects.createDialog.title'\">Create Project</h2>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 39,
+        "context": "<mat-label [transloco]=\"'projects.filterNameLabel'\">Filter by Name</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 23,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[placeholder]=\"'projects.createDialog.namePlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 48,
+        "context": "<mat-label [transloco]=\"'projects.filterTeamLabel'\">Filter by Team</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 34,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-error [transloco]=\"'projects.createDialog.nameRequired'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 54,
+        "context": "<mat-label [transloco]=\"'projects.filterStatusLabel'\">Filter by Status</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 66,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[placeholder]=\"'projects.createDialog.descriptionPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 65,
+        "context": "{{ 'projects.allStatuses' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 73,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-error [transloco]=\"'projects.createDialog.teamRequired'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 87,
+        "context": "<span [transloco]=\"'projects.clearFilters'\">Clear Filters</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 91,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[placeholder]=\"'projects.createDialog.uriPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 108,
+        "context": "<span [transloco]=\"'projects.addButton'\">Add Project</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 109,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[placeholder]=\"'projects.createDialog.statusPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 118,
+        "context": "{{ 'projects.columns.name' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 128,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<h2 mat-dialog-title [transloco]=\"'projects.relatedProjectsDialog.title'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 44,
+        "context": "{{ 'projects.columns.status' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 142,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<div class=\"no-items\">{{ 'projects.relatedProjectsDialog.noRelated' | transloco }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 50,
+        "context": "{{ 'projects.columns.team' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 155,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<span [transloco]=\"'projects.relatedProjectsDialog.addRelated'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 81,
+        "context": "{{ 'projects.columns.modified' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 164,
         "partial_match": "medium"
       }
     ]
   },
   "projects.responsiblePartiesDialog.title": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "<h1 [transloco]=\"'projects.title'\">Manage Projects</h1>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 4,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<p class=\"subtitle\" [transloco]=\"'projects.subtitle'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 5,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'projects.filterNameLabel'\">Filter by Name</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 25,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'projects.filterTeamLabel'\">Filter by Team</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 36,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'projects.filterStatusLabel'\">Filter by Status</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 68,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'projects.allStatuses' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 75,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'projects.clearFilters'\">Clear Filters</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 93,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-card-title [transloco]=\"'projects.listTitle'\">Projects</mat-card-title>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 102,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'projects.addButton'\">Add Project</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 111,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'projects.columns.name' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 130,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "projects.status.active": {
+    "ambiguous_word": false,
+    "confidence": "high",
+    "ellipsis_candidate": false,
+    "found_by": "fully-qualified",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "expect(component.getStatusLabel('active')).toBe('projects.status.active');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.spec.ts",
+        "line": 634
+      },
+      {
+        "classes": [],
+        "context": "expect(component.getStatusLabel('active')).toBe('projects.status.active');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.spec.ts",
+        "line": 212
+      }
+    ]
+  },
+  "projects.status.archived": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -39305,112 +39508,6 @@
         "context": "{{ 'projects.columns.modified' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
         "line": 164,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "projects.status.active": {
-    "ambiguous_word": false,
-    "confidence": "high",
-    "ellipsis_candidate": false,
-    "found_by": "fully-qualified",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "expect(component.getStatusLabel('active')).toBe('projects.status.active');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.spec.ts",
-        "line": 634
-      },
-      {
-        "classes": [],
-        "context": "expect(component.getStatusLabel('active')).toBe('projects.status.active');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.spec.ts",
-        "line": 212
-      }
-    ]
-  },
-  "projects.status.archived": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "<h2 mat-dialog-title [transloco]=\"'projects.createDialog.title'\">Create Project</h2>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 39,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[placeholder]=\"'projects.createDialog.namePlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-error [transloco]=\"'projects.createDialog.nameRequired'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 54,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[placeholder]=\"'projects.createDialog.descriptionPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 65,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-error [transloco]=\"'projects.createDialog.teamRequired'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 87,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[placeholder]=\"'projects.createDialog.uriPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 108,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[placeholder]=\"'projects.createDialog.statusPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 118,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<h2 mat-dialog-title [transloco]=\"'projects.relatedProjectsDialog.title'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 44,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<div class=\"no-items\">{{ 'projects.relatedProjectsDialog.noRelated' | transloco }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 50,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'projects.relatedProjectsDialog.addRelated'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 81,
         "partial_match": "medium"
       }
     ]
@@ -39558,23 +39655,23 @@
       },
       {
         "classes": [],
-        "context": "<h2 mat-dialog-title [transloco]=\"'projects.relatedProjectsDialog.title'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 44,
+        "context": "<mat-label [transloco]=\"'projects.picker.label'\">Project</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/project-picker/project-picker.component.ts",
+        "line": 43,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<div class=\"no-items\">{{ 'projects.relatedProjectsDialog.noRelated' | transloco }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 50,
+        "context": "<mat-option [value]=\"null\">{{ 'projects.picker.none' | transloco }}</mat-option>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/project-picker/project-picker.component.ts",
+        "line": 54,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<span [transloco]=\"'projects.relatedProjectsDialog.addRelated'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 81,
+        "context": "[matTooltip]=\"'projects.createNew' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/project-picker/project-picker.component.ts",
+        "line": 66,
         "partial_match": "medium"
       }
     ]
@@ -39591,72 +39688,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "<h2 mat-dialog-title [transloco]=\"'projects.createDialog.title'\">Create Project</h2>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 39,
+        "context": "<mat-label [transloco]=\"'projects.filterNameLabel'\">Filter by Name</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 23,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[placeholder]=\"'projects.createDialog.namePlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 48,
+        "context": "<mat-label [transloco]=\"'projects.filterTeamLabel'\">Filter by Team</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 34,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-error [transloco]=\"'projects.createDialog.nameRequired'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 54,
+        "context": "<mat-label [transloco]=\"'projects.filterStatusLabel'\">Filter by Status</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 66,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[placeholder]=\"'projects.createDialog.descriptionPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 65,
+        "context": "{{ 'projects.allStatuses' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 73,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-error [transloco]=\"'projects.createDialog.teamRequired'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 87,
+        "context": "<span [transloco]=\"'projects.clearFilters'\">Clear Filters</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 91,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[placeholder]=\"'projects.createDialog.uriPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 108,
+        "context": "<span [transloco]=\"'projects.addButton'\">Add Project</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 109,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[placeholder]=\"'projects.createDialog.statusPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 118,
+        "context": "{{ 'projects.columns.name' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 128,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<h2 mat-dialog-title [transloco]=\"'projects.relatedProjectsDialog.title'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 44,
+        "context": "{{ 'projects.columns.status' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 142,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<div class=\"no-items\">{{ 'projects.relatedProjectsDialog.noRelated' | transloco }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 50,
+        "context": "{{ 'projects.columns.team' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 155,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<span [transloco]=\"'projects.relatedProjectsDialog.addRelated'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 81,
+        "context": "{{ 'projects.columns.modified' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
+        "line": 164,
         "partial_match": "medium"
       }
     ]
@@ -39722,29 +39819,111 @@
       },
       {
         "classes": [],
-        "context": "<h2 mat-dialog-title [transloco]=\"'projects.relatedProjectsDialog.title'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 44,
+        "context": "<h1 [transloco]=\"'projects.title'\">Manage Projects</h1>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 4,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<div class=\"no-items\">{{ 'projects.relatedProjectsDialog.noRelated' | transloco }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 50,
+        "context": "<p class=\"subtitle\" [transloco]=\"'projects.subtitle'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 5,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<span [transloco]=\"'projects.relatedProjectsDialog.addRelated'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 81,
+        "context": "<mat-label [transloco]=\"'projects.filterNameLabel'\">Filter by Name</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 25,
         "partial_match": "medium"
       }
     ]
   },
   "projects.statusAll": {
     "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "<h2 mat-dialog-title [transloco]=\"'projects.createDialog.title'\">Create Project</h2>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 39,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'projects.createDialog.namePlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 48,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-error [transloco]=\"'projects.createDialog.nameRequired'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 54,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'projects.createDialog.descriptionPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 65,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-error [transloco]=\"'projects.createDialog.teamRequired'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 87,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'projects.createDialog.uriPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 108,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'projects.createDialog.statusPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 118,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<h1 [transloco]=\"'projects.title'\">Manage Projects</h1>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 4,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<p class=\"subtitle\" [transloco]=\"'projects.subtitle'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 5,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'projects.filterNameLabel'\">Filter by Name</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 25,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "projects.statusFilterLabel": {
+    "ambiguous_word": true,
     "confidence": "medium",
     "ellipsis_candidate": false,
     "found_by": "leaf",
@@ -39825,7 +40004,27 @@
       }
     ]
   },
-  "projects.statusFilterLabel": {
+  "projects.subtitle": {
+    "ambiguous_word": false,
+    "confidence": "high",
+    "ellipsis_candidate": false,
+    "found_by": "fully-qualified",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "description"
+    ],
+    "uses": [
+      {
+        "classes": [
+          "subtitle"
+        ],
+        "context": "<p class=\"subtitle\" [transloco]=\"'projects.subtitle'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
+        "line": 5
+      }
+    ]
+  },
+  "projects.teamFilterLabel": {
     "ambiguous_word": true,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -39886,125 +40085,23 @@
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'projects.picker.label'\">Project</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/project-picker/project-picker.component.ts",
-        "line": 43,
+        "context": "<h2 mat-dialog-title [transloco]=\"'projects.relatedProjectsDialog.title'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
+        "line": 44,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-option [value]=\"null\">{{ 'projects.picker.none' | transloco }}</mat-option>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/project-picker/project-picker.component.ts",
-        "line": 54,
+        "context": "<div class=\"no-items\">{{ 'projects.relatedProjectsDialog.noRelated' | transloco }}</div>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
+        "line": 50,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[matTooltip]=\"'projects.createNew' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/project-picker/project-picker.component.ts",
-        "line": 66,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "projects.subtitle": {
-    "ambiguous_word": false,
-    "confidence": "high",
-    "ellipsis_candidate": false,
-    "found_by": "fully-qualified",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "description"
-    ],
-    "uses": [
-      {
-        "classes": [
-          "subtitle"
-        ],
-        "context": "<p class=\"subtitle\" [transloco]=\"'projects.subtitle'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/projects/admin-projects.component.html",
-        "line": 5
-      }
-    ]
-  },
-  "projects.teamFilterLabel": {
-    "ambiguous_word": true,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "<mat-label [transloco]=\"'projects.filterNameLabel'\">Filter by Name</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 23,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label [transloco]=\"'projects.filterTeamLabel'\">Filter by Team</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 34,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label [transloco]=\"'projects.filterStatusLabel'\">Filter by Status</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 66,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'projects.allStatuses' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 73,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'projects.clearFilters'\">Clear Filters</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 91,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'projects.addButton'\">Add Project</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 109,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'projects.columns.name' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 128,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'projects.columns.status' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 142,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'projects.columns.team' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 155,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'projects.columns.modified' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/projects/projects.component.html",
-        "line": 164,
+        "context": "<span [transloco]=\"'projects.relatedProjectsDialog.addRelated'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
+        "line": 81,
         "partial_match": "medium"
       }
     ]
@@ -40617,20 +40714,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "SSVC: {{ 'ssvcCalculator.decisions.' + ssvc.decision | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 298,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'ssvcCalculator.openCalculator' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 314,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "nameKey: 'ssvcCalculator.exploitation.name',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
         "line": 101,
@@ -40683,6 +40766,20 @@
         "context": "descriptionKey: 'ssvcCalculator.exploitation.activeDesc',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
         "line": 117,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "nameKey: 'ssvcCalculator.utility.name',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 123,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "descriptionKey: 'ssvcCalculator.utility.description',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 124,
         "partial_match": "medium"
       }
     ]
@@ -40781,6 +40878,88 @@
     "uses": [
       {
         "classes": [],
+        "context": "SSVC: {{ 'ssvcCalculator.decisions.' + ssvc.decision | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 298,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'ssvcCalculator.openCalculator' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 314,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ t('ssvcCalculator.title') }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 4,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ t('ssvcCalculator.decisions.' + decision) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 7,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ t('ssvcCalculator.stepOf', { current: currentStep + 1, total: totalSteps }) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 43,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<h3 class=\"step-title\">{{ t('ssvcCalculator.summary') }}</h3>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 67,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<div class=\"decision-result-label\">{{ t('ssvcCalculator.decisionLabel') }}</div>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 85,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<div class=\"decision-result-value\">{{ t('ssvcCalculator.decisions.' + decision) }}</div>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 86,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ t('ssvcCalculator.decisions.' + decision + 'Desc') }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 88,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ t('ssvcCalculator.back') }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 99,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "ssvcCalculator.decisions.ImmediateDesc": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
         "context": "nameKey: 'ssvcCalculator.exploitation.name',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
         "line": 101,
@@ -40851,7 +41030,7 @@
       }
     ]
   },
-  "ssvcCalculator.decisions.ImmediateDesc": {
+  "ssvcCalculator.decisions.Out-of-Cycle": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -40929,88 +41108,6 @@
         "context": "descriptionKey: 'ssvcCalculator.exploitation.activeDesc',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
         "line": 117,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "ssvcCalculator.decisions.Out-of-Cycle": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "SSVC: {{ 'ssvcCalculator.decisions.' + ssvc.decision | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 298,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'ssvcCalculator.openCalculator' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 314,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ t('ssvcCalculator.title') }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 4,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ t('ssvcCalculator.decisions.' + decision) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 7,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ t('ssvcCalculator.stepOf', { current: currentStep + 1, total: totalSteps }) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 43,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<h3 class=\"step-title\">{{ t('ssvcCalculator.summary') }}</h3>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 67,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<div class=\"decision-result-label\">{{ t('ssvcCalculator.decisionLabel') }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 85,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<div class=\"decision-result-value\">{{ t('ssvcCalculator.decisions.' + decision) }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 86,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ t('ssvcCalculator.decisions.' + decision + 'Desc') }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 88,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ t('ssvcCalculator.back') }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 99,
         "partial_match": "medium"
       }
     ]
@@ -41041,6 +41138,88 @@
       },
       {
         "classes": [],
+        "context": "<span>{{ t('ssvcCalculator.title') }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 4,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ t('ssvcCalculator.decisions.' + decision) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 7,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ t('ssvcCalculator.stepOf', { current: currentStep + 1, total: totalSteps }) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 43,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<h3 class=\"step-title\">{{ t('ssvcCalculator.summary') }}</h3>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 67,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<div class=\"decision-result-label\">{{ t('ssvcCalculator.decisionLabel') }}</div>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 85,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<div class=\"decision-result-value\">{{ t('ssvcCalculator.decisions.' + decision) }}</div>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 86,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ t('ssvcCalculator.decisions.' + decision + 'Desc') }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 88,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ t('ssvcCalculator.back') }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 99,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "ssvcCalculator.decisions.Scheduled": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "SSVC: {{ 'ssvcCalculator.decisions.' + ssvc.decision | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 298,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'ssvcCalculator.openCalculator' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 314,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "nameKey: 'ssvcCalculator.exploitation.name',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
         "line": 101,
@@ -41097,88 +41276,6 @@
       }
     ]
   },
-  "ssvcCalculator.decisions.Scheduled": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "SSVC: {{ 'ssvcCalculator.decisions.' + ssvc.decision | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 298,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'ssvcCalculator.openCalculator' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 314,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span>{{ t('ssvcCalculator.title') }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 4,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ t('ssvcCalculator.decisions.' + decision) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 7,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ t('ssvcCalculator.stepOf', { current: currentStep + 1, total: totalSteps }) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 43,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<h3 class=\"step-title\">{{ t('ssvcCalculator.summary') }}</h3>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 67,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<div class=\"decision-result-label\">{{ t('ssvcCalculator.decisionLabel') }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 85,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<div class=\"decision-result-value\">{{ t('ssvcCalculator.decisions.' + decision) }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 86,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ t('ssvcCalculator.decisions.' + decision + 'Desc') }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 88,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ t('ssvcCalculator.back') }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 99,
-        "partial_match": "medium"
-      }
-    ]
-  },
   "ssvcCalculator.decisions.ScheduledDesc": {
     "ambiguous_word": false,
     "confidence": "medium",
@@ -41191,72 +41288,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "SSVC: {{ 'ssvcCalculator.decisions.' + ssvc.decision | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 298,
+        "context": "nameKey: 'ssvcCalculator.exploitation.name',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 101,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'ssvcCalculator.openCalculator' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 314,
+        "context": "descriptionKey: 'ssvcCalculator.exploitation.description',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 102,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<span>{{ t('ssvcCalculator.title') }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 4,
+        "context": "nameKey: 'ssvcCalculator.exploitation.none',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 106,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ t('ssvcCalculator.decisions.' + decision) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 7,
+        "context": "descriptionKey: 'ssvcCalculator.exploitation.noneDesc',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 107,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ t('ssvcCalculator.stepOf', { current: currentStep + 1, total: totalSteps }) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 43,
+        "context": "nameKey: 'ssvcCalculator.exploitation.poc',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 111,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<h3 class=\"step-title\">{{ t('ssvcCalculator.summary') }}</h3>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 67,
+        "context": "descriptionKey: 'ssvcCalculator.exploitation.pocDesc',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 112,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<div class=\"decision-result-label\">{{ t('ssvcCalculator.decisionLabel') }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 85,
+        "context": "nameKey: 'ssvcCalculator.exploitation.active',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 116,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<div class=\"decision-result-value\">{{ t('ssvcCalculator.decisions.' + decision) }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 86,
+        "context": "descriptionKey: 'ssvcCalculator.exploitation.activeDesc',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 117,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ t('ssvcCalculator.decisions.' + decision + 'Desc') }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 88,
+        "context": "nameKey: 'ssvcCalculator.utility.name',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 123,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ t('ssvcCalculator.back') }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 99,
+        "context": "descriptionKey: 'ssvcCalculator.utility.description',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 124,
         "partial_match": "medium"
       }
     ]
@@ -41417,72 +41514,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "SSVC: {{ 'ssvcCalculator.decisions.' + ssvc.decision | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 298,
+        "context": "nameKey: 'ssvcCalculator.exploitation.name',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 101,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'ssvcCalculator.openCalculator' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 314,
+        "context": "descriptionKey: 'ssvcCalculator.exploitation.description',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 102,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<span>{{ t('ssvcCalculator.title') }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 4,
+        "context": "nameKey: 'ssvcCalculator.exploitation.none',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 106,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ t('ssvcCalculator.decisions.' + decision) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 7,
+        "context": "descriptionKey: 'ssvcCalculator.exploitation.noneDesc',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 107,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ t('ssvcCalculator.stepOf', { current: currentStep + 1, total: totalSteps }) }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 43,
+        "context": "nameKey: 'ssvcCalculator.exploitation.poc',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 111,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<h3 class=\"step-title\">{{ t('ssvcCalculator.summary') }}</h3>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 67,
+        "context": "descriptionKey: 'ssvcCalculator.exploitation.pocDesc',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 112,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<div class=\"decision-result-label\">{{ t('ssvcCalculator.decisionLabel') }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 85,
+        "context": "nameKey: 'ssvcCalculator.exploitation.active',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 116,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<div class=\"decision-result-value\">{{ t('ssvcCalculator.decisions.' + decision) }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 86,
+        "context": "descriptionKey: 'ssvcCalculator.exploitation.activeDesc',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 117,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ t('ssvcCalculator.decisions.' + decision + 'Desc') }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 88,
+        "context": "nameKey: 'ssvcCalculator.utility.name',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 123,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ t('ssvcCalculator.back') }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
-        "line": 99,
+        "context": "descriptionKey: 'ssvcCalculator.utility.description',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
+        "line": 124,
         "partial_match": "medium"
       }
     ]
@@ -41951,72 +42048,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "nameKey: 'ssvcCalculator.exploitation.name',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
-        "line": 101,
+        "context": "SSVC: {{ 'ssvcCalculator.decisions.' + ssvc.decision | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 298,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "descriptionKey: 'ssvcCalculator.exploitation.description',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
-        "line": 102,
+        "context": "{{ 'ssvcCalculator.openCalculator' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 314,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "nameKey: 'ssvcCalculator.exploitation.none',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
-        "line": 106,
+        "context": "<span>{{ t('ssvcCalculator.title') }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 4,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "descriptionKey: 'ssvcCalculator.exploitation.noneDesc',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
-        "line": 107,
+        "context": "{{ t('ssvcCalculator.decisions.' + decision) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 7,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "nameKey: 'ssvcCalculator.exploitation.poc',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
-        "line": 111,
+        "context": "{{ t('ssvcCalculator.stepOf', { current: currentStep + 1, total: totalSteps }) }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 43,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "descriptionKey: 'ssvcCalculator.exploitation.pocDesc',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
-        "line": 112,
+        "context": "<h3 class=\"step-title\">{{ t('ssvcCalculator.summary') }}</h3>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 67,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "nameKey: 'ssvcCalculator.exploitation.active',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
-        "line": 116,
+        "context": "<div class=\"decision-result-label\">{{ t('ssvcCalculator.decisionLabel') }}</div>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 85,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "descriptionKey: 'ssvcCalculator.exploitation.activeDesc',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
-        "line": 117,
+        "context": "<div class=\"decision-result-value\">{{ t('ssvcCalculator.decisions.' + decision) }}</div>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 86,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "nameKey: 'ssvcCalculator.utility.name',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
-        "line": 123,
+        "context": "{{ t('ssvcCalculator.decisions.' + decision + 'Desc') }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 88,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "descriptionKey: 'ssvcCalculator.utility.description',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-decision-tree.ts",
-        "line": 124,
+        "context": "{{ t('ssvcCalculator.back') }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/ssvc-calculator-dialog/ssvc-calculator-dialog.component.html",
+        "line": 99,
         "partial_match": "medium"
       }
     ]
@@ -42589,13 +42686,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "{{ 'surveys.status.' + getStatusKey(response.status) | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
-        "line": 264,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "<h1 class=\"page-title\">{{ 'surveys.responses.pageTitle' | transloco }}</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
         "line": 3,
@@ -42655,6 +42745,13 @@
         "context": "[matTooltip]=\"'surveys.responses.continueEditing' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
         "line": 128,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'surveys.list.deleteDraft' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/surveys/components/my-responses/my-responses.component.html",
+        "line": 148,
         "partial_match": "medium"
       }
     ]
@@ -43824,15 +43921,15 @@
       },
       {
         "classes": [],
-        "context": "{ value: 'review_created', labelKey: 'surveys.status.reviewCreated' },",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.ts",
-        "line": 105
-      },
-      {
-        "classes": [],
         "context": "{ key: 'review_created', labelKey: 'surveys.status.reviewCreated' },",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.ts",
         "line": 355
+      },
+      {
+        "classes": [],
+        "context": "{ value: 'review_created', labelKey: 'surveys.status.reviewCreated' },",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.ts",
+        "line": 105
       }
     ]
   },
@@ -44354,72 +44451,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "<h2 mat-dialog-title [transloco]=\"'teams.relatedTeamsDialog.title'\">Manage Related Teams</h2>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
-        "line": 49,
+        "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
+        "line": 609,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<div class=\"no-items\">{{ 'teams.relatedTeamsDialog.noRelated' | transloco }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
-        "line": 53,
+        "context": "expect(component.getStatusLabel('archived')).toBe('teams.status.archived');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
+        "line": 613,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'teams.relationships.' + related.relationship | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
-        "line": 62,
+        "context": "<mat-label [transloco]=\"'teams.filterLabel'\">Filter Teams</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 24,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<span [transloco]=\"'teams.relatedTeamsDialog.addRelated'\">Add Related Team</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
-        "line": 84,
+        "context": "<span [transloco]=\"'teams.addButton'\">Add Team</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 47,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'teams.relatedTeamsDialog.selectTeam'\">Select Team</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
-        "line": 92,
+        "context": "{{ 'teams.columns.name' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 66,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'teams.relatedTeamsDialog.relationship'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
+        "context": "{{ 'teams.columns.status' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 80,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.members' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 93,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.projects' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 102,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.modified' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 111,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'teams.relationships.' + type | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
-        "line": 120,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label [transloco]=\"'teams.relatedTeamsDialog.customRelationship'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
-        "line": 128,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'teams.createNew' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 96,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<h2 mat-dialog-title [transloco]=\"'teams.editDialog.title'\">Edit Team</h2>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
-        "line": 64,
+        "context": "[matTooltip]=\"'teams.kebab.members' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 136,
         "partial_match": "medium"
       }
     ]
@@ -44490,13 +44587,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "[matTooltip]=\"'teams.createNew' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 96,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
         "line": 609,
@@ -44556,6 +44646,13 @@
         "context": "{{ 'teams.columns.modified' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 111,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'teams.kebab.members' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 136,
         "partial_match": "medium"
       }
     ]
@@ -44608,13 +44705,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "[matTooltip]=\"'teams.createNew' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 96,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
         "line": 609,
@@ -44674,6 +44764,13 @@
         "context": "{{ 'teams.columns.modified' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 111,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'teams.kebab.members' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 136,
         "partial_match": "medium"
       }
     ]
@@ -44960,6 +45057,13 @@
     "uses": [
       {
         "classes": [],
+        "context": "[matTooltip]=\"'teams.createNew' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 96,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
         "line": 609,
@@ -45019,13 +45123,6 @@
         "context": "{{ 'teams.columns.modified' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 111,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'teams.kebab.members' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 136,
         "partial_match": "medium"
       }
     ]
@@ -45168,72 +45265,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "[matTooltip]=\"'teams.createNew' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 96,
+        "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
+        "line": 609,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "const message = this.translocoService.translate('teams.deleteDialog.message', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.ts",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "const warning = this.translocoService.translate('teams.deleteDialog.projectWarning', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.ts",
-        "line": 59,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<h1 [transloco]=\"'teams.title'\">Manage Teams</h1>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
-        "line": 4,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<p class=\"subtitle\" [transloco]=\"'teams.subtitle'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
-        "line": 5,
+        "context": "expect(component.getStatusLabel('archived')).toBe('teams.status.archived');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
+        "line": 613,
         "partial_match": "medium"
       },
       {
         "classes": [],
         "context": "<mat-label [transloco]=\"'teams.filterLabel'\">Filter Teams</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 24,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-card-title [transloco]=\"'teams.listTitle'\">Teams</mat-card-title>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
-        "line": 38,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "<span [transloco]=\"'teams.addButton'\">Add Team</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 47,
         "partial_match": "medium"
       },
       {
         "classes": [],
         "context": "{{ 'teams.columns.name' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 66,
         "partial_match": "medium"
       },
       {
         "classes": [],
         "context": "{{ 'teams.columns.status' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
-        "line": 75,
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 80,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.members' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 93,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.projects' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 102,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.modified' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 111,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'teams.kebab.members' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 136,
         "partial_match": "medium"
       }
     ]
@@ -45275,6 +45372,88 @@
     ]
   },
   "teams.relationships.child": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
+        "line": 609,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(component.getStatusLabel('archived')).toBe('teams.status.archived');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
+        "line": 613,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'teams.createNew' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 96,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'teams.filterLabel'\">Filter Teams</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 24,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'teams.addButton'\">Add Team</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 47,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.name' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 66,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.status' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 80,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.members' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 93,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.projects' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 102,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.modified' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 111,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "teams.relationships.dependency": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -45356,88 +45535,6 @@
       }
     ]
   },
-  "teams.relationships.dependency": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "const message = this.translocoService.translate('teams.deleteDialog.message', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.ts",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "const warning = this.translocoService.translate('teams.deleteDialog.projectWarning', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.ts",
-        "line": 59,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<h1 [transloco]=\"'teams.title'\">Manage Teams</h1>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
-        "line": 4,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<p class=\"subtitle\" [transloco]=\"'teams.subtitle'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
-        "line": 5,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label [transloco]=\"'teams.filterLabel'\">Filter Teams</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
-        "line": 24,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-card-title [transloco]=\"'teams.listTitle'\">Teams</mat-card-title>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
-        "line": 38,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'teams.addButton'\">Add Team</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
-        "line": 47,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.columns.name' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
-        "line": 66,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.columns.status' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
-        "line": 75,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.columns.members' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
-        "line": 88,
-        "partial_match": "medium"
-      }
-    ]
-  },
   "teams.relationships.dependent": {
     "ambiguous_word": false,
     "confidence": "medium",
@@ -45448,41 +45545,6 @@
       "general"
     ],
     "uses": [
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'teams.createNew' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 96,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<h2 mat-dialog-title [transloco]=\"'teams.editDialog.title'\">Edit Team</h2>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
-        "line": 64,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[label]=\"'teams.editDialog.detailsTab' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
-        "line": 73,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.status.' + status | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
-        "line": 135,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'teams.editDialog.save'\">Save</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/edit-team-dialog/edit-team-dialog.component.ts",
-        "line": 250,
-        "partial_match": "medium"
-      },
       {
         "classes": [],
         "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
@@ -45499,23 +45561,58 @@
       },
       {
         "classes": [],
-        "context": "{{ 'teams.relationships.' + related.relationship | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 59,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.relationships.' + type | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
-        "line": 121,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "<mat-label [transloco]=\"'teams.filterLabel'\">Filter Teams</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 24,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'teams.addButton'\">Add Team</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 47,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.name' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 66,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.status' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 80,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.members' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 93,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.projects' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 102,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.modified' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 111,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'teams.kebab.members' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 136,
         "partial_match": "medium"
       }
     ]
@@ -45532,20 +45629,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "const message = this.translocoService.translate('teams.deleteDialog.message', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.ts",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "const warning = this.translocoService.translate('teams.deleteDialog.projectWarning', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.ts",
-        "line": 59,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
         "line": 609,
@@ -45560,44 +45643,58 @@
       },
       {
         "classes": [],
-        "context": "<h1 [transloco]=\"'teams.title'\">Manage Teams</h1>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
-        "line": 4,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<p class=\"subtitle\" [transloco]=\"'teams.subtitle'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
-        "line": 5,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "<mat-label [transloco]=\"'teams.filterLabel'\">Filter Teams</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 24,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-card-title [transloco]=\"'teams.listTitle'\">Teams</mat-card-title>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
-        "line": 38,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "<span [transloco]=\"'teams.addButton'\">Add Team</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 47,
         "partial_match": "medium"
       },
       {
         "classes": [],
         "context": "{{ 'teams.columns.name' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/admin/teams/admin-teams.component.html",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 66,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.status' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 80,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.members' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 93,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.projects' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 102,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.modified' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 111,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'teams.kebab.members' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 136,
         "partial_match": "medium"
       }
     ]
@@ -45696,72 +45793,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
-        "line": 609,
+        "context": "[matTooltip]=\"'teams.createNew' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 96,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "expect(component.getStatusLabel('archived')).toBe('teams.status.archived');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
-        "line": 613,
+        "context": "<h2 mat-dialog-title [transloco]=\"'teams.createDialog.title'\">Create Team</h2>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
+        "line": 32,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-label [transloco]=\"'teams.filterLabel'\">Filter Teams</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 24,
+        "context": "[placeholder]=\"'teams.createDialog.namePlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
+        "line": 41,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<span [transloco]=\"'teams.addButton'\">Add Team</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "context": "<mat-error [transloco]=\"'teams.createDialog.nameRequired'\">",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
         "line": 47,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'teams.columns.name' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "context": "[placeholder]=\"'teams.createDialog.descriptionPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
+        "line": 58,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'teams.createDialog.emailAddress'\">Email Address</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
         "line": 66,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'teams.columns.status' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 80,
+        "context": "[placeholder]=\"'teams.createDialog.emailPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
+        "line": 71,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'teams.columns.members' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 93,
+        "context": "[placeholder]=\"'teams.createDialog.uriPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
+        "line": 87,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'teams.columns.projects' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 102,
+        "context": "{{ 'teams.status.' + status | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-team-dialog/create-team-dialog.component.ts",
+        "line": 98,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'teams.columns.modified' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 111,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'teams.kebab.members' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 136,
+        "context": "<mat-label [transloco]=\"'teams.membersDialog.role'\">Role</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/user-picker-dialog/user-picker-dialog.component.ts",
+        "line": 123,
         "partial_match": "medium"
       }
     ]
@@ -45949,6 +46046,20 @@
       },
       {
         "classes": [],
+        "context": "{{ 'teams.relationships.' + related.relationship | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
+        "line": 59,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.relationships.' + type | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.ts",
+        "line": 121,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
         "line": 609,
@@ -45994,20 +46105,6 @@
         "context": "{{ 'teams.columns.members' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 93,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.columns.projects' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 102,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.columns.modified' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 111,
         "partial_match": "medium"
       }
     ]
@@ -46120,6 +46217,13 @@
       },
       {
         "classes": [],
+        "context": "[matTooltip]=\"'teams.createNew' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 96,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "<mat-label [transloco]=\"'teams.filterLabel'\">Filter Teams</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 24,
@@ -46165,13 +46269,6 @@
         "context": "{{ 'teams.columns.modified' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 111,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'teams.kebab.members' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 136,
         "partial_match": "medium"
       }
     ]
@@ -46270,88 +46367,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "[matTooltip]=\"'teams.createNew' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 96,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
-        "line": 609,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(component.getStatusLabel('archived')).toBe('teams.status.archived');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
-        "line": 613,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label [transloco]=\"'teams.filterLabel'\">Filter Teams</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 24,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'teams.addButton'\">Add Team</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 47,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.columns.name' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 66,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.columns.status' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 80,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.columns.members' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 93,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.columns.projects' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 102,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.columns.modified' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 111,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "teams.roles.engineer": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
         "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
         "line": 609,
@@ -46418,6 +46433,88 @@
         "context": "[matTooltip]=\"'teams.kebab.members' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 136,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "teams.roles.engineer": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
+        "line": 609,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(component.getStatusLabel('archived')).toBe('teams.status.archived');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
+        "line": 613,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'teams.createNew' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 96,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'teams.filterLabel'\">Filter Teams</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 24,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'teams.addButton'\">Add Team</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 47,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.name' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 66,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.status' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 80,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.members' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 93,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.projects' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 102,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.modified' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 111,
         "partial_match": "medium"
       }
     ]
@@ -46516,11 +46613,86 @@
     "uses": [
       {
         "classes": [],
-        "context": "[matTooltip]=\"'teams.createNew' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 96,
+        "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
+        "line": 609,
         "partial_match": "medium"
       },
+      {
+        "classes": [],
+        "context": "expect(component.getStatusLabel('archived')).toBe('teams.status.archived');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
+        "line": 613,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'teams.filterLabel'\">Filter Teams</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 24,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'teams.addButton'\">Add Team</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 47,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.name' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 66,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.status' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 80,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.members' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 93,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.projects' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 102,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.modified' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 111,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'teams.kebab.members' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 136,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "teams.roles.product_manager": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
       {
         "classes": [],
         "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
@@ -46583,87 +46755,12 @@
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 111,
         "partial_match": "medium"
-      }
-    ]
-  },
-  "teams.roles.product_manager": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
-        "line": 609,
-        "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "expect(component.getStatusLabel('archived')).toBe('teams.status.archived');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
-        "line": 613,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'teams.createNew' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 96,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<h2 mat-dialog-title [transloco]=\"'teams.relatedTeamsDialog.title'\">Manage Related Teams</h2>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
-        "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<div class=\"no-items\">{{ 'teams.relatedTeamsDialog.noRelated' | transloco }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.relationships.' + related.relationship | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
-        "line": 62,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'teams.relatedTeamsDialog.addRelated'\">Add Related Team</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
-        "line": 84,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label [transloco]=\"'teams.relatedTeamsDialog.selectTeam'\">Select Team</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
-        "line": 92,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label [transloco]=\"'teams.relatedTeamsDialog.relationship'\">",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
-        "line": 111,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.relationships.' + type | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.ts",
-        "line": 120,
+        "context": "[matTooltip]=\"'teams.kebab.members' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 136,
         "partial_match": "medium"
       }
     ]
@@ -46798,6 +46895,13 @@
     "uses": [
       {
         "classes": [],
+        "context": "[matTooltip]=\"'teams.createNew' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
+        "line": 96,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
         "line": 609,
@@ -46857,13 +46961,6 @@
         "context": "{{ 'teams.columns.modified' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 111,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'teams.kebab.members' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 136,
         "partial_match": "medium"
       }
     ]
@@ -46962,13 +47059,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "[matTooltip]=\"'teams.createNew' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 96,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
         "line": 609,
@@ -47028,93 +47118,18 @@
         "context": "{{ 'teams.columns.modified' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
         "line": 111,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'teams.kebab.members' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 136,
         "partial_match": "medium"
       }
     ]
   },
   "teams.status.splitting": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
-        "line": 609,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(component.getStatusLabel('archived')).toBe('teams.status.archived');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
-        "line": 613,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'teams.createNew' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/components/create-project-dialog/create-project-dialog.component.ts",
-        "line": 96,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label [transloco]=\"'teams.filterLabel'\">Filter Teams</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 24,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'teams.addButton'\">Add Team</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 47,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.columns.name' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 66,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.columns.status' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 80,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.columns.members' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 93,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.columns.projects' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 102,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'teams.columns.modified' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
-        "line": 111,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "teams.status.winding_down": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -47196,6 +47211,88 @@
       }
     ]
   },
+  "teams.status.winding_down": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "expect(component.getStatusLabel('active')).toBe('teams.status.active');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
+        "line": 609,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(component.getStatusLabel('archived')).toBe('teams.status.archived');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.spec.ts",
+        "line": 613,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label [transloco]=\"'teams.filterLabel'\">Filter Teams</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 24,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'teams.addButton'\">Add Team</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 47,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.name' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 66,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.status' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 80,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.members' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 93,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.projects' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 102,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'teams.columns.modified' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 111,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'teams.kebab.members' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/teams/teams.component.html",
+        "line": 136,
+        "partial_match": "medium"
+      }
+    ]
+  },
   "teams.subtitle": {
     "ambiguous_word": false,
     "confidence": "high",
@@ -47254,150 +47351,6 @@
   },
   "threatEditor.addCvssEntry": {
     "ambiguous_word": true,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "expect(getFieldKeysForFieldType('threatEditor.threatSeverity')).toHaveLength(6);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 110,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(getFieldKeysForFieldType('threatEditor.threatStatus')).toHaveLength(10);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 114,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(getFieldKeysForFieldType('threatEditor.threatPriority')).toHaveLength(5);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 118,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "const keys = getFieldKeysForFieldType('threatEditor.threatSeverity');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 130,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "migrateFieldValue(null, 'threatEditor.threatSeverity', mockTranslocoService as never),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 138,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "migrateFieldValue(undefined, 'threatEditor.threatSeverity', mockTranslocoService as never),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 144,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "migrateFieldValue('', 'threatEditor.threatSeverity', mockTranslocoService as never),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 150,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "migrateFieldValue('high', 'threatEditor.threatSeverity', mockTranslocoService as never),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 156,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'threatEditor.threatStatus',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 161,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "migrateFieldValue('0', 'threatEditor.threatSeverity', mockTranslocoService as never),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 169,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "threatEditor.addMapping": {
-    "ambiguous_word": true,
-    "confidence": "high",
-    "ellipsis_candidate": true,
-    "found_by": "fully-qualified",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "button"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "{{ 'threatEditor.addMapping' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 350
-      }
-    ]
-  },
-  "threatEditor.createNewThreat": {
-    "ambiguous_word": false,
-    "confidence": "high",
-    "ellipsis_candidate": false,
-    "found_by": "fully-qualified",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "expect(component.dialogTitle).toBe('threatEditor.createNewThreat');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.spec.ts",
-        "line": 138
-      },
-      {
-        "classes": [],
-        "context": "this.dialogTitle = 'threatEditor.createNewThreat';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.ts",
-        "line": 378
-      }
-    ]
-  },
-  "threatEditor.cvss": {
-    "ambiguous_word": false,
-    "confidence": "high",
-    "ellipsis_candidate": false,
-    "found_by": "fully-qualified",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [
-          "mapping-label"
-        ],
-        "context": "<span class=\"mapping-label\">{{ 'threatEditor.cvss' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 397
-      }
-    ]
-  },
-  "threatEditor.cvssVector": {
-    "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
     "found_by": "leaf",
@@ -47478,6 +47431,150 @@
       }
     ]
   },
+  "threatEditor.addMapping": {
+    "ambiguous_word": true,
+    "confidence": "high",
+    "ellipsis_candidate": true,
+    "found_by": "fully-qualified",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "button"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "{{ 'threatEditor.addMapping' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 350
+      }
+    ]
+  },
+  "threatEditor.createNewThreat": {
+    "ambiguous_word": false,
+    "confidence": "high",
+    "ellipsis_candidate": false,
+    "found_by": "fully-qualified",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "expect(component.dialogTitle).toBe('threatEditor.createNewThreat');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.spec.ts",
+        "line": 138
+      },
+      {
+        "classes": [],
+        "context": "this.dialogTitle = 'threatEditor.createNewThreat';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.ts",
+        "line": 378
+      }
+    ]
+  },
+  "threatEditor.cvss": {
+    "ambiguous_word": false,
+    "confidence": "high",
+    "ellipsis_candidate": false,
+    "found_by": "fully-qualified",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [
+          "mapping-label"
+        ],
+        "context": "<span class=\"mapping-label\">{{ 'threatEditor.cvss' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
+        "line": 397
+      }
+    ]
+  },
+  "threatEditor.cvssVector": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "expect(getFieldKeysForFieldType('threatEditor.threatSeverity')).toHaveLength(6);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 110,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(getFieldKeysForFieldType('threatEditor.threatStatus')).toHaveLength(10);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 114,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(getFieldKeysForFieldType('threatEditor.threatPriority')).toHaveLength(5);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 118,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "const keys = getFieldKeysForFieldType('threatEditor.threatSeverity');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 130,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "migrateFieldValue(null, 'threatEditor.threatSeverity', mockTranslocoService as never),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 138,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "migrateFieldValue(undefined, 'threatEditor.threatSeverity', mockTranslocoService as never),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 144,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "migrateFieldValue('', 'threatEditor.threatSeverity', mockTranslocoService as never),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 150,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "migrateFieldValue('high', 'threatEditor.threatSeverity', mockTranslocoService as never),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 156,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'threatEditor.threatStatus',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 161,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "migrateFieldValue('0', 'threatEditor.threatSeverity', mockTranslocoService as never),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 169,
+        "partial_match": "medium"
+      }
+    ]
+  },
   "threatEditor.cvssVectorPlaceholder": {
     "ambiguous_word": false,
     "confidence": "medium",
@@ -47511,6 +47608,34 @@
       },
       {
         "classes": [],
+        "context": "private readonly severityKeys = getFieldKeysForFieldType('threatEditor.threatSeverity');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 87,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "private readonly threatStatusKeys = getFieldKeysForFieldType('threatEditor.threatStatus');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 88,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "? (migrateFieldValue(severity, 'threatEditor.threatSeverity', this.transloco) ?? 'unknown')",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 290,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "const priorityKeys = getFieldKeysForFieldType('threatEditor.threatPriority');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 321,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "| 'threatEditor.threatStatus'",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 9,
@@ -47528,34 +47653,6 @@
         "context": "| 'threatEditor.threatPriority';",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 11,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 42,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 55,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 57,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "* @param keyPrefix The translation key prefix (e.g., 'threatEditor.threatSeverity')",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 68,
         "partial_match": "medium"
       }
     ]
@@ -47654,55 +47751,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "value: getFieldLabel(threat.severity, 'threatEditor.threatSeverity', transloco),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 588,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "value: getFieldLabel(threat.status, 'threatEditor.threatStatus', transloco),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 600,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "value: getFieldLabel(threat.priority, 'threatEditor.threatPriority', transloco),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 606,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "private readonly severityKeys = getFieldKeysForFieldType('threatEditor.threatSeverity');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
-        "line": 87,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "private readonly threatStatusKeys = getFieldKeysForFieldType('threatEditor.threatStatus');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
-        "line": 88,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "? (migrateFieldValue(severity, 'threatEditor.threatSeverity', this.transloco) ?? 'unknown')",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
-        "line": 290,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "const priorityKeys = getFieldKeysForFieldType('threatEditor.threatPriority');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
-        "line": 321,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "| 'threatEditor.threatStatus'",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 9,
@@ -47720,6 +47768,55 @@
         "context": "| 'threatEditor.threatPriority';",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 11,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatEditor.threatStatus':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 42,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatEditor.threatSeverity':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 55,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatEditor.threatPriority':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 57,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "* @param keyPrefix The translation key prefix (e.g., 'threatEditor.threatSeverity')",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 68,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatEditor.threatStatus':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 213,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatEditor.threatSeverity':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 214,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatEditor.threatPriority':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 215,
         "partial_match": "medium"
       }
     ]
@@ -47885,12 +47982,6 @@
       {
         "classes": [],
         "context": "name: this.translocoService.translate('threatEditor.notAssociatedWithAsset'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.ts",
-        "line": 422
-      },
-      {
-        "classes": [],
-        "context": "name: this.translocoService.translate('threatEditor.notAssociatedWithAsset'),",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.ts",
         "line": 264
       },
@@ -47899,6 +47990,12 @@
         "context": "'threatEditor.notAssociatedWithAsset',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-editor-dialog/threat-editor-dialog.component.ts",
         "line": 652
+      },
+      {
+        "classes": [],
+        "context": "name: this.translocoService.translate('threatEditor.notAssociatedWithAsset'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.ts",
+        "line": 422
       }
     ]
   },
@@ -48146,6 +48243,62 @@
     "uses": [
       {
         "classes": [],
+        "context": "return getFieldLabel(severity, 'threatEditor.threatSeverity', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 426,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "return getFieldLabel(status, 'threatEditor.threatStatus', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 432,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.threatSeverityOptions = getFieldOptions('threatEditor.threatSeverity', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 447,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.threatStatusOptions = getFieldOptions('threatEditor.threatStatus', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 448,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.threatPriorityOptions = getFieldOptions('threatEditor.threatPriority', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 449,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.threatSeverityOptions = getFieldOptions('threatEditor.threatSeverity', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 507,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.threatStatusOptions = getFieldOptions('threatEditor.threatStatus', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 508,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.threatPriorityOptions = getFieldOptions('threatEditor.threatPriority', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 509,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "| 'threatEditor.threatStatus'",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 9,
@@ -48156,62 +48309,6 @@
         "context": "| 'threatEditor.threatSeverity'",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 10,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "| 'threatEditor.threatPriority';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 11,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 42,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 55,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 57,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "* @param keyPrefix The translation key prefix (e.g., 'threatEditor.threatSeverity')",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 68,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 213,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 214,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 215,
         "partial_match": "medium"
       }
     ]
@@ -48310,72 +48407,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "| 'threatEditor.threatStatus'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 9,
+        "context": "return getFieldLabel(severity, 'threatEditor.threatSeverity', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 426,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "| 'threatEditor.threatSeverity'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 10,
+        "context": "return getFieldLabel(status, 'threatEditor.threatStatus', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 432,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "| 'threatEditor.threatPriority';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 11,
+        "context": "this.threatSeverityOptions = getFieldOptions('threatEditor.threatSeverity', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 447,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 42,
+        "context": "this.threatStatusOptions = getFieldOptions('threatEditor.threatStatus', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 448,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 55,
+        "context": "this.threatPriorityOptions = getFieldOptions('threatEditor.threatPriority', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 449,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 57,
+        "context": "this.threatSeverityOptions = getFieldOptions('threatEditor.threatSeverity', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 507,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "* @param keyPrefix The translation key prefix (e.g., 'threatEditor.threatSeverity')",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 68,
+        "context": "this.threatStatusOptions = getFieldOptions('threatEditor.threatStatus', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 508,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 213,
+        "context": "this.threatPriorityOptions = getFieldOptions('threatEditor.threatPriority', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 509,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 214,
+        "context": "// 'threatEditor.threatSeverity.high'; the identity-mock transloco",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.spec.ts",
+        "line": 106,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 215,
+        "context": "expect(component.getSeverityLabel('high')).toBe('threatEditor.threatSeverity.high');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.spec.ts",
+        "line": 108,
         "partial_match": "medium"
       }
     ]
@@ -48392,6 +48489,55 @@
     "uses": [
       {
         "classes": [],
+        "context": "value: getFieldLabel(threat.severity, 'threatEditor.threatSeverity', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 588,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "value: getFieldLabel(threat.status, 'threatEditor.threatStatus', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 600,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "value: getFieldLabel(threat.priority, 'threatEditor.threatPriority', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 606,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "private readonly severityKeys = getFieldKeysForFieldType('threatEditor.threatSeverity');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 87,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "private readonly threatStatusKeys = getFieldKeysForFieldType('threatEditor.threatStatus');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 88,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "? (migrateFieldValue(severity, 'threatEditor.threatSeverity', this.transloco) ?? 'unknown')",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 290,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "const priorityKeys = getFieldKeysForFieldType('threatEditor.threatPriority');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 321,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "| 'threatEditor.threatStatus'",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 9,
@@ -48409,55 +48555,6 @@
         "context": "| 'threatEditor.threatPriority';",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 11,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 42,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 55,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 57,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "* @param keyPrefix The translation key prefix (e.g., 'threatEditor.threatSeverity')",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 68,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 213,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 214,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 215,
         "partial_match": "medium"
       }
     ]
@@ -48638,72 +48735,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "| 'threatEditor.threatStatus'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 9,
+        "context": "return getFieldLabel(severity, 'threatEditor.threatSeverity', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 426,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "| 'threatEditor.threatSeverity'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 10,
+        "context": "return getFieldLabel(status, 'threatEditor.threatStatus', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 432,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "| 'threatEditor.threatPriority';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 11,
+        "context": "this.threatSeverityOptions = getFieldOptions('threatEditor.threatSeverity', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 447,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 42,
+        "context": "this.threatStatusOptions = getFieldOptions('threatEditor.threatStatus', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 448,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 55,
+        "context": "this.threatPriorityOptions = getFieldOptions('threatEditor.threatPriority', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 449,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 57,
+        "context": "this.threatSeverityOptions = getFieldOptions('threatEditor.threatSeverity', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 507,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "* @param keyPrefix The translation key prefix (e.g., 'threatEditor.threatSeverity')",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 68,
+        "context": "this.threatStatusOptions = getFieldOptions('threatEditor.threatStatus', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 508,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 213,
+        "context": "this.threatPriorityOptions = getFieldOptions('threatEditor.threatPriority', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 509,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 214,
+        "context": "private readonly severityKeys = getFieldKeysForFieldType('threatEditor.threatSeverity');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 87,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 215,
+        "context": "private readonly threatStatusKeys = getFieldKeysForFieldType('threatEditor.threatStatus');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 88,
         "partial_match": "medium"
       }
     ]
@@ -48802,72 +48899,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "'threatEditor.sections.tracking' | transloco",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 83,
+        "context": "| 'threatEditor.threatStatus'",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 9,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[placeholder]=\"'threatEditor.issueUriPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 103,
+        "context": "| 'threatEditor.threatSeverity'",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 10,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-hint>{{ 'threatEditor.issueUriHint' | transloco }}</mat-hint>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 105,
+        "context": "| 'threatEditor.threatPriority';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 11,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "'threatEditor.threatStatus.' + option.key + '.description' | transloco",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 136,
+        "context": "case 'threatEditor.threatStatus':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 42,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'threatEditor.threatStatus.' + option.key | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 139,
+        "context": "case 'threatEditor.threatSeverity':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 55,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "'threatEditor.sections.description' | transloco",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 178,
+        "context": "case 'threatEditor.threatPriority':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 57,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "'threatEditor.sections.classification' | transloco",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 241,
+        "context": "* @param keyPrefix The translation key prefix (e.g., 'threatEditor.threatSeverity')",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 68,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<span class=\"mapping-label\">{{ 'threatEditor.frameworkMappings' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 323,
+        "context": "case 'threatEditor.threatStatus':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 213,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'threatEditor.addMapping' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 350,
+        "context": "case 'threatEditor.threatSeverity':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 214,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<span class=\"mapping-label\">{{ 'threatEditor.cweMappings' | transloco }}</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threat-page/threat-page.component.html",
-        "line": 358,
+        "context": "case 'threatEditor.threatPriority':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 215,
         "partial_match": "medium"
       }
     ]
@@ -48984,12 +49081,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "'threatEditor.threatSeverity.high',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 304
-      },
-      {
-        "classes": [],
         "context": "// 'threatEditor.threatSeverity.high'; the identity-mock transloco",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.spec.ts",
         "line": 106
@@ -49005,6 +49096,12 @@
         "context": "this.severityLabel = 'threatEditor.threatSeverity.high';",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/cvss-calculator-dialog/cvss-calculator-dialog.component.ts",
         "line": 392
+      },
+      {
+        "classes": [],
+        "context": "'threatEditor.threatSeverity.high',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 304
       }
     ]
   },
@@ -49220,72 +49317,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "| 'threatEditor.threatStatus'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 9,
+        "context": "return getFieldLabel(severity, 'threatEditor.threatSeverity', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 426,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "| 'threatEditor.threatSeverity'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 10,
+        "context": "return getFieldLabel(status, 'threatEditor.threatStatus', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 432,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "| 'threatEditor.threatPriority';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 11,
+        "context": "this.threatSeverityOptions = getFieldOptions('threatEditor.threatSeverity', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 447,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 42,
+        "context": "this.threatStatusOptions = getFieldOptions('threatEditor.threatStatus', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 448,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 55,
+        "context": "this.threatPriorityOptions = getFieldOptions('threatEditor.threatPriority', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 449,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 57,
+        "context": "this.threatSeverityOptions = getFieldOptions('threatEditor.threatSeverity', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 507,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "* @param keyPrefix The translation key prefix (e.g., 'threatEditor.threatSeverity')",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 68,
+        "context": "this.threatStatusOptions = getFieldOptions('threatEditor.threatStatus', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 508,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 213,
+        "context": "this.threatPriorityOptions = getFieldOptions('threatEditor.threatPriority', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 509,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 214,
+        "context": "value: getFieldLabel(threat.severity, 'threatEditor.threatSeverity', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 588,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 215,
+        "context": "value: getFieldLabel(threat.status, 'threatEditor.threatStatus', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 600,
         "partial_match": "medium"
       }
     ]
@@ -49484,72 +49581,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "| 'threatEditor.threatStatus'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 9,
+        "context": "value: getFieldLabel(threat.severity, 'threatEditor.threatSeverity', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 588,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "| 'threatEditor.threatSeverity'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 10,
+        "context": "value: getFieldLabel(threat.status, 'threatEditor.threatStatus', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 600,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "| 'threatEditor.threatPriority';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 11,
+        "context": "value: getFieldLabel(threat.priority, 'threatEditor.threatPriority', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 606,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 42,
+        "context": "// 'threatEditor.threatSeverity.high'; the identity-mock transloco",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.spec.ts",
+        "line": 106,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 55,
+        "context": "expect(component.getSeverityLabel('high')).toBe('threatEditor.threatSeverity.high');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.spec.ts",
+        "line": 108,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 57,
+        "context": "return getFieldLabel(severity, 'threatEditor.threatSeverity', this.translocoService);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.ts",
+        "line": 98,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "* @param keyPrefix The translation key prefix (e.g., 'threatEditor.threatSeverity')",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 68,
+        "context": "private readonly severityKeys = getFieldKeysForFieldType('threatEditor.threatSeverity');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 87,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 213,
+        "context": "private readonly threatStatusKeys = getFieldKeysForFieldType('threatEditor.threatStatus');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 88,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 214,
+        "context": "? (migrateFieldValue(severity, 'threatEditor.threatSeverity', this.transloco) ?? 'unknown')",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 290,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 215,
+        "context": "const priorityKeys = getFieldKeysForFieldType('threatEditor.threatPriority');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 321,
         "partial_match": "medium"
       }
     ]
@@ -49566,72 +49663,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "| 'threatEditor.threatStatus'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 9,
+        "context": "expect(getFieldKeysForFieldType('threatEditor.threatSeverity')).toHaveLength(6);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 110,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "| 'threatEditor.threatSeverity'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 10,
+        "context": "expect(getFieldKeysForFieldType('threatEditor.threatStatus')).toHaveLength(10);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 114,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "| 'threatEditor.threatPriority';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 11,
+        "context": "expect(getFieldKeysForFieldType('threatEditor.threatPriority')).toHaveLength(5);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 118,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 42,
+        "context": "const keys = getFieldKeysForFieldType('threatEditor.threatSeverity');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 130,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 55,
+        "context": "migrateFieldValue(null, 'threatEditor.threatSeverity', mockTranslocoService as never),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 138,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 57,
+        "context": "migrateFieldValue(undefined, 'threatEditor.threatSeverity', mockTranslocoService as never),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 144,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "* @param keyPrefix The translation key prefix (e.g., 'threatEditor.threatSeverity')",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 68,
+        "context": "migrateFieldValue('', 'threatEditor.threatSeverity', mockTranslocoService as never),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 150,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 213,
+        "context": "migrateFieldValue('high', 'threatEditor.threatSeverity', mockTranslocoService as never),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 156,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 214,
+        "context": "'threatEditor.threatStatus',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 161,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 215,
+        "context": "migrateFieldValue('0', 'threatEditor.threatSeverity', mockTranslocoService as never),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 169,
         "partial_match": "medium"
       }
     ]
@@ -49648,6 +49745,27 @@
     "uses": [
       {
         "classes": [],
+        "context": "value: getFieldLabel(threat.severity, 'threatEditor.threatSeverity', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 588,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "value: getFieldLabel(threat.status, 'threatEditor.threatStatus', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 600,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "value: getFieldLabel(threat.priority, 'threatEditor.threatPriority', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 606,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "| 'threatEditor.threatStatus'",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 9,
@@ -49693,27 +49811,6 @@
         "context": "* @param keyPrefix The translation key prefix (e.g., 'threatEditor.threatSeverity')",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 68,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 213,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 214,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 215,
         "partial_match": "medium"
       }
     ]
@@ -49730,6 +49827,88 @@
     "uses": [
       {
         "classes": [],
+        "context": "value: getFieldLabel(threat.severity, 'threatEditor.threatSeverity', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 588,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "value: getFieldLabel(threat.status, 'threatEditor.threatStatus', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 600,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "value: getFieldLabel(threat.priority, 'threatEditor.threatPriority', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 606,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "// 'threatEditor.threatSeverity.high'; the identity-mock transloco",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.spec.ts",
+        "line": 106,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(component.getSeverityLabel('high')).toBe('threatEditor.threatSeverity.high');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.spec.ts",
+        "line": 108,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "| 'threatEditor.threatStatus'",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 9,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "| 'threatEditor.threatSeverity'",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 10,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "| 'threatEditor.threatPriority';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 11,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatEditor.threatStatus':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 42,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatEditor.threatSeverity':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 55,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "threatEditor.threatStatus.closed.description": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
         "context": "| 'threatEditor.threatStatus'",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 9,
@@ -49796,88 +49975,6 @@
         "context": "case 'threatEditor.threatPriority':",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 215,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "threatEditor.threatStatus.closed.description": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "return getFieldLabel(severity, 'threatEditor.threatSeverity', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 420,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "return getFieldLabel(status, 'threatEditor.threatStatus', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 426,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.threatSeverityOptions = getFieldOptions('threatEditor.threatSeverity', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 441,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.threatStatusOptions = getFieldOptions('threatEditor.threatStatus', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 442,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.threatPriorityOptions = getFieldOptions('threatEditor.threatPriority', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 443,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.threatSeverityOptions = getFieldOptions('threatEditor.threatSeverity', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 501,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.threatStatusOptions = getFieldOptions('threatEditor.threatStatus', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 502,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.threatPriorityOptions = getFieldOptions('threatEditor.threatPriority', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 503,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "value: getFieldLabel(threat.severity, 'threatEditor.threatSeverity', transloco),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 588,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "value: getFieldLabel(threat.status, 'threatEditor.threatStatus', transloco),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 600,
         "partial_match": "medium"
       }
     ]
@@ -49976,72 +50073,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "| 'threatEditor.threatStatus'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 9,
+        "context": "private readonly severityKeys = getFieldKeysForFieldType('threatEditor.threatSeverity');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 87,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "| 'threatEditor.threatSeverity'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 10,
+        "context": "private readonly threatStatusKeys = getFieldKeysForFieldType('threatEditor.threatStatus');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 88,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "| 'threatEditor.threatPriority';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 11,
+        "context": "? (migrateFieldValue(severity, 'threatEditor.threatSeverity', this.transloco) ?? 'unknown')",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 290,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 42,
+        "context": "const priorityKeys = getFieldKeysForFieldType('threatEditor.threatPriority');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
+        "line": 321,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 55,
+        "context": "value: getFieldLabel(threat.severity, 'threatEditor.threatSeverity', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 588,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 57,
+        "context": "value: getFieldLabel(threat.status, 'threatEditor.threatStatus', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 600,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "* @param keyPrefix The translation key prefix (e.g., 'threatEditor.threatSeverity')",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 68,
+        "context": "value: getFieldLabel(threat.priority, 'threatEditor.threatPriority', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 606,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 213,
+        "context": "// 'threatEditor.threatSeverity.high'; the identity-mock transloco",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.spec.ts",
+        "line": 106,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 214,
+        "context": "expect(component.getSeverityLabel('high')).toBe('threatEditor.threatSeverity.high');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.spec.ts",
+        "line": 108,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 215,
+        "context": "return getFieldLabel(severity, 'threatEditor.threatSeverity', this.translocoService);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.ts",
+        "line": 98,
         "partial_match": "medium"
       }
     ]
@@ -50140,72 +50237,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "// 'threatEditor.threatSeverity.high'; the identity-mock transloco",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.spec.ts",
-        "line": 106,
+        "context": "| 'threatEditor.threatStatus'",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 9,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "expect(component.getSeverityLabel('high')).toBe('threatEditor.threatSeverity.high');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.spec.ts",
-        "line": 108,
+        "context": "| 'threatEditor.threatSeverity'",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 10,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "value: getFieldLabel(threat.severity, 'threatEditor.threatSeverity', transloco),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 588,
+        "context": "| 'threatEditor.threatPriority';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 11,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "value: getFieldLabel(threat.status, 'threatEditor.threatStatus', transloco),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 600,
+        "context": "case 'threatEditor.threatStatus':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 42,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "value: getFieldLabel(threat.priority, 'threatEditor.threatPriority', transloco),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 606,
+        "context": "case 'threatEditor.threatSeverity':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 55,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "return getFieldLabel(severity, 'threatEditor.threatSeverity', this.translocoService);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/threats-dialog/threats-dialog.component.ts",
-        "line": 98,
+        "context": "case 'threatEditor.threatPriority':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 57,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "private readonly severityKeys = getFieldKeysForFieldType('threatEditor.threatSeverity');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
-        "line": 87,
+        "context": "* @param keyPrefix The translation key prefix (e.g., 'threatEditor.threatSeverity')",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 68,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "private readonly threatStatusKeys = getFieldKeysForFieldType('threatEditor.threatStatus');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
-        "line": 88,
+        "context": "case 'threatEditor.threatStatus':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 213,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "? (migrateFieldValue(severity, 'threatEditor.threatSeverity', this.transloco) ?? 'unknown')",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
-        "line": 290,
+        "context": "case 'threatEditor.threatSeverity':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 214,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "const priorityKeys = getFieldKeysForFieldType('threatEditor.threatPriority');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/tm-edit-formatting.service.ts",
-        "line": 321,
+        "context": "case 'threatEditor.threatPriority':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 215,
         "partial_match": "medium"
       }
     ]
@@ -50386,6 +50483,27 @@
     "uses": [
       {
         "classes": [],
+        "context": "value: getFieldLabel(threat.severity, 'threatEditor.threatSeverity', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 588,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "value: getFieldLabel(threat.status, 'threatEditor.threatStatus', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 600,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "value: getFieldLabel(threat.priority, 'threatEditor.threatPriority', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 606,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "| 'threatEditor.threatStatus'",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 9,
@@ -50431,27 +50549,6 @@
         "context": "* @param keyPrefix The translation key prefix (e.g., 'threatEditor.threatSeverity')",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 68,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 213,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 214,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 215,
         "partial_match": "medium"
       }
     ]
@@ -50468,6 +50565,27 @@
     "uses": [
       {
         "classes": [],
+        "context": "value: getFieldLabel(threat.severity, 'threatEditor.threatSeverity', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 588,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "value: getFieldLabel(threat.status, 'threatEditor.threatStatus', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 600,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "value: getFieldLabel(threat.priority, 'threatEditor.threatPriority', transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 606,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "| 'threatEditor.threatStatus'",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 9,
@@ -50513,27 +50631,6 @@
         "context": "* @param keyPrefix The translation key prefix (e.g., 'threatEditor.threatSeverity')",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 68,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatStatus':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 213,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatSeverity':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 214,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatEditor.threatPriority':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 215,
         "partial_match": "medium"
       }
     ]
@@ -50960,62 +51057,6 @@
     "uses": [
       {
         "classes": [],
-        "context": "return getFieldLabel(severity, 'threatEditor.threatSeverity', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 420,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "return getFieldLabel(status, 'threatEditor.threatStatus', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 426,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.threatSeverityOptions = getFieldOptions('threatEditor.threatSeverity', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 441,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.threatStatusOptions = getFieldOptions('threatEditor.threatStatus', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 442,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.threatPriorityOptions = getFieldOptions('threatEditor.threatPriority', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 443,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.threatSeverityOptions = getFieldOptions('threatEditor.threatSeverity', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 501,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.threatStatusOptions = getFieldOptions('threatEditor.threatStatus', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 502,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.threatPriorityOptions = getFieldOptions('threatEditor.threatPriority', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 503,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "| 'threatEditor.threatStatus'",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 9,
@@ -51026,6 +51067,62 @@
         "context": "| 'threatEditor.threatSeverity'",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 10,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "| 'threatEditor.threatPriority';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 11,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatEditor.threatStatus':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 42,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatEditor.threatSeverity':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 55,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatEditor.threatPriority':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 57,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "* @param keyPrefix The translation key prefix (e.g., 'threatEditor.threatSeverity')",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 68,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatEditor.threatStatus':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 213,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatEditor.threatSeverity':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 214,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatEditor.threatPriority':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 215,
         "partial_match": "medium"
       }
     ]
@@ -51248,15 +51345,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "[matTooltip]=\"'threatModels.changeSecurityReviewer' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 285
+        "context": "title: this.transloco.translate('threatModels.changeSecurityReviewer'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
+        "line": 825
       },
       {
         "classes": [],
-        "context": "title: this.transloco.translate('threatModels.changeSecurityReviewer'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 819
+        "context": "[matTooltip]=\"'threatModels.changeSecurityReviewer' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 287
       }
     ]
   },
@@ -51274,7 +51371,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'threatModels.clearSecurityReviewer' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 293
+        "line": 295
       }
     ]
   },
@@ -51310,7 +51407,7 @@
         "classes": [],
         "context": "<span>{{ 'threatModels.confidentialProject' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 40
+        "line": 42
       }
     ]
   },
@@ -51365,7 +51462,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'threatModels.createNewRepository' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 950
+        "line": 952
       }
     ]
   },
@@ -51385,7 +51482,7 @@
         ],
         "context": "<span class=\"info-label\">{{ 'threatModels.created' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 442
+        "line": 444
       }
     ]
   },
@@ -51405,7 +51502,7 @@
         ],
         "context": "<span class=\"info-label\">{{ 'threatModels.createdBy' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 434
+        "line": 436
       }
     ]
   },
@@ -51501,6 +51598,34 @@
     "uses": [
       {
         "classes": [],
+        "context": "const statuses = getFieldKeysForFieldType('threatModels.status').filter(s => s !== 'closed');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 147,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "label: getFieldLabel(s, 'threatModels.status', this.transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 152,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "const nonClosedStatuses = getFieldKeysForFieldType('threatModels.status')",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 215,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "return getFieldLabel(status, 'threatModels.status', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 456,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "| 'threatModels.status'",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 8,
@@ -51540,34 +51665,6 @@
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
         "line": 226,
         "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "const options = getFieldOptions('threatModels.status', mockTranslocoService as never);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 267,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "getFieldTooltip('not_started', 'threatModels.status', mockTranslocoService as never);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 351,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'threatModels.status.not_started.tooltip',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 353,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "value: tm.status ? getFieldLabel(tm.status, 'threatModels.status', transloco) : noData,",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 135,
-        "partial_match": "medium"
       }
     ]
   },
@@ -51585,7 +51682,7 @@
         "classes": [],
         "context": "placeholder=\"{{ 'threatModels.descriptionPlaceholder' | transloco }}\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 132
+        "line": 134
       }
     ]
   },
@@ -51603,7 +51700,7 @@
         "classes": [],
         "context": "<mat-card-title [transloco]=\"'threatModels.details'\">Threat Model Details</mat-card-title>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 36
+        "line": 38
       }
     ]
   },
@@ -51645,7 +51742,7 @@
         "classes": [],
         "context": ": ('threatModels.diagramPreview' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1425
+        "line": 1427
       }
     ]
   },
@@ -51679,15 +51776,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "[transloco]=\"'threatModels.diagrams'\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1337
-      },
-      {
-        "classes": [],
         "context": "{{ 'threatModels.diagrams' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
         "line": 426
+      },
+      {
+        "classes": [],
+        "context": "[transloco]=\"'threatModels.diagrams'\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 1339
       }
     ]
   },
@@ -51838,7 +51935,7 @@
         "classes": [],
         "context": "<span>{{ 'threatModels.export' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 64
+        "line": 66
       }
     ]
   },
@@ -51994,7 +52091,7 @@
         "classes": [],
         "context": "{{ 'threatModels.frameworkDisabledHint' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 377
+        "line": 379
       }
     ]
   },
@@ -52010,19 +52107,19 @@
     "uses": [
       {
         "classes": [
-          "info-label"
-        ],
-        "context": "<span class=\"info-label\">{{ 'threatModels.idLabel' | transloco }}:</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 410
-      },
-      {
-        "classes": [
           "dialog-subtitle"
         ],
         "context": "<div class=\"dialog-subtitle\">{{ 'threatModels.idLabel' | transloco }}: {{ diagramId }}</div>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
         "line": 17
+      },
+      {
+        "classes": [
+          "info-label"
+        ],
+        "context": "<span class=\"info-label\">{{ 'threatModels.idLabel' | transloco }}:</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 412
       }
     ]
   },
@@ -52132,7 +52229,7 @@
         "classes": [],
         "context": "<mat-hint>{{ 'threatModels.issueUriHint' | transloco }}</mat-hint>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 332
+        "line": 334
       }
     ]
   },
@@ -52168,7 +52265,7 @@
         "classes": [],
         "context": "{{ 'threatModels.noAssets' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 681
+        "line": 683
       }
     ]
   },
@@ -52186,7 +52283,7 @@
         "classes": [],
         "context": "{{ 'threatModels.noDiagrams' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1549
+        "line": 1551
       }
     ]
   },
@@ -52204,7 +52301,7 @@
         "classes": [],
         "context": "{{ 'threatModels.noDocuments' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 911
+        "line": 913
       }
     ]
   },
@@ -52240,7 +52337,7 @@
         "classes": [],
         "context": "{{ 'threatModels.noNotes' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1313
+        "line": 1315
       }
     ]
   },
@@ -52276,7 +52373,7 @@
         "classes": [],
         "context": "{{ 'threatModels.noRepositories' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1116
+        "line": 1118
       }
     ]
   },
@@ -52294,7 +52391,7 @@
         "classes": [],
         "context": "{{ 'threatModels.noThreats' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1947
+        "line": 1949
       }
     ]
   },
@@ -52310,72 +52407,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "| 'threatModels.status'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 8,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatModels.status':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 29,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatModels.status':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 211,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(getFieldKeysForFieldType('threatModels.status')).toHaveLength(10);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 122,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "migrateFieldValue('Not Started', 'threatModels.status', mockTranslocoService as never),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 224,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(migrateFieldValue('0', 'threatModels.status', mockTranslocoService as never)).toBe(",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 226,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "const options = getFieldOptions('threatModels.status', mockTranslocoService as never);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 267,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "getFieldTooltip('not_started', 'threatModels.status', mockTranslocoService as never);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 351,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'threatModels.status.not_started.tooltip',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 353,
+        "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 204,
         "partial_match": "medium"
       },
       {
         "classes": [],
         "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 204,
+        "line": 304,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.transloco.translate('threatModels.deleteSuccess', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 580,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.transloco.translate('threatModels.deleteError', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 602,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.showError(this.transloco.translate('threatModels.fileSizeExceeded', { maxSize: 10 }));",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 879,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.showError(this.transloco.translate('threatModels.importFormatError'));",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 925,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.transloco.translate('threatModels.importValidationError', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 933,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.transloco.translate('threatModels.importError', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 954,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.transloco.translate('threatModels.importSuccess', { name: model.name }),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 966,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<h1 class=\"page-title\" [transloco]=\"'threatModels.dashboard'\">Dashboard</h1>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
+        "line": 2,
         "partial_match": "medium"
       }
     ]
@@ -52482,6 +52579,48 @@
     "uses": [
       {
         "classes": [],
+        "context": "value: tm.status ? getFieldLabel(tm.status, 'threatModels.status', transloco) : noData,",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 135,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "cursor = drawSectionHeading(ctx, cursor, ctx.transloco.translate('threatModels.sections.inputs'));",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 196,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "ctx.transloco.translate('threatModels.sections.outputs'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 235,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "header: transloco.translate('threatModels.documentUrl'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 373,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "header: transloco.translate('threatModels.repositoryType'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 410,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "header: transloco.translate('threatModels.repositoryUri'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
+        "line": 414,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "| 'threatModels.status'",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 8,
@@ -52506,48 +52645,6 @@
         "context": "expect(getFieldKeysForFieldType('threatModels.status')).toHaveLength(10);",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
         "line": 122,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "migrateFieldValue('Not Started', 'threatModels.status', mockTranslocoService as never),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 224,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(migrateFieldValue('0', 'threatModels.status', mockTranslocoService as never)).toBe(",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 226,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "const options = getFieldOptions('threatModels.status', mockTranslocoService as never);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 267,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "getFieldTooltip('not_started', 'threatModels.status', mockTranslocoService as never);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 351,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'threatModels.status.not_started.tooltip',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 353,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 204,
         "partial_match": "medium"
       }
     ]
@@ -52804,15 +52901,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "<mat-label>{{ 'threatModels.repositoryType' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
-        "line": 56
-      },
-      {
-        "classes": [],
         "context": "header: transloco.translate('threatModels.repositoryType'),",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
         "line": 410
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'threatModels.repositoryType' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/repository-editor-dialog/repository-editor-dialog.component.html",
+        "line": 56
       }
     ]
   },
@@ -52854,7 +52951,7 @@
         "classes": [],
         "context": "<mat-panel-title>{{ 'threatModels.sections.audit' | transloco }}</mat-panel-title>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 393
+        "line": 395
       }
     ]
   },
@@ -52874,7 +52971,7 @@
         ],
         "context": "<span class=\"section-title\" [transloco]=\"'threatModels.sections.inputs'\">Inputs</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 466
+        "line": 468
       },
       {
         "classes": [],
@@ -52898,7 +52995,7 @@
         "classes": [],
         "context": "[transloco]=\"'threatModels.sections.inputsDescription'\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 469
+        "line": 471
       }
     ]
   },
@@ -52918,7 +53015,7 @@
         ],
         "context": "<span class=\"section-title\" [transloco]=\"'threatModels.sections.outputs'\">Outputs</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1150
+        "line": 1152
       },
       {
         "classes": [],
@@ -52942,7 +53039,7 @@
         "classes": [],
         "context": "[transloco]=\"'threatModels.sections.outputsDescription'\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1153
+        "line": 1155
       }
     ]
   },
@@ -52960,7 +53057,7 @@
         "classes": [],
         "context": "'threatModels.sections.reviewProcess' | transloco",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 167
+        "line": 169
       }
     ]
   },
@@ -52979,13 +53076,13 @@
         "classes": [],
         "context": ">{{ 'threatModels.securityReviewer' | transloco }}:</span",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 195
+        "line": 197
       },
       {
         "classes": [],
         "context": "<mat-label>{{ 'threatModels.securityReviewer' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 257
+        "line": 259
       },
       {
         "classes": [
@@ -52993,7 +53090,7 @@
         ],
         "context": "<span class=\"info-label\">{{ 'threatModels.securityReviewer' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 274
+        "line": 276
       },
       {
         "classes": [
@@ -53001,7 +53098,7 @@
         ],
         "context": "<span class=\"info-label\">{{ 'threatModels.securityReviewer' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 301
+        "line": 303
       }
     ]
   },
@@ -53059,6 +53156,27 @@
     "uses": [
       {
         "classes": [],
+        "context": "| 'threatModels.status'",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 8,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatModels.status':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 29,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatModels.status':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 211,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "expect(getFieldKeysForFieldType('threatModels.status')).toHaveLength(10);",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
         "line": 122,
@@ -53097,27 +53215,6 @@
         "context": "'threatModels.status.not_started.tooltip',",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
         "line": 353,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "| 'threatModels.status'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 8,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatModels.status':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 29,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatModels.status':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 211,
         "partial_match": "medium"
       },
       {
@@ -53204,9 +53301,9 @@
       },
       {
         "classes": [],
-        "context": "<h1 class=\"page-title\" [transloco]=\"'threatModels.dashboard'\">Dashboard</h1>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 2,
+        "context": "const statuses = getFieldKeysForFieldType('threatModels.status').filter(s => s !== 'closed');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 147,
         "partial_match": "medium"
       }
     ]
@@ -53223,72 +53320,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 204,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 304,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.deleteSuccess', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 580,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.deleteError', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 602,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.showError(this.transloco.translate('threatModels.fileSizeExceeded', { maxSize: 10 }));",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 879,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.showError(this.transloco.translate('threatModels.importFormatError'));",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 925,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.importValidationError', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 933,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.importError', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 954,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.importSuccess', { name: model.name }),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 966,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "{{ 'threatModels.newThreatModel' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
         "line": 5,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span class=\"title-prefix\">{{ 'threatModels.threatModelPrefix' | transloco }}:</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 7,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-card-title [transloco]=\"'threatModels.details'\">Threat Model Details</mat-card-title>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 38,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'threatModels.confidentialProject' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 42,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span>{{ 'threatModels.export' | transloco }}</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 66,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "placeholder=\"{{ 'threatModels.descriptionPlaceholder' | transloco }}\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 134,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'threatModels.sections.reviewProcess' | transloco",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 169,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'threatModels.status.' + threatModelForm.get('status')?.value | transloco",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 179,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": ">{{ 'threatModels.statusLastUpdated' | transloco }}:</span",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 187,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": ">{{ 'threatModels.securityReviewer' | transloco }}:</span",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
+        "line": 197,
         "partial_match": "medium"
       }
     ]
@@ -53368,9 +53465,9 @@
       },
       {
         "classes": [],
-        "context": "const statuses = getFieldKeysForFieldType('threatModels.status').filter(s => s !== 'closed');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
-        "line": 147,
+        "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 204,
         "partial_match": "medium"
       }
     ]
@@ -53387,72 +53484,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "| 'threatModels.status'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 8,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatModels.status':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 29,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatModels.status':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 211,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(getFieldKeysForFieldType('threatModels.status')).toHaveLength(10);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 122,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "migrateFieldValue('Not Started', 'threatModels.status', mockTranslocoService as never),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 224,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(migrateFieldValue('0', 'threatModels.status', mockTranslocoService as never)).toBe(",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 226,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "const options = getFieldOptions('threatModels.status', mockTranslocoService as never);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 267,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "getFieldTooltip('not_started', 'threatModels.status', mockTranslocoService as never);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 351,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'threatModels.status.not_started.tooltip',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 353,
+        "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 204,
         "partial_match": "medium"
       },
       {
         "classes": [],
         "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 204,
+        "line": 304,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.transloco.translate('threatModels.deleteSuccess', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 580,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.transloco.translate('threatModels.deleteError', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 602,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.showError(this.transloco.translate('threatModels.fileSizeExceeded', { maxSize: 10 }));",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 879,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.showError(this.transloco.translate('threatModels.importFormatError'));",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 925,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.transloco.translate('threatModels.importValidationError', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 933,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.transloco.translate('threatModels.importError', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 954,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.transloco.translate('threatModels.importSuccess', { name: model.name }),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 966,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<h1 class=\"page-title\" [transloco]=\"'threatModels.dashboard'\">Dashboard</h1>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
+        "line": 2,
         "partial_match": "medium"
       }
     ]
@@ -53551,6 +53648,27 @@
     "uses": [
       {
         "classes": [],
+        "context": "| 'threatModels.status'",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 8,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatModels.status':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 29,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatModels.status':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 211,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
         "line": 204,
@@ -53596,114 +53714,11 @@
         "context": "this.transloco.translate('threatModels.importValidationError', {",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
         "line": 933,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.importError', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 954,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.importSuccess', { name: model.name }),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 966,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "const statuses = getFieldKeysForFieldType('threatModels.status').filter(s => s !== 'closed');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
-        "line": 147,
         "partial_match": "medium"
       }
     ]
   },
   "threatModels.status.deferred.tooltip": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 204,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 304,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.deleteSuccess', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 580,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.deleteError', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 602,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.showError(this.transloco.translate('threatModels.fileSizeExceeded', { maxSize: 10 }));",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 879,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.showError(this.transloco.translate('threatModels.importFormatError'));",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 925,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.importValidationError', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 933,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.importError', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 954,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.importSuccess', { name: model.name }),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 966,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "const statuses = getFieldKeysForFieldType('threatModels.status').filter(s => s !== 'closed');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
-        "line": 147,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "threatModels.status.in_progress": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -53736,6 +53751,67 @@
       },
       {
         "classes": [],
+        "context": "expect(getFieldKeysForFieldType('threatModels.status')).toHaveLength(10);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 122,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "migrateFieldValue('Not Started', 'threatModels.status', mockTranslocoService as never),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 224,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(migrateFieldValue('0', 'threatModels.status', mockTranslocoService as never)).toBe(",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 226,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "const options = getFieldOptions('threatModels.status', mockTranslocoService as never);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 267,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "getFieldTooltip('not_started', 'threatModels.status', mockTranslocoService as never);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 351,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'threatModels.status.not_started.tooltip',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 353,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "const statuses = getFieldKeysForFieldType('threatModels.status').filter(s => s !== 'closed');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 147,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "threatModels.status.in_progress": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
         "context": "const statuses = getFieldKeysForFieldType('threatModels.status').filter(s => s !== 'closed');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
         "line": 147,
@@ -53760,6 +53836,27 @@
         "context": "return getFieldLabel(status, 'threatModels.status', this.transloco);",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
         "line": 456,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "| 'threatModels.status'",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 8,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatModels.status':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 29,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatModels.status':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 211,
         "partial_match": "medium"
       },
       {
@@ -53862,112 +53959,12 @@
         "classes": [],
         "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.ts",
-        "line": 438,
+        "line": 444,
         "partial_match": "medium"
       }
     ]
   },
   "threatModels.status.not_started": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 204,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 304,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.deleteSuccess', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 580,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.deleteError', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 602,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.showError(this.transloco.translate('threatModels.fileSizeExceeded', { maxSize: 10 }));",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 879,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.showError(this.transloco.translate('threatModels.importFormatError'));",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 925,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.importValidationError', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 933,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.importError', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 954,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.transloco.translate('threatModels.importSuccess', { name: model.name }),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 966,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<h1 class=\"page-title\" [transloco]=\"'threatModels.dashboard'\">Dashboard</h1>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 2,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "threatModels.status.not_started.tooltip": {
-    "ambiguous_word": false,
-    "confidence": "high",
-    "ellipsis_candidate": false,
-    "found_by": "fully-qualified",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "'threatModels.status.not_started.tooltip',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 353
-      }
-    ]
-  },
-  "threatModels.status.pending_review": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -54049,7 +54046,25 @@
       }
     ]
   },
-  "threatModels.status.pending_review.tooltip": {
+  "threatModels.status.not_started.tooltip": {
+    "ambiguous_word": false,
+    "confidence": "high",
+    "ellipsis_candidate": false,
+    "found_by": "fully-qualified",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "'threatModels.status.not_started.tooltip',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 353
+      }
+    ]
+  },
+  "threatModels.status.pending_review": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -54124,9 +54139,91 @@
       },
       {
         "classes": [],
-        "context": "{{ 'threatModels.newThreatModel' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 5,
+        "context": "<h1 class=\"page-title\" [transloco]=\"'threatModels.dashboard'\">Dashboard</h1>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
+        "line": 2,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "threatModels.status.pending_review.tooltip": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "const statuses = getFieldKeysForFieldType('threatModels.status').filter(s => s !== 'closed');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 147,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "label: getFieldLabel(s, 'threatModels.status', this.transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 152,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "const nonClosedStatuses = getFieldKeysForFieldType('threatModels.status')",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 215,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "return getFieldLabel(status, 'threatModels.status', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 456,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "| 'threatModels.status'",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 8,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatModels.status':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 29,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatModels.status':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 211,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(getFieldKeysForFieldType('threatModels.status')).toHaveLength(10);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 122,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "migrateFieldValue('Not Started', 'threatModels.status', mockTranslocoService as never),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 224,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(migrateFieldValue('0', 'threatModels.status', mockTranslocoService as never)).toBe(",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 226,
         "partial_match": "medium"
       }
     ]
@@ -54143,72 +54240,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "value: tm.status ? getFieldLabel(tm.status, 'threatModels.status', transloco) : noData,",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 135,
+        "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 204,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "cursor = drawSectionHeading(ctx, cursor, ctx.transloco.translate('threatModels.sections.inputs'));",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 196,
+        "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 304,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "ctx.transloco.translate('threatModels.sections.outputs'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 235,
+        "context": "this.transloco.translate('threatModels.deleteSuccess', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 580,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "header: transloco.translate('threatModels.documentUrl'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 373,
+        "context": "this.transloco.translate('threatModels.deleteError', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 602,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "header: transloco.translate('threatModels.repositoryType'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 410,
+        "context": "this.showError(this.transloco.translate('threatModels.fileSizeExceeded', { maxSize: 10 }));",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 879,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "header: transloco.translate('threatModels.repositoryUri'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/services/report/pdf-section-renderers.ts",
-        "line": 414,
+        "context": "this.showError(this.transloco.translate('threatModels.importFormatError'));",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 925,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "? ('threatModels.viewDiagramName' | transloco)",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
-        "line": 4,
+        "context": "this.transloco.translate('threatModels.importValidationError', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 933,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": ": ('threatModels.renameDiagram' | transloco)",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
-        "line": 5,
+        "context": "this.transloco.translate('threatModels.importError', {",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 954,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<div class=\"dialog-subtitle\">{{ 'threatModels.idLabel' | transloco }}: {{ diagramId }}</div>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
-        "line": 17,
+        "context": "this.transloco.translate('threatModels.importSuccess', { name: model.name }),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 966,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-label>{{ 'threatModels.diagramName' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/components/rename-diagram-dialog/rename-diagram-dialog.component.html",
-        "line": 22,
+        "context": "<h1 class=\"page-title\" [transloco]=\"'threatModels.dashboard'\">Dashboard</h1>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
+        "line": 2,
         "partial_match": "medium"
       }
     ]
@@ -54307,72 +54404,72 @@
     "uses": [
       {
         "classes": [],
-        "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 204,
+        "context": "const statuses = getFieldKeysForFieldType('threatModels.status').filter(s => s !== 'closed');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 147,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 304,
+        "context": "label: getFieldLabel(s, 'threatModels.status', this.transloco),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 152,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "this.transloco.translate('threatModels.deleteSuccess', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 580,
+        "context": "const nonClosedStatuses = getFieldKeysForFieldType('threatModels.status')",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 215,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "this.transloco.translate('threatModels.deleteError', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 602,
+        "context": "return getFieldLabel(status, 'threatModels.status', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 456,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "this.showError(this.transloco.translate('threatModels.fileSizeExceeded', { maxSize: 10 }));",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 879,
+        "context": "| 'threatModels.status'",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 8,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "this.showError(this.transloco.translate('threatModels.importFormatError'));",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 925,
+        "context": "case 'threatModels.status':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 29,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "this.transloco.translate('threatModels.importValidationError', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 933,
+        "context": "case 'threatModels.status':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 211,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "this.transloco.translate('threatModels.importError', {",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 954,
+        "context": "expect(getFieldKeysForFieldType('threatModels.status')).toHaveLength(10);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 122,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "this.transloco.translate('threatModels.importSuccess', { name: model.name }),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
-        "line": 966,
+        "context": "migrateFieldValue('Not Started', 'threatModels.status', mockTranslocoService as never),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 224,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<h1 class=\"page-title\" [transloco]=\"'threatModels.dashboard'\">Dashboard</h1>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 2,
+        "context": "expect(migrateFieldValue('0', 'threatModels.status', mockTranslocoService as never)).toBe(",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 226,
         "partial_match": "medium"
       }
     ]
@@ -54492,88 +54589,6 @@
       },
       {
         "classes": [],
-        "context": "expect(getFieldKeysForFieldType('threatModels.status')).toHaveLength(10);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 122,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "migrateFieldValue('Not Started', 'threatModels.status', mockTranslocoService as never),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 224,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(migrateFieldValue('0', 'threatModels.status', mockTranslocoService as never)).toBe(",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 226,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "const options = getFieldOptions('threatModels.status', mockTranslocoService as never);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 267,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "getFieldTooltip('not_started', 'threatModels.status', mockTranslocoService as never);",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 351,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'threatModels.status.not_started.tooltip',",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
-        "line": 353,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "const statuses = getFieldKeysForFieldType('threatModels.status').filter(s => s !== 'closed');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
-        "line": 147,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "threatModels.status.remediation_required.tooltip": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "| 'threatModels.status'",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 8,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatModels.status':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 29,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "case 'threatModels.status':",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
-        "line": 211,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
         "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
         "line": 204,
@@ -54623,7 +54638,7 @@
       }
     ]
   },
-  "threatModels.status.verification_pending": {
+  "threatModels.status.remediation_required.tooltip": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -54705,7 +54720,7 @@
       }
     ]
   },
-  "threatModels.status.verification_pending.tooltip": {
+  "threatModels.status.verification_pending": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -54780,9 +54795,91 @@
       },
       {
         "classes": [],
+        "context": "const statuses = getFieldKeysForFieldType('threatModels.status').filter(s => s !== 'closed');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 147,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "threatModels.status.verification_pending.tooltip": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
         "context": "| 'threatModels.status'",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
         "line": 8,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatModels.status':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 29,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "case 'threatModels.status':",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.ts",
+        "line": 211,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(getFieldKeysForFieldType('threatModels.status')).toHaveLength(10);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 122,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "migrateFieldValue('Not Started', 'threatModels.status', mockTranslocoService as never),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 224,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "expect(migrateFieldValue('0', 'threatModels.status', mockTranslocoService as never)).toBe(",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 226,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "const options = getFieldOptions('threatModels.status', mockTranslocoService as never);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 267,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "getFieldTooltip('not_started', 'threatModels.status', mockTranslocoService as never);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 351,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "'threatModels.status.not_started.tooltip',",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/shared/utils/field-value-helpers.spec.ts",
+        "line": 353,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "this.statusOptions = getFieldOptions('threatModels.status', this.transloco);",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.ts",
+        "line": 204,
         "partial_match": "medium"
       }
     ]
@@ -54800,8 +54897,14 @@
       {
         "classes": [],
         "context": ">{{ 'threatModels.statusLastUpdated' | transloco }}:</span",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
+        "line": 348
+      },
+      {
+        "classes": [],
+        "context": ">{{ 'threatModels.statusLastUpdated' | transloco }}:</span",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 185
+        "line": 187
       },
       {
         "classes": [
@@ -54809,13 +54912,7 @@
         ],
         "context": "<span class=\"info-label\">{{ 'threatModels.statusLastUpdated' | transloco }}:</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 245
-      },
-      {
-        "classes": [],
-        "context": ">{{ 'threatModels.statusLastUpdated' | transloco }}:</span",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/dashboard/dashboard.component.html",
-        "line": 348
+        "line": 247
       }
     ]
   },
@@ -54851,13 +54948,13 @@
         "classes": [],
         "context": "<mat-label [transloco]=\"'threatModels.threatModelFramework'\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 359
+        "line": 361
       },
       {
         "classes": [],
         "context": "[attr.aria-label]=\"'threatModels.threatModelFramework' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 366
+        "line": 368
       }
     ]
   },
@@ -54895,7 +54992,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'threatModels.tooltips.addAsset' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 492
+        "line": 494
       }
     ]
   },
@@ -54913,7 +55010,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'threatModels.tooltips.addDiagram' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1348
+        "line": 1350
       }
     ]
   },
@@ -54931,7 +55028,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'threatModels.tooltips.addDocument' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 721
+        "line": 723
       }
     ]
   },
@@ -54949,7 +55046,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'threatModels.tooltips.addNote' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1175
+        "line": 1177
       }
     ]
   },
@@ -54967,7 +55064,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'threatModels.tooltips.assetsCardTitle' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 482
+        "line": 484
       }
     ]
   },
@@ -54985,7 +55082,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'threatModels.tooltips.diagramsCardTitle' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1338
+        "line": 1340
       }
     ]
   },
@@ -55003,7 +55100,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'threatModels.tooltips.documentsCardTitle' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 711
+        "line": 713
       }
     ]
   },
@@ -55021,7 +55118,7 @@
         "classes": [],
         "context": "<span>{{ 'threatModels.tooltips.downloadModel' | transloco }}</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1505
+        "line": 1507
       }
     ]
   },
@@ -55039,7 +55136,7 @@
         "classes": [],
         "context": "[attr.data-drop-hint]=\"'threatModels.tooltips.dropToCreateDocument' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 706
+        "line": 708
       }
     ]
   },
@@ -55057,7 +55154,7 @@
         "classes": [],
         "context": "[attr.data-drop-hint]=\"'threatModels.tooltips.dropToCreateRepository' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 935
+        "line": 937
       }
     ]
   },
@@ -55075,7 +55172,7 @@
         "classes": [],
         "context": "[attr.data-drop-hint]=\"'threatModels.tooltips.dropToSetIssueUri' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 320
+        "line": 322
       },
       {
         "classes": [],
@@ -55117,7 +55214,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'threatModels.tooltips.notesCardTitle' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1165
+        "line": 1167
       }
     ]
   },
@@ -55135,7 +55232,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'threatModels.tooltips.repositoriesCardTitle' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 940
+        "line": 942
       }
     ]
   },
@@ -55153,7 +55250,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'threatModels.tooltips.threatsCardTitle' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1574
+        "line": 1576
       }
     ]
   },
@@ -55209,7 +55306,7 @@
         "classes": [],
         "context": "{{ 'threats.filters.clearAll' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1701
+        "line": 1703
       }
     ]
   },
@@ -55227,7 +55324,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'threats.filters.clearName' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1622
+        "line": 1624
       }
     ]
   },
@@ -55246,7 +55343,7 @@
         "classes": [],
         "context": "? ('threats.filters.lessFilters' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1682
+        "line": 1684
       }
     ]
   },
@@ -55264,7 +55361,7 @@
         "classes": [],
         "context": "[matTooltip]=\"'threats.filters.mitigatedTooltip' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1663
+        "line": 1665
       }
     ]
   },
@@ -55283,7 +55380,7 @@
         "classes": [],
         "context": ": ('threats.filters.moreFilters' | transloco)",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1683
+        "line": 1685
       }
     ]
   },
@@ -55301,7 +55398,7 @@
         "classes": [],
         "context": "<mat-label>{{ 'threats.filters.nameLabel' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1609
+        "line": 1611
       }
     ]
   },
@@ -55319,7 +55416,7 @@
         "classes": [],
         "context": "[placeholder]=\"'threats.filters.namePlaceholder' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1615
+        "line": 1617
       }
     ]
   },
@@ -55337,7 +55434,7 @@
         "classes": [],
         "context": "{{ 'threats.filters.noMatchingThreats' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1943
+        "line": 1945
       }
     ]
   },
@@ -55355,7 +55452,7 @@
         "classes": [],
         "context": "<mat-label>{{ 'threats.filters.priority' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1727
+        "line": 1729
       }
     ]
   },
@@ -55373,7 +55470,7 @@
         "classes": [],
         "context": "<mat-label>{{ 'threats.filters.threatType' | transloco }}</mat-label>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tm/tm-edit.component.html",
-        "line": 1711
+        "line": 1713
       }
     ]
   },
@@ -55820,18 +55917,18 @@
     ],
     "uses": [
       {
+        "classes": [],
+        "context": "<a routerLink=\"/tos\" [transloco]=\"'tos.title'\">Terms of Service</a>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/footer/footer.component.html",
+        "line": 19
+      },
+      {
         "classes": [
           "page-title"
         ],
         "context": "<h1 class=\"page-title\" [transloco]=\"'tos.title'\">Terms of Service</h1>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/tos/tos.component.html",
         "line": 3
-      },
-      {
-        "classes": [],
-        "context": "<a routerLink=\"/tos\" [transloco]=\"'tos.title'\">Terms of Service</a>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/footer/footer.component.html",
-        "line": 19
       }
     ]
   },
@@ -55872,88 +55969,6 @@
     ]
   },
   "triage.bulkActions": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'triage.title'\">Triage</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.html",
-        "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'triage.title'\">Triage</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.html",
-        "line": 133,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.error = this.transloco.translate('triage.reviewerAssignment.errorLoading');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
-        "line": 257,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "title: this.transloco.translate('triage.reviewerAssignment.selectReviewer'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
-        "line": 381,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[placeholder]=\"'triage.reviewerAssignment.searchPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 11,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'triage.reviewerAssignment.unassigned' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 48,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'triage.reviewerAssignment.reviewer' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 53,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[placeholder]=\"'triage.reviewerAssignment.reviewerPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 59,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'triage.filters.clearFilters' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 87,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<p>{{ 'triage.reviewerAssignment.loading' | transloco }}</p>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 165,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "triage.changeStatus": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -56035,25 +56050,7 @@
       }
     ]
   },
-  "triage.columns.confidentialTooltip": {
-    "ambiguous_word": false,
-    "confidence": "high",
-    "ellipsis_candidate": false,
-    "found_by": "fully-qualified",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "tooltip"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "[matTooltip]=\"'triage.columns.confidentialTooltip' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 144
-      }
-    ]
-  },
-  "triage.createTm": {
+  "triage.changeStatus": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -56131,6 +56128,106 @@
         "context": "<p>{{ 'triage.reviewerAssignment.loading' | transloco }}</p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
         "line": 165,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "triage.columns.confidentialTooltip": {
+    "ambiguous_word": false,
+    "confidence": "high",
+    "ellipsis_candidate": false,
+    "found_by": "fully-qualified",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "tooltip"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "[matTooltip]=\"'triage.columns.confidentialTooltip' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
+        "line": 144
+      }
+    ]
+  },
+  "triage.createTm": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "this.error = this.transloco.translate('triage.reviewerAssignment.errorLoading');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 257,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "title: this.transloco.translate('triage.reviewerAssignment.selectReviewer'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 381,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'triage.reviewerAssignment.searchPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 11,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'triage.reviewerAssignment.unassigned' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 48,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'triage.reviewerAssignment.reviewer' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 53,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'triage.reviewerAssignment.reviewerPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 59,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'triage.filters.clearFilters' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 87,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<p>{{ 'triage.reviewerAssignment.loading' | transloco }}</p>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 165,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<h2>{{ 'triage.reviewerAssignment.noUnassignedFiltered' | transloco }}</h2>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 180,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'triage.filters.clearFilters' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 182,
         "partial_match": "medium"
       }
     ]
@@ -56373,6 +56470,20 @@
     "uses": [
       {
         "classes": [],
+        "context": "<span [transloco]=\"'triage.title'\">Triage</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.html",
+        "line": 49,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'triage.title'\">Triage</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.html",
+        "line": 133,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "this.error = this.transloco.translate('triage.reviewerAssignment.errorLoading');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
         "line": 257,
@@ -56387,58 +56498,44 @@
       },
       {
         "classes": [],
-        "context": "[placeholder]=\"'triage.reviewerAssignment.searchPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 11,
+        "context": "this.error = this.transloco.translate('triage.list.errorLoadingResponses');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.ts",
+        "line": 231,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'triage.reviewerAssignment.unassigned' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 48,
+        "context": "this.transloco.translate('triage.messages.approveSuccess'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.ts",
+        "line": 299,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-label>{{ 'triage.reviewerAssignment.reviewer' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 53,
+        "context": "this.transloco.translate('triage.messages.approveError'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.ts",
+        "line": 307,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[placeholder]=\"'triage.reviewerAssignment.reviewerPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 59,
+        "context": "this.transloco.translate('triage.messages.returnForRevisionSuccess'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.ts",
+        "line": 341,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'triage.filters.clearFilters' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 87,
+        "context": "this.transloco.translate('triage.messages.returnForRevisionError'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.ts",
+        "line": 349,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<p>{{ 'triage.reviewerAssignment.loading' | transloco }}</p>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 165,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<h2>{{ 'triage.reviewerAssignment.noUnassignedFiltered' | transloco }}</h2>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 180,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'triage.filters.clearFilters' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 182,
+        "context": "this.transloco.translate('triage.messages.createThreatModelSuccess'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.ts",
+        "line": 374,
         "partial_match": "medium"
       }
     ]
@@ -56537,6 +56634,88 @@
     "uses": [
       {
         "classes": [],
+        "context": "this.error = this.transloco.translate('triage.reviewerAssignment.errorLoading');",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 257,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "title: this.transloco.translate('triage.reviewerAssignment.selectReviewer'),",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
+        "line": 381,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'triage.reviewerAssignment.searchPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 11,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'triage.reviewerAssignment.unassigned' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 48,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'triage.reviewerAssignment.reviewer' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 53,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'triage.reviewerAssignment.reviewerPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 59,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'triage.filters.clearFilters' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 87,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<p>{{ 'triage.reviewerAssignment.loading' | transloco }}</p>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 165,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<h2>{{ 'triage.reviewerAssignment.noUnassignedFiltered' | transloco }}</h2>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 180,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'triage.filters.clearFilters' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 182,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "triage.detail.noteNamePlaceholder": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
         "context": "<span [transloco]=\"'triage.title'\">Triage</span>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.html",
         "line": 49,
@@ -56607,7 +56786,43 @@
       }
     ]
   },
-  "triage.detail.noteNamePlaceholder": {
+  "triage.detail.notes": {
+    "ambiguous_word": false,
+    "confidence": "high",
+    "ellipsis_candidate": false,
+    "found_by": "fully-qualified",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": ": ('triage.detail.notes' | transloco)",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
+        "line": 166
+      }
+    ]
+  },
+  "triage.detail.responseDetails": {
+    "ambiguous_word": false,
+    "confidence": "high",
+    "ellipsis_candidate": false,
+    "found_by": "fully-qualified",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "page-title"
+    ],
+    "uses": [
+      {
+        "classes": [],
+        "context": "<mat-card-title>{{ 'triage.detail.responseDetails' | transloco }}</mat-card-title>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
+        "line": 254
+      }
+    ]
+  },
+  "triage.detail.reviewedAt": {
     "ambiguous_word": false,
     "confidence": "medium",
     "ellipsis_candidate": false,
@@ -56685,124 +56900,6 @@
         "context": "{{ 'triage.filters.clearFilters' | transloco }}",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
         "line": 182,
-        "partial_match": "medium"
-      }
-    ]
-  },
-  "triage.detail.notes": {
-    "ambiguous_word": false,
-    "confidence": "high",
-    "ellipsis_candidate": false,
-    "found_by": "fully-qualified",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": ": ('triage.detail.notes' | transloco)",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
-        "line": 166
-      }
-    ]
-  },
-  "triage.detail.responseDetails": {
-    "ambiguous_word": false,
-    "confidence": "high",
-    "ellipsis_candidate": false,
-    "found_by": "fully-qualified",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "page-title"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "<mat-card-title>{{ 'triage.detail.responseDetails' | transloco }}</mat-card-title>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
-        "line": 254
-      }
-    ]
-  },
-  "triage.detail.reviewedAt": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'triage.title'\">Triage</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.html",
-        "line": 49,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<span [transloco]=\"'triage.title'\">Triage</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.html",
-        "line": 133,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'triage.noteEditor.nameLabel' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 18,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[placeholder]=\"'triage.noteEditor.namePlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 22,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'triage.noteEditor.contentLabel' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 104,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[placeholder]=\"'triage.noteEditor.contentPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.html",
-        "line": 111,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.error = this.transloco.translate('triage.reviewerAssignment.errorLoading');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
-        "line": 257,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "title: this.transloco.translate('triage.reviewerAssignment.selectReviewer'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
-        "line": 381,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.mode === 'view' ? 'triage.noteEditor.title.view' : 'triage.noteEditor.title.create';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.ts",
-        "line": 140,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "expect(build({ mode: 'create' }).dialogTitle).toBe('triage.noteEditor.title.create');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.spec.ts",
-        "line": 74,
         "partial_match": "medium"
       }
     ]
@@ -56922,6 +57019,20 @@
     "uses": [
       {
         "classes": [],
+        "context": "<span [transloco]=\"'triage.title'\">Triage</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.html",
+        "line": 49,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'triage.title'\">Triage</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.html",
+        "line": 133,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "this.error = this.transloco.translate('triage.reviewerAssignment.errorLoading');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
         "line": 257,
@@ -56936,58 +57047,44 @@
       },
       {
         "classes": [],
-        "context": "<h1 class=\"page-title\">{{ 'triage.queue' | transloco }}</h1>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 4,
+        "context": "[placeholder]=\"'triage.reviewerAssignment.searchPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 11,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'triage.tabs.surveyResponses' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 20,
+        "context": "{{ 'triage.reviewerAssignment.unassigned' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 48,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[placeholder]=\"'triage.list.searchPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 35,
+        "context": "<mat-label>{{ 'triage.reviewerAssignment.reviewer' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 53,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-option [value]=\"null\">{{ 'triage.list.allSurveys' | transloco }}</mat-option>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 72,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'triage.filters.confidential' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 81,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'triage.filters.confidentialOnly' | transloco",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 85,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'triage.filters.nonConfidential' | transloco",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 88,
+        "context": "[placeholder]=\"'triage.reviewerAssignment.reviewerPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 59,
         "partial_match": "medium"
       },
       {
         "classes": [],
         "context": "{{ 'triage.filters.clearFilters' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 97,
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 87,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<p>{{ 'triage.reviewerAssignment.loading' | transloco }}</p>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 165,
         "partial_match": "medium"
       }
     ]
@@ -57197,15 +57294,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "{{ 'triage.list.approve' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
-        "line": 33
-      },
-      {
-        "classes": [],
         "context": "[matTooltip]=\"'triage.list.approve' | transloco\"",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
         "line": 226
+      },
+      {
+        "classes": [],
+        "context": "{{ 'triage.list.approve' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.html",
+        "line": 33
       }
     ]
   },
@@ -57249,44 +57346,44 @@
       },
       {
         "classes": [],
-        "context": "<h1 class=\"page-title\">{{ 'triage.queue' | transloco }}</h1>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 4,
+        "context": "[placeholder]=\"'triage.reviewerAssignment.searchPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 11,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "{{ 'triage.tabs.surveyResponses' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 20,
+        "context": "{{ 'triage.reviewerAssignment.unassigned' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 48,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "[placeholder]=\"'triage.list.searchPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 35,
+        "context": "<mat-label>{{ 'triage.reviewerAssignment.reviewer' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 53,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-option [value]=\"null\">{{ 'triage.list.allSurveys' | transloco }}</mat-option>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 72,
+        "context": "[placeholder]=\"'triage.reviewerAssignment.reviewerPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 59,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<mat-label>{{ 'triage.filters.confidential' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 81,
+        "context": "{{ 'triage.filters.clearFilters' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 87,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "'triage.filters.confidentialOnly' | transloco",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 85,
+        "context": "<p>{{ 'triage.reviewerAssignment.loading' | transloco }}</p>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 165,
         "partial_match": "medium"
       }
     ]
@@ -57547,6 +57644,74 @@
       },
       {
         "classes": [],
+        "context": "[placeholder]=\"'triage.reviewerAssignment.searchPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 11,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'triage.reviewerAssignment.unassigned' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 48,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<mat-label>{{ 'triage.reviewerAssignment.reviewer' | transloco }}</mat-label>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 53,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "[placeholder]=\"'triage.reviewerAssignment.reviewerPlaceholder' | transloco\"",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 59,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'triage.filters.clearFilters' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 87,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<p>{{ 'triage.reviewerAssignment.loading' | transloco }}</p>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 165,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<h2>{{ 'triage.reviewerAssignment.noUnassignedFiltered' | transloco }}</h2>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 180,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "{{ 'triage.filters.clearFilters' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 182,
+        "partial_match": "medium"
+      }
+    ]
+  },
+  "triage.markPendingTriage": {
+    "ambiguous_word": false,
+    "confidence": "medium",
+    "ellipsis_candidate": false,
+    "found_by": "leaf",
+    "needs_translator_comment": false,
+    "surfaces": [
+      "general"
+    ],
+    "uses": [
+      {
+        "classes": [],
         "context": "this.error = this.transloco.translate('triage.reviewerAssignment.errorLoading');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
         "line": 257,
@@ -57600,87 +57765,19 @@
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
         "line": 165,
         "partial_match": "medium"
-      }
-    ]
-  },
-  "triage.markPendingTriage": {
-    "ambiguous_word": false,
-    "confidence": "medium",
-    "ellipsis_candidate": false,
-    "found_by": "leaf",
-    "needs_translator_comment": false,
-    "surfaces": [
-      "general"
-    ],
-    "uses": [
+      },
       {
         "classes": [],
-        "context": "<span [transloco]=\"'triage.title'\">Triage</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.html",
-        "line": 49,
+        "context": "<h2>{{ 'triage.reviewerAssignment.noUnassignedFiltered' | transloco }}</h2>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 180,
         "partial_match": "medium"
       },
       {
         "classes": [],
-        "context": "<span [transloco]=\"'triage.title'\">Triage</span>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.html",
-        "line": 133,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "this.error = this.transloco.translate('triage.reviewerAssignment.errorLoading');",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
-        "line": 257,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "title: this.transloco.translate('triage.reviewerAssignment.selectReviewer'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
-        "line": 381,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<h1 class=\"page-title\">{{ 'triage.queue' | transloco }}</h1>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 4,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'triage.tabs.surveyResponses' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 20,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "[placeholder]=\"'triage.list.searchPlaceholder' | transloco\"",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 35,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-option [value]=\"null\">{{ 'triage.list.allSurveys' | transloco }}</mat-option>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 72,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<mat-label>{{ 'triage.filters.confidential' | transloco }}</mat-label>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 81,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "'triage.filters.confidentialOnly' | transloco",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.html",
-        "line": 85,
+        "context": "{{ 'triage.filters.clearFilters' | transloco }}",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
+        "line": 182,
         "partial_match": "medium"
       }
     ]
@@ -57794,14 +57891,14 @@
       {
         "classes": [],
         "context": "this.transloco.translate('triage.messages.returnForRevisionError'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.ts",
-        "line": 349
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.ts",
+        "line": 482
       },
       {
         "classes": [],
         "context": "this.transloco.translate('triage.messages.returnForRevisionError'),",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-detail/triage-detail.component.ts",
-        "line": 482
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-list/triage-list.component.ts",
+        "line": 349
       }
     ]
   },
@@ -58002,15 +58099,15 @@
     "uses": [
       {
         "classes": [],
-        "context": "this.mode === 'view' ? 'triage.noteEditor.title.view' : 'triage.noteEditor.title.create';",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.ts",
-        "line": 140
-      },
-      {
-        "classes": [],
         "context": "expect(build({ mode: 'create' }).dialogTitle).toBe('triage.noteEditor.title.create');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.spec.ts",
         "line": 74
+      },
+      {
+        "classes": [],
+        "context": "this.mode === 'view' ? 'triage.noteEditor.title.view' : 'triage.noteEditor.title.create';",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/triage-note-editor-dialog/triage-note-editor-dialog.component.ts",
+        "line": 140
       }
     ]
   },
@@ -58070,6 +58167,20 @@
     "uses": [
       {
         "classes": [],
+        "context": "<span [transloco]=\"'triage.title'\">Triage</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.html",
+        "line": 49,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
+        "context": "<span [transloco]=\"'triage.title'\">Triage</span>",
+        "file": "/Users/efitz/Projects/tmi-ux/src/app/core/components/navbar/navbar.component.html",
+        "line": 133,
+        "partial_match": "medium"
+      },
+      {
+        "classes": [],
         "context": "this.error = this.transloco.translate('triage.reviewerAssignment.errorLoading');",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.ts",
         "line": 257,
@@ -58122,20 +58233,6 @@
         "context": "<p>{{ 'triage.reviewerAssignment.loading' | transloco }}</p>",
         "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
         "line": 165,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "<h2>{{ 'triage.reviewerAssignment.noUnassignedFiltered' | transloco }}</h2>",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 180,
-        "partial_match": "medium"
-      },
-      {
-        "classes": [],
-        "context": "{{ 'triage.filters.clearFilters' | transloco }}",
-        "file": "/Users/efitz/Projects/tmi-ux/src/app/pages/triage/components/reviewer-assignment-list/reviewer-assignment-list.component.html",
-        "line": 182,
         "partial_match": "medium"
       }
     ]

--- a/src/assets/i18n/es-ES.json
+++ b/src/assets/i18n/es-ES.json
@@ -269,7 +269,11 @@
       "subtitle": "Configurar límites de tasa y cuotas para usuarios.",
       "title": "Gestionar cuotas",
       "userAPITitle": "Límites de tasa de API",
-      "webhookTitle": "Límites de webhook"
+      "webhookTitle": "Límites de webhook",
+      "hint": {
+        "defaultAndRange": "Predeterminado: {{default}} (rango: {{min}}–{{max}})",
+        "outOfRange": "Introduce un valor entre {{min}} y {{max}}"
+      }
     },
     "sections": {
       "addons": {

--- a/src/assets/i18n/fr-FR.json
+++ b/src/assets/i18n/fr-FR.json
@@ -269,7 +269,11 @@
       "subtitle": "Configurer les limites de taux et les quotas pour les utilisateurs.",
       "title": "Gérer les quotas",
       "userAPITitle": "Limites de taux API",
-      "webhookTitle": "Limites des webhooks"
+      "webhookTitle": "Limites des webhooks",
+      "hint": {
+        "defaultAndRange": "Par défaut : {{default}} (plage : {{min}}–{{max}})",
+        "outOfRange": "Saisissez une valeur entre {{min}} et {{max}}"
+      }
     },
     "sections": {
       "addons": {

--- a/src/assets/i18n/he-IL.json
+++ b/src/assets/i18n/he-IL.json
@@ -269,7 +269,11 @@
       "subtitle": "הגדר מגבלות קצב ומכסות למשתמשים.",
       "title": "ניהול מכסות",
       "userAPITitle": "מגבלות קצב API",
-      "webhookTitle": "מגבלות Webhook"
+      "webhookTitle": "מגבלות Webhook",
+      "hint": {
+        "defaultAndRange": "ברירת מחדל: {{default}} (טווח: {{min}}–{{max}})",
+        "outOfRange": "יש להזין ערך בין {{min}} ל-{{max}}"
+      }
     },
     "sections": {
       "addons": {

--- a/src/assets/i18n/hi-IN.json
+++ b/src/assets/i18n/hi-IN.json
@@ -269,7 +269,11 @@
       "subtitle": "उपयोगकर्ताओं के लिए दर सीमाएं और कोटा कॉन्फ़िगर करें।",
       "title": "कोटा प्रबंधित करें",
       "userAPITitle": "API दर सीमाएं",
-      "webhookTitle": "Webhook सीमाएं"
+      "webhookTitle": "Webhook सीमाएं",
+      "hint": {
+        "defaultAndRange": "डिफ़ॉल्ट: {{default}} (सीमा: {{min}}–{{max}})",
+        "outOfRange": "{{min}} और {{max}} के बीच कोई मान दर्ज करें"
+      }
     },
     "sections": {
       "addons": {

--- a/src/assets/i18n/id-ID.json
+++ b/src/assets/i18n/id-ID.json
@@ -269,7 +269,11 @@
       "subtitle": "Konfigurasikan batas tingkat dan kuota untuk pengguna.",
       "title": "Kelola Kuota",
       "userAPITitle": "Batas Tingkat API",
-      "webhookTitle": "Batas Webhook"
+      "webhookTitle": "Batas Webhook",
+      "hint": {
+        "defaultAndRange": "Bawaan: {{default}} (rentang: {{min}}–{{max}})",
+        "outOfRange": "Masukkan nilai antara {{min}} dan {{max}}"
+      }
     },
     "sections": {
       "addons": {

--- a/src/assets/i18n/ja-JP.json
+++ b/src/assets/i18n/ja-JP.json
@@ -269,7 +269,11 @@
       "subtitle": "ユーザーのレート制限とクォータを設定します。",
       "title": "クォータの管理",
       "userAPITitle": "APIレート制限",
-      "webhookTitle": "Webhook制限"
+      "webhookTitle": "Webhook制限",
+      "hint": {
+        "defaultAndRange": "デフォルト: {{default}} (範囲: {{min}}〜{{max}})",
+        "outOfRange": "{{min}}〜{{max}} の値を入力してください"
+      }
     },
     "sections": {
       "addons": {

--- a/src/assets/i18n/ko-KR.json
+++ b/src/assets/i18n/ko-KR.json
@@ -269,7 +269,11 @@
       "subtitle": "사용자의 요청 제한 및 할당량을 구성합니다.",
       "title": "할당량 관리",
       "userAPITitle": "API 제한",
-      "webhookTitle": "Webhook 제한"
+      "webhookTitle": "Webhook 제한",
+      "hint": {
+        "defaultAndRange": "기본값: {{default}} (범위: {{min}}–{{max}})",
+        "outOfRange": "{{min}}에서 {{max}} 사이의 값을 입력하세요"
+      }
     },
     "sections": {
       "addons": {

--- a/src/assets/i18n/pt-BR.json
+++ b/src/assets/i18n/pt-BR.json
@@ -269,7 +269,11 @@
       "subtitle": "Configure limites de taxa e cotas para usuários.",
       "title": "Gerenciar cotas",
       "userAPITitle": "Limites de taxa de API",
-      "webhookTitle": "Limites de webhook"
+      "webhookTitle": "Limites de webhook",
+      "hint": {
+        "defaultAndRange": "Padrão: {{default}} (intervalo: {{min}}–{{max}})",
+        "outOfRange": "Insira um valor entre {{min}} e {{max}}"
+      }
     },
     "sections": {
       "addons": {

--- a/src/assets/i18n/ru-RU.json
+++ b/src/assets/i18n/ru-RU.json
@@ -269,7 +269,11 @@
       "subtitle": "Настройка лимитов и квот для пользователей.",
       "title": "Управление квотами",
       "userAPITitle": "Лимиты API",
-      "webhookTitle": "Лимиты вебхуков"
+      "webhookTitle": "Лимиты вебхуков",
+      "hint": {
+        "defaultAndRange": "По умолчанию: {{default}} (диапазон: {{min}}–{{max}})",
+        "outOfRange": "Введите значение от {{min}} до {{max}}"
+      }
     },
     "sections": {
       "addons": {

--- a/src/assets/i18n/th-TH.json
+++ b/src/assets/i18n/th-TH.json
@@ -269,7 +269,11 @@
       "subtitle": "กำหนดค่าขีดจำกัดอัตราและโควตาสำหรับผู้ใช้",
       "title": "จัดการโควตา",
       "userAPITitle": "ขีดจำกัดอัตรา API",
-      "webhookTitle": "ขีดจำกัด Webhook"
+      "webhookTitle": "ขีดจำกัด Webhook",
+      "hint": {
+        "defaultAndRange": "ค่าเริ่มต้น: {{default}} (ช่วง: {{min}}–{{max}})",
+        "outOfRange": "ป้อนค่าระหว่าง {{min}} ถึง {{max}}"
+      }
     },
     "sections": {
       "addons": {

--- a/src/assets/i18n/ur-PK.json
+++ b/src/assets/i18n/ur-PK.json
@@ -269,7 +269,11 @@
       "subtitle": "صارفین کے لیے شرح کی حدود اور کوٹہ ترتیب دیں۔",
       "title": "کوٹہ کا انتظام",
       "userAPITitle": "API شرح کی حدود",
-      "webhookTitle": "Webhook کی حدود"
+      "webhookTitle": "Webhook کی حدود",
+      "hint": {
+        "defaultAndRange": "طے شدہ: {{default}} (حد: {{min}}–{{max}})",
+        "outOfRange": "{{min}} اور {{max}} کے درمیان قدر درج کریں"
+      }
     },
     "sections": {
       "addons": {

--- a/src/assets/i18n/zh-CN.json
+++ b/src/assets/i18n/zh-CN.json
@@ -269,7 +269,11 @@
       "subtitle": "为用户配置速率限制和配额。",
       "title": "管理配额",
       "userAPITitle": "API 速率限制",
-      "webhookTitle": "Webhook 限制"
+      "webhookTitle": "Webhook 限制",
+      "hint": {
+        "defaultAndRange": "默认值:{{default}}(范围:{{min}}–{{max}})",
+        "outOfRange": "请输入 {{min}} 到 {{max}} 之间的值"
+      }
     },
     "sections": {
       "addons": {


### PR DESCRIPTION
## Summary
- New `QUOTA_LIMITS` constant in `quota.types.ts` transcribing per-field min/max from the OpenAPI spec's `UserQuotaUpdate`/`WebhookQuotaUpdate` schemas (the `minimum`/`maximum` constraints don't survive codegen — `api-types.d.ts` has bare `number`). The JSDoc names the spec as source of truth and flags the drift risk; ericfitz/tmi#649 tracks having the server expose defaults/ranges at runtime.
- All six quota fields in the add-quota dialog now enforce the range with `Validators.max` (plus spec-sourced min); the save button was already gated on form validity.
- The six hard-coded, unlocalized `Default: N` hints are replaced with one localized hint per field — "Default: {{default}} (range: {{min}}–{{max}})" — plus a `mat-error` showing the allowed range, and `[min]`/`[max]` on the inputs.
- Hint params are precomputed once at module scope rather than rebuilt every change-detection cycle.
- `admin.quotas.hint.*` strings added to all 16 locales; usage-map sidecar regenerated.

## Test plan
- [x] `pnpm run lint:all` clean
- [x] `pnpm run build` clean
- [x] Dialog spec 15/15 (3 new: max violation, boundary values, hint params)
- [x] Pre-commit code review (verdict: ready to merge; two minors applied — precomputed params, constant-derived test expectation)

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PujcZ538V2YCGz4yv6PswX