### PR TITLE
ops: deploy tmi-ux to the local k3s cluster; fix container builds; add HANDOFF.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN npm install -g pnpm@10.18.3
 
 # Copy package files
 COPY package.json pnpm-lock.yaml ./
+# pnpm patches (package.json pnpm.patchedDependencies) must be present at install time
+COPY patches ./patches
 
 # Install dependencies
 RUN pnpm install --frozen-lockfile
@@ -33,7 +35,7 @@ LABEL org.opencontainers.image.version=$APP_VERSION
 WORKDIR /app
 
 # Create minimal package.json for runtime dependencies only
-RUN echo '{"name":"tmi-ux-server","version":"1.0.0","type":"module","dependencies":{"express":"^5.1.0","express-rate-limit":"^8.1.0"}}' > package.json
+RUN echo '{"name":"tmi-ux-server","version":"1.0.0","type":"module","dependencies":{"express":"^5.2.1","express-rate-limit":"^8.6.2","http-proxy-middleware":"^4.2.0"}}' > package.json
 
 # Install only runtime dependencies
 RUN npm install --omit=dev --production

--- a/Dockerfile.chainguard
+++ b/Dockerfile.chainguard
@@ -14,6 +14,8 @@ RUN corepack enable && corepack prepare pnpm@10.24.0 --activate
 
 # Copy package files first for layer caching
 COPY package.json pnpm-lock.yaml ./
+# pnpm patches (package.json pnpm.patchedDependencies) must be present at install time
+COPY patches ./patches
 
 # Install all dependencies (including devDependencies for build)
 RUN pnpm install --frozen-lockfile
@@ -31,7 +33,7 @@ USER root
 WORKDIR /app
 
 # Create minimal package.json with only runtime server dependencies
-RUN echo '{"name":"tmi-ux-server","version":"1.0.0","type":"module","dependencies":{"express":"^5.1.0","express-rate-limit":"^8.1.0"}}' > package.json
+RUN echo '{"name":"tmi-ux-server","version":"1.0.0","type":"module","dependencies":{"express":"^5.2.1","express-rate-limit":"^8.6.2","http-proxy-middleware":"^4.2.0"}}' > package.json
 
 # Install only production dependencies
 RUN npm install --omit=dev --production

--- a/Dockerfile.oci
+++ b/Dockerfile.oci
@@ -19,6 +19,8 @@ RUN npm install -g pnpm@10.18.3
 
 # Copy package files
 COPY package.json pnpm-lock.yaml ./
+# pnpm patches (package.json pnpm.patchedDependencies) must be present at install time
+COPY patches ./patches
 
 # Install dependencies
 RUN pnpm install --frozen-lockfile
@@ -33,7 +35,7 @@ RUN pnpm run build:oci
 # This runs in the builder stage which has npm registry access
 RUN mkdir /runtime && \
     cd /runtime && \
-    echo '{"name":"tmi-ux-server","version":"1.0.0","type":"module","dependencies":{"express":"^5.2.1","express-rate-limit":"^8.3.1"}}' > package.json && \
+    echo '{"name":"tmi-ux-server","version":"1.0.0","type":"module","dependencies":{"express":"^5.2.1","express-rate-limit":"^8.6.2","http-proxy-middleware":"^4.2.0"}}' > package.json && \
     npm install --omit=dev
 
 # Stage 2: Production server on Oracle Linux 9

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,31 @@
+# HANDOFF — state as of 2026-08-19 (v1.11.2)
+
+Read this first when resuming. Everything below is on `main` unless noted.
+
+## Where things stand
+
+- **v1.11.2 on `main`** (`9b271116`). Two batches landed today:
+  - **#860 CI quality gate** (PR #863, v1.11.1): `.github/workflows/quality.yml` runs three required checks on every PR — `Checks (lint, typecheck, validate)`, `Unit tests`, `Build` — plus CodeQL; all four are required by the `main` ruleset (ruleset id 17854947) with no bypass. Check-only lint scripts `lint:*:check`; `pretest`/`pretypecheck:vitest` generate the gitignored `src/build-info.json` so fresh checkouts work.
+  - **#858 spec type errors 342 → 0** (PR #864, v1.11.2): `pnpm run typecheck:vitest` is a CI gate at **zero**; the ratchet (script, baseline, `*:ratchet` scripts) is gone. Rules for keeping it there: fix fixtures to the real interface; never `any`/`@ts-expect-error`/widening; `as unknown as T` only for deliberately malformed input, commented, and never when a plain `as T` compiles. ESLint's typed rules use `tsconfig.json` (no `@testing/*` alias) — run `lint:check` as well as tsc.
+- **tmi-ux is now deployed on the Raspberry Pi k3s cluster** (kube context `k3s-rp`, namespace `tmi-platform`): `http://rp2:30081/` (NodePort 30081; also `http://192.168.1.2:30081/`), image `rp2:30500/tmi-ux:dev`, API URL `http://rp2:30080`. Deploy/redeploy with **`pnpm run deploy:k3s`** (`scripts/deploy-k3s.sh` → `deployments/k8s/dev/k3s/tmi-ux.yml`). Verified serving the v1.11.2 bundle.
+  - **Pending (needs you, blocked for Claude by the permission classifier):** browser login from that origin needs `http://rp2:30081/*` (and `http://192.168.1.2:30081/*`) in the server's runtime `auth.oauth.client_callback_allowlist` — a **DB row** (`system_settings`) that overrides the YAML. One-liner in the last session transcript / or: `kubectl --context k3s-rp -n tmi-platform exec sts/postgres -- psql …` appending to the JSON array. Also note the server's `auth.oauth_callback_url` is `http://localhost:8080/oauth2/callback`; if login still fails after the allowlist change, that redirect URI is the next suspect (it assumes a `localhost:8080` port-forward). Consider adding the k3s origin to `tmi/config-development.yml` so a fresh DB seeds it.
+  - Container builds had two latent breaks fixed in this PR: Dockerfiles didn't `COPY patches` before `pnpm install` (x6 pnpm patch → ENOENT), and the runtime-deps stage lacked `http-proxy-middleware`. All three Dockerfiles fixed.
+
+## Open follow-ups from #858 (Backlog, TMI project)
+
+#865 `fix:` production `_isLocalProviderOffline()` reads phantom `authService.isUsingLocalProvider` via `as any` (always falsy) · #866 two divergent `LoadResult` types / `loadDiagram(): Observable<any>` · #867 validator param vs its `unknown` interface · #868 shared `createTestUser()` factories · #869 `'peer'` literal in related-dialog specs · #870 spec `as any` sweep (~750) · #871 export `PageSize`/`MarginSize`.
+
+## Next session
+
+1. **Browser verification debt** (merged in v1.11.0, never exercised in a browser) — the k3s deployment now gives you a real target: #812 page-header close buttons white-on-red in all four palettes (light/dark × normal/colorblind); #821 triage search no-match state + column sort; #831 `pnpm run test:e2e:field-coverage` (needs `pnpm dev:e2e` + a backend on `:8080`).
+2. Complete the k3s login config (above), then smoke-test login at `http://rp2:30081/`.
+3. Pick from #865–#871 (start with #865 — real dead code behind a cast).
+
+## Gotchas (still true)
+
+- `pnpm run lint:i18n` enforces sentence-final punctuation; 143 keys use `.lint-skip`. `pnpm run check-i18n` re-sorts locale files — isolate in a `style:` commit.
+- Script/heredoc edits bypass the formatting hook — `format:check` is a CI gate for `src/**` (not `.github/`, `package.json`).
+- graphify does not index HTML templates.
+- SSH key is Touch ID gated; a `Permission denied (publickey)` push means wait for the user, do not retry.
+- `rp2` must resolve (it is pinned in `/etc/hosts`); Docker Desktop trusts `rp2:30500` as insecure; see `tmi/deployments/k8s/dev/k3s/README-node-setup.md`.
+- Pi 5 nodes run a 16KB-page kernel: jemalloc-built images (e.g. Chainguard redis) abort; Node images are fine.

--- a/deployments/k8s/dev/k3s/tmi-ux.yml
+++ b/deployments/k8s/dev/k3s/tmi-ux.yml
@@ -1,0 +1,78 @@
+# tmi-ux on the local Raspberry Pi k3s cluster (kube context `k3s-rp`).
+#
+# Companion to the server's k3s dev overlay in the tmi repo
+# (deployments/k8s/dev/k3s/): same namespace, same in-cluster registry
+# (rp2:30500), served on NodePort 30081 next to the server's 30080.
+# Deploy with `pnpm run deploy:k3s` (scripts/deploy-k3s.sh), which builds
+# Dockerfile.chainguard for the host arch (Apple Silicon == Pi arm64), pushes
+# to rp2:30500, applies this file, and waits for the rollout.
+#
+# The browser talks to the API directly at http://rp2:30080 (TMI_API_URL); the
+# server's OAuth client_callback_allowlist must admit http://rp2:30081/* —
+# see deploy-k3s.sh's post-deploy note.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tmi-ux
+  namespace: tmi-platform
+  labels:
+    app: tmi-ux
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tmi-ux
+  template:
+    metadata:
+      labels:
+        app: tmi-ux
+    spec:
+      containers:
+        - name: tmi-ux
+          image: rp2:30500/tmi-ux:dev
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: TMI_API_URL
+              value: http://rp2:30080
+            - name: TMI_OPERATOR_NAME
+              value: TMI dev (k3s-rp)
+            - name: TMI_LOG_LEVEL
+              value: debug
+          readinessProbe:
+            httpGet:
+              path: /config.json
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /config.json
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 96Mi
+            limits:
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tmi-ux
+  namespace: tmi-platform
+  labels:
+    app: tmi-ux
+spec:
+  type: NodePort
+  selector:
+    app: tmi-ux
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      nodePort: 30081

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmi-ux",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "type": "module",
   "scripts": {
     "prepare": "git config core.hooksPath .husky 2>/dev/null || true",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "deploy:chainguard": "./scripts/push-chainguard.sh",
     "deploy:aws:ecr": "./scripts/push-ecr.sh",
     "deploy:aws:eks": "aws eks update-kubeconfig --region us-east-1 --name tmi-eks && kubectl rollout restart deployment/tmi-ux -n tmi && kubectl get pods -n tmi -l app=tmi-ux -w",
+    "deploy:k3s": "bash scripts/deploy-k3s.sh",
     "generate:api-types": "sh scripts/generate-api-types.sh",
     "generate:icon-manifest": "tsx scripts/generate-icon-manifest.ts"
   },

--- a/scripts/deploy-k3s.sh
+++ b/scripts/deploy-k3s.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Deploy tmi-ux to the local Raspberry Pi k3s cluster (kube context k3s-rp).
+#
+# Builds Dockerfile.chainguard for the host architecture (Apple Silicon and the
+# Pi 5 nodes are both arm64, so no buildx/--platform is needed), pushes the image
+# to the in-cluster registry at rp2:30500, applies deployments/k8s/dev/k3s/tmi-ux.yml
+# and waits for the rollout. Mirrors the server repo's `make dev-up CLUSTER=k3s`
+# image path (see tmi/deployments/k8s/dev/k3s/README-node-setup.md for the
+# one-time host/node setup: rp2 in /etc/hosts, rp2:30500 as an insecure registry
+# in Docker Desktop, and the containerd mirror on each node).
+#
+# Usage:
+#   pnpm run deploy:k3s            # build, push, apply, rollout
+#   pnpm run deploy:k3s -- --skip-build   # re-apply/restart with the existing image
+#
+# Environment:
+#   K3S_CONTEXT   kube context (default: k3s-rp)
+#   K3S_REGISTRY  registry host:port (default: rp2:30500)
+#   IMAGE_TAG     image tag (default: dev)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+K3S_CONTEXT="${K3S_CONTEXT:-k3s-rp}"
+K3S_REGISTRY="${K3S_REGISTRY:-rp2:30500}"
+IMAGE_TAG="${IMAGE_TAG:-dev}"
+NAMESPACE="tmi-platform"
+MANIFEST="$PROJECT_ROOT/deployments/k8s/dev/k3s/tmi-ux.yml"
+IMAGE="${K3S_REGISTRY}/tmi-ux:${IMAGE_TAG}"
+SKIP_BUILD=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --skip-build) SKIP_BUILD=true ;;
+    --help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown option: $arg" >&2; exit 1 ;;
+  esac
+done
+
+echo "=== tmi-ux -> k3s (${K3S_CONTEXT}) ==="
+echo "Image:    ${IMAGE}"
+echo "Manifest: ${MANIFEST}"
+echo ""
+
+# Pre-flight: the cluster must be reachable and the registry service present.
+kubectl --context "$K3S_CONTEXT" get svc registry -n "$NAMESPACE" >/dev/null
+if ! docker info 2>/dev/null | grep -A5 "Insecure Registries" | grep -q "$K3S_REGISTRY"; then
+  echo "Docker daemon does not list ${K3S_REGISTRY} as an insecure registry; push will fail." >&2
+  echo "See tmi/deployments/k8s/dev/k3s/README-node-setup.md." >&2
+  exit 1
+fi
+
+if [ "$SKIP_BUILD" = false ]; then
+  APP_VERSION=$(node -p "require('$PROJECT_ROOT/package.json').version")
+  # build-info.json is generated on the host (no git inside the container build).
+  sh "$SCRIPT_DIR/generate-build-info.sh"
+  echo "Building ${IMAGE} (version ${APP_VERSION})..."
+  docker build \
+    --build-arg APP_VERSION="${APP_VERSION}" \
+    -f "$PROJECT_ROOT/Dockerfile.chainguard" \
+    -t "$IMAGE" \
+    "$PROJECT_ROOT"
+  echo "Pushing ${IMAGE}..."
+  docker push "$IMAGE"
+fi
+
+echo "Applying manifest..."
+kubectl --context "$K3S_CONTEXT" apply -f "$MANIFEST"
+# imagePullPolicy: Always + a fixed tag means a re-push needs a restart to pick
+# up the new digest.
+kubectl --context "$K3S_CONTEXT" -n "$NAMESPACE" rollout restart deployment/tmi-ux
+kubectl --context "$K3S_CONTEXT" -n "$NAMESPACE" rollout status deployment/tmi-ux --timeout=180s
+
+NODE_IP=$(kubectl --context "$K3S_CONTEXT" get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+NODE_PORT=$(kubectl --context "$K3S_CONTEXT" -n "$NAMESPACE" get svc tmi-ux -o jsonpath='{.spec.ports[0].nodePort}')
+echo ""
+echo "=== Deployed ==="
+echo "UI:      http://rp2:${NODE_PORT}/  (also http://${NODE_IP}:${NODE_PORT}/)"
+echo "API:     $(kubectl --context "$K3S_CONTEXT" -n "$NAMESPACE" get deploy tmi-ux -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="TMI_API_URL")].value}')"
+echo ""
+echo "Note: OAuth login from this origin requires http://rp2:${NODE_PORT}/* in the"
+echo "server's auth.oauth.client_callback_allowlist (runtime setting in the DB)."


### PR DESCRIPTION
## Summary
- **k3s deployment**: `deployments/k8s/dev/k3s/tmi-ux.yml` (Deployment + NodePort 30081 in `tmi-platform`, `TMI_API_URL=http://rp2:30080`) and `scripts/deploy-k3s.sh` wired as `pnpm run deploy:k3s` — builds `Dockerfile.chainguard` for the host arch, pushes to the in-cluster registry `rp2:30500`, applies, waits for rollout. Mirrors the server repo's `make dev-up CLUSTER=k3s` image path. Already deployed and verified serving v1.11.2 at `http://rp2:30081/`.
- **Container build fixes** (all three Dockerfiles; both broke every image build/run since the x6 v3 upgrade and the API-proxy feature): `COPY patches` before `pnpm install` (pnpm patch ENOENT), and `http-proxy-middleware` added to the runtime-deps stage (`server.js` imports it; container crash-looped).
- **HANDOFF.md** recreated with current status (#860, #858, k3s) and next steps.

Note: OAuth login from the k3s origin still needs `http://rp2:30081/*` in the server's runtime `auth.oauth.client_callback_allowlist` DB row — documented in HANDOFF.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FY8MrMWjT81hGBsHuDHdtU