### PR TITLE
ops: stop Dependabot proposing @oxc-project/runtime bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,3 +85,13 @@ updates:
       - dependency-name: "zone.js"
         update-types: ["version-update:semver-minor"]
         versions: [">=0.16.0", "<1.0.0"]
+
+      # oxc runtime helpers: must be bumped together with vite/rolldown, never
+      # on their own. The helpers pair with the oxc transformer bundled inside
+      # rolldown, but neither vite nor rolldown declares this package, so there
+      # is no dependency edge for pnpm to enforce -- and build/test/lint stay
+      # green even when the pairing is wrong. See the rationale recorded in
+      # package.json under comments.devDependencies. Bump it by hand alongside
+      # vite, then smoke-test a cold-boot `ng serve` plus a real browser load.
+      - dependency-name: "@oxc-project/runtime"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
Stops Dependabot from proposing `@oxc-project/runtime` minor/patch bumps.

## Why

The package supplies oxc *runtime helpers* that must match the oxc *transformer* bundled inside rolldown. The pairing is real but invisible to the package manager — verified on this branch:

```
$ pnpm why @oxc-project/runtime
@oxc-project/runtime@0.143.0
└── tmi-ux (devDependencies)          # nothing else depends on it

$ jq '.dependencies|keys' node_modules/vite/package.json
["lightningcss","picomatch","postcss","rolldown","tinyglobby"]   # no oxc runtime
```

No dependency edge exists, so pnpm cannot enforce or even detect a mismatch, and `build` / `test` / `lint` all stay green when it is wrong. The failure mode is a cold-boot `ng serve`, which CI does not run.

Dependabot had been reopening this on every release (most recently #854), and each one had to be re-reasoned from scratch.

## Scope

Minor and patch only, matching the existing Angular v21 and zone.js ignore entries. Majors are deliberately still proposed — a 0.x → 1.0 is worth surfacing.

The rationale for the hold itself is recorded in `package.json` under `comments.devDependencies` (#856); this PR only stops the automated churn.

Config parses clean (21 ignore entries, oxc entry included); `pnpm run lint:all` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Z7iTLabv64pfzCA2iHx6G
