### PR TITLE
ops: bump GitHub Actions pins to Node 24 runtimes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,15 +25,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 
@@ -43,7 +43,7 @@ jobs:
         run: echo "store-path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ steps.pnpm-cache.outputs.store-path }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -54,7 +54,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
@@ -63,6 +63,6 @@ jobs:
         run: pnpm run build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/deps-bump.yml
+++ b/.github/workflows/deps-bump.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Mint GitHub App token (reads Dependabot alerts)
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.DEPS_BOT_APP_ID }}
           private-key: ${{ secrets.DEPS_BOT_APP_PRIVATE_KEY }}
@@ -78,7 +78,7 @@ jobs:
       group: deps-bump-run-${{ matrix.branch }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ matrix.branch }}
           fetch-depth: 0
@@ -88,12 +88,12 @@ jobs:
           persist-credentials: false
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false   # version is read from package.json "packageManager"
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
 
@@ -149,7 +149,7 @@ jobs:
       # scoped to this App's Contents + Pull-requests permissions on this repo.
       - name: Mint GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.DEPS_BOT_APP_ID }}
           private-key: ${{ secrets.DEPS_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -36,7 +36,7 @@ jobs:
           E2E_API_URL: ${{ inputs.api_url }}
 
       - name: Upload test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -53,20 +53,20 @@ jobs:
     steps:
       - name: Mint GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.DEPS_BOT_APP_ID }}
           private-key: ${{ secrets.DEPS_BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
 
@@ -102,13 +102,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
 
@@ -139,12 +139,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout PR merge ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
 


### PR DESCRIPTION
Every action pinned in the four workflows ran on the deprecated node20
runtime and was being force-run on Node 24 by the runner. That warning
preceded the `bump` job in Version Bump hanging: all of its steps
reported success but the check-run never finalized, leaving PR #848
stuck at UNSTABLE with a phantom in_progress check.

- actions/checkout                 v4 -> v7
- actions/setup-node               v4 -> v7
- actions/create-github-app-token  v1 -> v3
- actions/cache                    v4 -> v6
- actions/upload-artifact          v4 -> v7
- pnpm/action-setup                v4 -> v6
- github/codeql-action/{init,analyze} v3 -> v4

Compatibility checked against the breaking changes in each major:

- create-github-app-token v2 removed the snake_case inputs and made
  app-id/private-key required; all three call sites already use the
  hyphenated required form. v3 needs NODE_USE_ENV_PROXY only for proxy
  setups, which we do not use.
- setup-node v5 auto-caches when package.json has a packageManager
  field, which would have broken the jobs that set up Node before pnpm.
  v6 narrowed that to npm only, and this repo declares pnpm, so landing
  directly on v7 skips the hazard entirely.
- checkout v7 blocks fork checkouts for pull_request_target and
  workflow_run; no workflow here uses either trigger. v6 moved persisted
  credentials to a separate file, but persist-credentials still defaults
  true, so the Version Bump push keeps working, and deps-bump already
  sets it false and pushes with the App token explicitly.
- pnpm/action-setup reads the version from packageManager (pnpm 10.34.4)
  at every call site; v6 only adds pnpm 11 support.
- codeql-action v4 forked from 3.x at 4.30.7 solely for the Node 24
  runtime. The only removed input, add-snippets, is not used here, and
  the local config-file path form is still accepted.

Verified with actionlint (clean apart from a pre-existing SC2086 info at
codeql.yml:43) and pnpm run lint:all.