### PR TITLE
fix: account deletion endpoint, E2E seed alias, and dashboard visibility coverage (#880, #885)

### DIFF
--- a/e2e/fixtures/auth-fixtures.ts
+++ b/e2e/fixtures/auth-fixtures.ts
@@ -52,6 +52,19 @@ export const adminTest = base.extend<{ adminPage: Page }>({
 });
 
 /**
+ * Test fixture authenticated as a user who is neither a security reviewer nor
+ * the owner of (nor granted access to) any seeded entity. Exists so visibility
+ * rules can be asserted negatively — see the seed spec's `test-outsider` note.
+ */
+export const outsiderTest = base.extend<{ outsiderPage: Page }>({
+  outsiderPage: async ({ browser }, use) => {
+    const { page, cleanup } = await createAuthenticatedPage(browser, 'test-outsider');
+    await use(page);
+    await cleanup();
+  },
+});
+
+/**
  * Test fixture with all three roles for cross-role workflow tests.
  * Each role gets its own BrowserContext (separate sessions).
  */

--- a/e2e/pages/dashboard.page.ts
+++ b/e2e/pages/dashboard.page.ts
@@ -17,11 +17,9 @@ export class DashboardPage {
     await this.createTmButton().waitFor({ state: 'visible', timeout });
   }
 
-  readonly createTmButton = () =>
-    this.page.getByTestId('create-threat-model-button');
+  readonly createTmButton = () => this.page.getByTestId('create-threat-model-button');
 
-  readonly tmCards = () =>
-    this.page.getByTestId('threat-model-card');
+  readonly tmCards = () => this.page.getByTestId('threat-model-card');
 
   // SEM@e15bebe5e59e4b6516150171ca189d73b0206f1c: locate a threat model card matching the given name (pure)
   tmCard(name: string) {
@@ -42,6 +40,8 @@ export class DashboardPage {
   readonly clearFiltersButton = () => this.page.getByTestId('dashboard-clear-filters-button');
   readonly descriptionFilter = () => this.page.getByTestId('dashboard-description-filter');
   readonly ownerFilter = () => this.page.getByTestId('dashboard-owner-filter');
+  readonly securityReviewerFilter = () =>
+    this.page.getByTestId('dashboard-security-reviewer-filter');
   readonly issueUriFilter = () => this.page.getByTestId('dashboard-issue-uri-filter');
   readonly createdAfter = () => this.page.getByTestId('dashboard-created-after');
   readonly createdBefore = () => this.page.getByTestId('dashboard-created-before');

--- a/e2e/seed/seed-spec.json
+++ b/e2e/seed/seed-spec.json
@@ -84,7 +84,6 @@
       "project_id": "Seed Project One",
       "security_reviewer": "test-reviewer",
       "issue_uri": "https://example.com/issues/1",
-      "alias": ["seed-tm-1", "full-fields-tm"],
       "metadata": [{ "key": "risk_level", "value": "high" }],
       "authorization": [
         { "user_id": "test-user", "role": "reader" },

--- a/e2e/seed/seed-spec.json
+++ b/e2e/seed/seed-spec.json
@@ -25,6 +25,15 @@
       "roles": { "is_admin": true, "is_security_reviewer": true },
       "oauth_provider": "tmi",
       "api_quota": { "rpm": 100000, "rph": 1000000 }
+    },
+    {
+      "id": "test-outsider",
+      "email": "test-outsider@tmi.local",
+      "display_name": "Test Outsider",
+      "roles": { "is_admin": false, "is_security_reviewer": false },
+      "oauth_provider": "tmi",
+      "api_quota": { "rpm": 100000, "rph": 1000000 },
+      "notes": "Owns nothing and is granted nothing, deliberately. Negative case for dashboard visibility: a non-reviewer with no owned threat models must see an empty dashboard. Do not grant this user access to any seeded entity."
     }
   ],
   "teams": [
@@ -38,18 +47,14 @@
         { "user_id": "test-user", "role": "engineer" },
         { "user_id": "test-reviewer", "role": "engineering_lead" }
       ],
-      "responsible_parties": [
-        { "user_id": "test-reviewer", "role": "engineering_lead" }
-      ],
+      "responsible_parties": [{ "user_id": "test-reviewer", "role": "engineering_lead" }],
       "metadata": [{ "key": "department", "value": "Engineering" }]
     },
     {
       "name": "Seed Team Beta",
       "status": "active",
       "description": "Secondary team for relationship testing",
-      "members": [
-        { "user_id": "test-user", "role": "member" }
-      ],
+      "members": [{ "user_id": "test-user", "role": "member" }],
       "metadata": []
     }
   ],
@@ -60,9 +65,7 @@
       "status": "active",
       "description": "Primary project for E2E testing",
       "uri": "https://example.com/projects/one",
-      "responsible_parties": [
-        { "user_id": "test-user", "role": "engineer" }
-      ],
+      "responsible_parties": [{ "user_id": "test-user", "role": "engineer" }],
       "metadata": [{ "key": "fiscal_year", "value": "2026" }]
     },
     {
@@ -77,7 +80,7 @@
     {
       "name": "Seed TM - Full Fields",
       "description": "Threat model with all fields populated for field-coverage testing",
-      "owner": "test-reviewer",
+      "owner": "test-user",
       "threat_model_framework": "STRIDE",
       "status": "active",
       "is_confidential": false,
@@ -85,10 +88,7 @@
       "security_reviewer": "test-reviewer",
       "issue_uri": "https://example.com/issues/1",
       "metadata": [{ "key": "risk_level", "value": "high" }],
-      "authorization": [
-        { "user_id": "test-user", "role": "reader" },
-        { "user_id": "test-reviewer", "role": "writer" }
-      ],
+      "authorization": [{ "user_id": "test-reviewer", "role": "writer" }],
       "threats": [
         {
           "name": "Seed Threat - All Fields",
@@ -102,7 +102,11 @@
           "mitigation": "Implement input validation and CSRF tokens",
           "cwe_id": ["CWE-79", "CWE-352"],
           "cvss": [
-            { "version": "3.1", "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", "score": 9.8 }
+            {
+              "version": "3.1",
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "score": 9.8
+            }
           ],
           "issue_uri": "https://example.com/issues/2",
           "include_in_report": true
@@ -170,13 +174,38 @@
             { "id": "actor-ext", "type": "actor", "label": "External User", "x": 50, "y": 150 },
             { "id": "actor-int", "type": "actor", "label": "Internal Admin", "x": 50, "y": 450 },
             { "id": "process-gw", "type": "process", "label": "API Gateway", "x": 300, "y": 300 },
-            { "id": "process-auth", "type": "process", "label": "Auth Service", "x": 550, "y": 150 },
-            { "id": "process-core", "type": "process", "label": "Core Service", "x": 550, "y": 300 },
-            { "id": "process-notify", "type": "process", "label": "Notification Service", "x": 550, "y": 450 },
+            {
+              "id": "process-auth",
+              "type": "process",
+              "label": "Auth Service",
+              "x": 550,
+              "y": 150
+            },
+            {
+              "id": "process-core",
+              "type": "process",
+              "label": "Core Service",
+              "x": 550,
+              "y": 300
+            },
+            {
+              "id": "process-notify",
+              "type": "process",
+              "label": "Notification Service",
+              "x": 550,
+              "y": 450
+            },
             { "id": "store-db", "type": "store", "label": "Primary DB", "x": 800, "y": 200 },
             { "id": "store-cache", "type": "store", "label": "Redis Cache", "x": 800, "y": 400 },
             { "id": "store-queue", "type": "store", "label": "Message Queue", "x": 800, "y": 550 },
-            { "id": "process-embedded", "type": "process", "label": "Validator", "x": 320, "y": 320, "parent": "process-gw" }
+            {
+              "id": "process-embedded",
+              "type": "process",
+              "label": "Validator",
+              "x": 320,
+              "y": 320,
+              "parent": "process-gw"
+            }
           ],
           "edges": [
             { "source": "actor-ext", "target": "process-gw", "label": "HTTPS Request" },
@@ -208,41 +237,127 @@
             "name": "basicInputs",
             "title": "Basic Inputs",
             "elements": [
-              { "type": "text", "name": "project_name", "title": "Project Name", "isRequired": true },
-              { "type": "comment", "name": "project_description", "title": "Describe Your Project" },
-              { "type": "boolean", "name": "has_external_users", "title": "Does this project have external users?", "labelTrue": "Yes", "labelFalse": "No" }
+              {
+                "type": "text",
+                "name": "project_name",
+                "title": "Project Name",
+                "isRequired": true
+              },
+              {
+                "type": "comment",
+                "name": "project_description",
+                "title": "Describe Your Project"
+              },
+              {
+                "type": "boolean",
+                "name": "has_external_users",
+                "title": "Does this project have external users?",
+                "labelTrue": "Yes",
+                "labelFalse": "No"
+              }
             ]
           },
           {
             "name": "selectionInputs",
             "title": "Selection Inputs",
             "elements": [
-              { "type": "radiogroup", "name": "data_sensitivity", "title": "Data Sensitivity Level", "choices": [{ "value": "public", "text": "Public" }, { "value": "internal", "text": "Internal" }, { "value": "confidential", "text": "Confidential" }, { "value": "restricted", "text": "Restricted" }] },
-              { "type": "checkbox", "name": "compliance_frameworks", "title": "Applicable Compliance Frameworks", "choices": [{ "value": "soc2", "text": "SOC 2" }, { "value": "hipaa", "text": "HIPAA" }, { "value": "pci", "text": "PCI DSS" }, { "value": "gdpr", "text": "GDPR" }] },
-              { "type": "dropdown", "name": "deployment_model", "title": "Deployment Model", "choices": [{ "value": "cloud", "text": "Cloud (SaaS)" }, { "value": "on_prem", "text": "On-Premises" }, { "value": "hybrid", "text": "Hybrid" }] }
+              {
+                "type": "radiogroup",
+                "name": "data_sensitivity",
+                "title": "Data Sensitivity Level",
+                "choices": [
+                  { "value": "public", "text": "Public" },
+                  { "value": "internal", "text": "Internal" },
+                  { "value": "confidential", "text": "Confidential" },
+                  { "value": "restricted", "text": "Restricted" }
+                ]
+              },
+              {
+                "type": "checkbox",
+                "name": "compliance_frameworks",
+                "title": "Applicable Compliance Frameworks",
+                "choices": [
+                  { "value": "soc2", "text": "SOC 2" },
+                  { "value": "hipaa", "text": "HIPAA" },
+                  { "value": "pci", "text": "PCI DSS" },
+                  { "value": "gdpr", "text": "GDPR" }
+                ]
+              },
+              {
+                "type": "dropdown",
+                "name": "deployment_model",
+                "title": "Deployment Model",
+                "choices": [
+                  { "value": "cloud", "text": "Cloud (SaaS)" },
+                  { "value": "on_prem", "text": "On-Premises" },
+                  { "value": "hybrid", "text": "Hybrid" }
+                ]
+              }
             ]
           },
           {
             "name": "conditionalLogic",
             "title": "Conditional Logic",
             "elements": [
-              { "type": "radiogroup", "name": "stores_pii", "title": "Does this system store PII?", "choices": [{ "value": "yes", "text": "Yes" }, { "value": "no", "text": "No" }] },
-              { "type": "comment", "name": "pii_details", "title": "Describe what PII is stored and how it is protected", "visibleIf": "{stores_pii} = 'yes'" },
-              { "type": "text", "name": "pii_retention_days", "title": "PII retention period (days)", "inputType": "number", "visibleIf": "{stores_pii} = 'yes'" }
+              {
+                "type": "radiogroup",
+                "name": "stores_pii",
+                "title": "Does this system store PII?",
+                "choices": [
+                  { "value": "yes", "text": "Yes" },
+                  { "value": "no", "text": "No" }
+                ]
+              },
+              {
+                "type": "comment",
+                "name": "pii_details",
+                "title": "Describe what PII is stored and how it is protected",
+                "visibleIf": "{stores_pii} = 'yes'"
+              },
+              {
+                "type": "text",
+                "name": "pii_retention_days",
+                "title": "PII retention period (days)",
+                "inputType": "number",
+                "visibleIf": "{stores_pii} = 'yes'"
+              }
             ]
           },
           {
             "name": "groupedInputs",
             "title": "Grouped Inputs",
             "elements": [
-              { "type": "panel", "name": "infrastructure_panel", "title": "Infrastructure Details", "elements": [
-                { "type": "text", "name": "cloud_provider", "title": "Cloud Provider" },
-                { "type": "text", "name": "region", "title": "Primary Region" }
-              ]},
-              { "type": "paneldynamic", "name": "integrations", "title": "Third-Party Integrations", "templateTitle": "Integration #{panelIndex}", "templateElements": [
-                { "type": "text", "name": "integration_name", "title": "Integration Name" },
-                { "type": "dropdown", "name": "integration_type", "title": "Integration Type", "choices": [{ "value": "api", "text": "API" }, { "value": "sdk", "text": "SDK" }, { "value": "webhook", "text": "Webhook" }] }
-              ], "panelCount": 1, "minPanelCount": 0, "maxPanelCount": 5 }
+              {
+                "type": "panel",
+                "name": "infrastructure_panel",
+                "title": "Infrastructure Details",
+                "elements": [
+                  { "type": "text", "name": "cloud_provider", "title": "Cloud Provider" },
+                  { "type": "text", "name": "region", "title": "Primary Region" }
+                ]
+              },
+              {
+                "type": "paneldynamic",
+                "name": "integrations",
+                "title": "Third-Party Integrations",
+                "templateTitle": "Integration #{panelIndex}",
+                "templateElements": [
+                  { "type": "text", "name": "integration_name", "title": "Integration Name" },
+                  {
+                    "type": "dropdown",
+                    "name": "integration_type",
+                    "title": "Integration Type",
+                    "choices": [
+                      { "value": "api", "text": "API" },
+                      { "value": "sdk", "text": "SDK" },
+                      { "value": "webhook", "text": "Webhook" }
+                    ]
+                  }
+                ],
+                "panelCount": 1,
+                "minPanelCount": 0,
+                "maxPanelCount": 5
+              }
             ]
           }
         ]
@@ -264,7 +379,16 @@
             "elements": [
               { "type": "text", "name": "system_name", "title": "System Name", "isRequired": true },
               { "type": "comment", "name": "review_reason", "title": "Reason for Review Request" },
-              { "type": "radiogroup", "name": "urgency", "title": "Urgency", "choices": [{ "value": "low", "text": "Low" }, { "value": "medium", "text": "Medium" }, { "value": "high", "text": "High" }] }
+              {
+                "type": "radiogroup",
+                "name": "urgency",
+                "title": "Urgency",
+                "choices": [
+                  { "value": "low", "text": "Low" },
+                  { "value": "medium", "text": "Medium" },
+                  { "value": "high", "text": "High" }
+                ]
+              }
             ]
           }
         ]
@@ -277,13 +401,15 @@
       "survey": "Simple Workflow Survey",
       "user": "test-user",
       "status": "submitted",
-      "responses": { "system_name": "E2E Seed System", "review_reason": "Annual security review", "urgency": "medium" }
+      "responses": {
+        "system_name": "E2E Seed System",
+        "review_reason": "Annual security review",
+        "urgency": "medium"
+      }
     }
   ],
   "admin_entities": {
-    "groups": [
-      { "name": "Seed Group - Engineering", "members": ["test-user", "test-reviewer"] }
-    ],
+    "groups": [{ "name": "Seed Group - Engineering", "members": ["test-user", "test-reviewer"] }],
     "quotas": [],
     "webhooks": [
       {

--- a/e2e/tests/workflows/dashboard-filters.spec.ts
+++ b/e2e/tests/workflows/dashboard-filters.spec.ts
@@ -5,8 +5,9 @@ import { DashboardFilterFlow } from '../../flows/dashboard-filter.flow';
 
 const SEEDED_TM = 'Seed TM - Full Fields';
 
-// The seeded TM is owned by test-reviewer — use the reviewer fixture so the
-// dashboard shows it without permission workarounds.
+// The seeded TM is owned by test-user and security-reviewed by test-reviewer,
+// so it satisfies either role's default dashboard filter. The reviewer fixture
+// is used here so the default view shows it without permission workarounds.
 reviewerTest.describe('Dashboard Filters', () => {
   reviewerTest.setTimeout(30000);
 
@@ -18,17 +19,17 @@ reviewerTest.describe('Dashboard Filters', () => {
 
     // Search for the seeded TM — this works regardless of pagination.
     await filterFlow.searchByName(SEEDED_TM);
-    await expect(
-      dashboard.tmCard(SEEDED_TM).or(dashboard.tableRow(SEEDED_TM))
-    ).toBeVisible({ timeout: 5000 });
+    await expect(dashboard.tmCard(SEEDED_TM).or(dashboard.tableRow(SEEDED_TM))).toBeVisible({
+      timeout: 5000,
+    });
 
     // Clear the search and re-assert with the search term again to avoid
     // pagination hiding the TM behind unrelated entries.
     await dashboard.searchClear().click();
     await filterFlow.searchByName(SEEDED_TM);
-    await expect(
-      dashboard.tmCard(SEEDED_TM).or(dashboard.tableRow(SEEDED_TM))
-    ).toBeVisible({ timeout: 5000 });
+    await expect(dashboard.tmCard(SEEDED_TM).or(dashboard.tableRow(SEEDED_TM))).toBeVisible({
+      timeout: 5000,
+    });
   });
 
   reviewerTest('Status filter', async ({ reviewerPage }) => {
@@ -40,9 +41,9 @@ reviewerTest.describe('Dashboard Filters', () => {
     // Narrow the list to the seeded TM so pagination (from other leftover
     // E2E TMs) doesn't hide it behind page 1.
     await filterFlow.searchByName(SEEDED_TM);
-    await expect(
-      dashboard.tmCard(SEEDED_TM).or(dashboard.tableRow(SEEDED_TM))
-    ).toBeVisible({ timeout: 10000 });
+    await expect(dashboard.tmCard(SEEDED_TM).or(dashboard.tableRow(SEEDED_TM))).toBeVisible({
+      timeout: 10000,
+    });
 
     // Add a status filter the seeded TM does not have — it should disappear.
     await filterFlow.filterByStatus(['Approved']);
@@ -59,10 +60,10 @@ reviewerTest.describe('Dashboard Filters', () => {
 
     // Narrow by name first so pagination doesn't hide the seeded TM.
     await filterFlow.searchByName(SEEDED_TM);
-    await filterFlow.filterByOwner('test-reviewer');
-    await expect(
-      dashboard.tmCard(SEEDED_TM).or(dashboard.tableRow(SEEDED_TM))
-    ).toBeVisible({ timeout: 5000 });
+    await filterFlow.filterByOwner('test-user');
+    await expect(dashboard.tmCard(SEEDED_TM).or(dashboard.tableRow(SEEDED_TM))).toBeVisible({
+      timeout: 5000,
+    });
 
     await filterFlow.clearAllFilters();
   });
@@ -74,15 +75,15 @@ reviewerTest.describe('Dashboard Filters', () => {
     const filterFlow = new DashboardFilterFlow(reviewerPage);
 
     await filterFlow.searchByName(SEEDED_TM);
-    await expect(
-      dashboard.tmCard(SEEDED_TM).or(dashboard.tableRow(SEEDED_TM))
-    ).toBeVisible({ timeout: 10000 });
+    await expect(dashboard.tmCard(SEEDED_TM).or(dashboard.tableRow(SEEDED_TM))).toBeVisible({
+      timeout: 10000,
+    });
 
     // Past created-after date — TM still visible
     await filterFlow.filterByDateRange('created', '01/01/2020');
-    await expect(
-      dashboard.tmCard(SEEDED_TM).or(dashboard.tableRow(SEEDED_TM))
-    ).toBeVisible({ timeout: 5000 });
+    await expect(dashboard.tmCard(SEEDED_TM).or(dashboard.tableRow(SEEDED_TM))).toBeVisible({
+      timeout: 5000,
+    });
 
     await filterFlow.clearAllFilters();
 
@@ -108,7 +109,10 @@ reviewerTest.describe('Dashboard Filters', () => {
     // Switch to table view to see paginator more reliably
     await dashboard.viewToggle().click();
 
-    const paginatorVisible = await dashboard.paginator().isVisible().catch(() => false);
+    const paginatorVisible = await dashboard
+      .paginator()
+      .isVisible()
+      .catch(() => false);
     if (paginatorVisible) {
       await expect(dashboard.paginator()).toBeVisible();
     } else {

--- a/e2e/tests/workflows/dashboard-visibility.spec.ts
+++ b/e2e/tests/workflows/dashboard-visibility.spec.ts
@@ -1,0 +1,144 @@
+import { expect } from '@playwright/test';
+import { userTest, reviewerTest, outsiderTest } from '../../fixtures/auth-fixtures';
+import { DashboardPage } from '../../pages/dashboard.page';
+
+/**
+ * Who sees which threat models on the dashboard, asserted positively and
+ * negatively.
+ *
+ * The dashboard opens with a role-specific identity filter already applied
+ * (`computeDefaultFilters`, dashboard-filter.model.ts): security reviewers get
+ * `securityReviewer = <their email>`, everyone else gets `owner = <their
+ * email>`. That default is the "only mine" view, and it is the reason a test
+ * that simply loads /dashboard and looks for a seeded threat model can fail
+ * even though the data and the grants are both correct.
+ *
+ * The seed is arranged so a single threat model exercises both roles:
+ * `Seed TM - Full Fields` is owned by `test-user` (not a reviewer) and has
+ * `test-reviewer` as its security reviewer, so it satisfies each role's
+ * default filter. `test-outsider` owns nothing and is granted nothing, which
+ * makes the negative case meaningful rather than vacuous.
+ */
+
+const SEEDED_TM = 'Seed TM - Full Fields';
+
+/**
+ * Navigate to the dashboard and return the server's threat-model listing.
+ *
+ * A "sees nothing" assertion is worthless on its own: an empty dashboard looks
+ * identical whether the user genuinely has no access or the API call failed —
+ * and the dev port-forward does drop connections, so that is a live risk, not a
+ * hypothetical one. Both empty states in dashboard.component.html render on
+ * error too, so the UI cannot be used as its own control. Asserting the
+ * response is ok() proves the server answered, and its `total` proves what it
+ * answered with.
+ */
+async function gotoDashboardAndCaptureListing(
+  page: import('@playwright/test').Page,
+): Promise<{ total: number; names: string[] }> {
+  const [response] = await Promise.all([
+    page.waitForResponse(
+      r => r.url().includes('/threat_models?') && r.request().method() === 'GET',
+      { timeout: 20000 },
+    ),
+    page.goto('/dashboard'),
+  ]);
+
+  expect(response.ok(), `GET /threat_models returned ${response.status()}`).toBeTruthy();
+
+  const body = (await response.json()) as {
+    threat_models: { name: string }[];
+    total: number;
+  };
+  return { total: body.total, names: body.threat_models.map(t => t.name) };
+}
+
+reviewerTest.describe('Dashboard visibility — security reviewer', () => {
+  reviewerTest.setTimeout(60000);
+
+  reviewerTest(
+    'sees assigned models by default, and more once the filter is cleared',
+    async ({ reviewerPage }) => {
+      const dashboard = new DashboardPage(reviewerPage);
+      const scoped = await gotoDashboardAndCaptureListing(reviewerPage);
+      await dashboard.waitForReady();
+
+      // Default view is scoped to models this reviewer is assigned to.
+      await expect(dashboard.securityReviewerFilter()).toHaveValue('test-reviewer@tmi.local');
+      expect(scoped.names).toContain(SEEDED_TM);
+      await expect(dashboard.tmCard(SEEDED_TM).first()).toBeVisible({ timeout: 10000 });
+
+      const scopedCount = await dashboard.tmCards().count();
+      expect(scopedCount).toBeGreaterThan(0);
+
+      // Clearing the "only mine" filter must not lose anything it was showing,
+      // and may reveal models assigned to other reviewers.
+      await dashboard.securityReviewerFilter().fill('');
+      await expect(dashboard.securityReviewerFilter()).toHaveValue('');
+      await expect(dashboard.tmCard(SEEDED_TM).first()).toBeVisible({ timeout: 10000 });
+      expect(await dashboard.tmCards().count()).toBeGreaterThanOrEqual(scopedCount);
+    },
+  );
+});
+
+userTest.describe('Dashboard visibility — non-reviewer who owns a model', () => {
+  userTest.setTimeout(60000);
+
+  userTest('sees the model they own under the default owner filter', async ({ userPage }) => {
+    const dashboard = new DashboardPage(userPage);
+    const listing = await gotoDashboardAndCaptureListing(userPage);
+    await dashboard.waitForReady();
+
+    // A non-reviewer gets the owner filter, pre-filled with their own address.
+    await expect(dashboard.ownerFilter()).toHaveValue('test-user@tmi.local');
+    expect(listing.names).toContain(SEEDED_TM);
+
+    // test-user owns the seeded model, so the default view already shows it —
+    // no filter clearing required.
+    await expect(dashboard.tmCard(SEEDED_TM).first()).toBeVisible({ timeout: 10000 });
+  });
+});
+
+outsiderTest.describe('Dashboard visibility — non-reviewer who owns nothing', () => {
+  outsiderTest.setTimeout(60000);
+
+  outsiderTest('sees no threat models', async ({ outsiderPage }) => {
+    const dashboard = new DashboardPage(outsiderPage);
+    const listing = await gotoDashboardAndCaptureListing(outsiderPage);
+    await dashboard.waitForReady();
+
+    // The server answered, and it answered with nothing for this user.
+    expect(listing.total).toBe(0);
+    expect(listing.names).toEqual([]);
+
+    await expect(dashboard.ownerFilter()).toHaveValue('test-outsider@tmi.local');
+    await expect(dashboard.tmCards()).toHaveCount(0);
+  });
+
+  outsiderTest('still sees nothing once every filter is cleared', async ({ outsiderPage }) => {
+    const dashboard = new DashboardPage(outsiderPage);
+    await gotoDashboardAndCaptureListing(outsiderPage);
+    await dashboard.waitForReady();
+
+    // The point of this case: an empty dashboard must be the result of having
+    // no access, not merely of the default filter. Clearing the filter issues a
+    // fresh request, and that request must also come back empty — otherwise the
+    // seeded threat model owned by someone else would be exposed.
+    const [unfiltered] = await Promise.all([
+      outsiderPage.waitForResponse(
+        r => r.url().includes('/threat_models?') && r.request().method() === 'GET',
+        { timeout: 20000 },
+      ),
+      dashboard.ownerFilter().fill(''),
+    ]);
+
+    expect(unfiltered.ok(), `GET /threat_models returned ${unfiltered.status()}`).toBeTruthy();
+    const body = (await unfiltered.json()) as { threat_models: { name: string }[]; total: number };
+    expect(body.total).toBe(0);
+    expect(body.threat_models.map(t => t.name)).not.toContain(SEEDED_TM);
+
+    await expect(dashboard.ownerFilter()).toHaveValue('');
+    await expect(dashboard.tmCard(SEEDED_TM)).toHaveCount(0);
+    await expect(dashboard.tmCards()).toHaveCount(0);
+  });
+});

--- a/e2e/tests/workflows/error-scenarios.spec.ts
+++ b/e2e/tests/workflows/error-scenarios.spec.ts
@@ -160,7 +160,7 @@ adminTest.describe('Error Scenarios (Admin)', () => {
   });
 
   adminTest('admin check failure redirects away from /admin', async ({ adminPage }) => {
-    // Mocking /users/me to 500 trips the authGuard before reaching adminGuard,
+    // Mocking /me to 500 trips the authGuard before reaching adminGuard,
     // producing a session_expired redirect to /login rather than the
     // admin_check_failed redirect from adminGuard's error branch. The valuable
     // invariant is that /admin is never rendered when profile cannot be

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmi-ux",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "type": "module",
   "scripts": {
     "prepare": "git config core.hooksPath .husky 2>/dev/null || true",

--- a/src/app/auth/guards/admin.guard.ts
+++ b/src/app/auth/guards/admin.guard.ts
@@ -2,7 +2,7 @@
  * Admin Route Guard
  *
  * This guard protects routes that require administrator privileges.
- * It verifies admin status by calling GET /users/me to ensure freshness.
+ * It verifies admin status by calling GET /me to ensure freshness.
  *
  * Key functionality:
  * - Uses Angular's functional guard pattern with dependency injection

--- a/src/app/auth/guards/reviewer.guard.ts
+++ b/src/app/auth/guards/reviewer.guard.ts
@@ -2,7 +2,7 @@
  * Security Reviewer Route Guard
  *
  * This guard protects routes that require security reviewer privileges.
- * It verifies reviewer status by calling GET /users/me to ensure freshness.
+ * It verifies reviewer status by calling GET /me to ensure freshness.
  *
  * Key functionality:
  * - Uses Angular's functional guard pattern with dependency injection

--- a/src/app/auth/models/auth.models.ts
+++ b/src/app/auth/models/auth.models.ts
@@ -71,19 +71,19 @@ export interface UserProfile {
 
   /**
    * Whether the user has administrator privileges
-   * Populated from JWT tmi_is_administrator claim and verified via GET /users/me
+   * Populated from JWT tmi_is_administrator claim and verified via GET /me
    */
   is_admin?: boolean;
 
   /**
    * Whether the user has security reviewer privileges
-   * Populated from JWT tmi_is_security_reviewer claim and verified via GET /users/me
+   * Populated from JWT tmi_is_security_reviewer claim and verified via GET /me
    */
   is_security_reviewer?: boolean;
 }
 
 /**
- * API response from GET /users/me endpoint
+ * API response from GET /me endpoint
  * Uses different field names than UserProfile (backend API naming)
  */
 export interface UserMeResponse {

--- a/src/app/core/services/user.service.spec.ts
+++ b/src/app/core/services/user.service.spec.ts
@@ -54,7 +54,7 @@ describe('UserService', () => {
 
       service.requestDeleteChallenge().subscribe(response => {
         expect(response).toEqual(mockResponse);
-        expect(apiService.delete).toHaveBeenCalledWith('users/me');
+        expect(apiService.delete).toHaveBeenCalledWith('me');
         expect(loggerService.info).toHaveBeenCalledWith('Requesting account deletion challenge');
       });
     });
@@ -77,7 +77,7 @@ describe('UserService', () => {
       vi.mocked(apiService.deleteWithParams).mockReturnValue(of(undefined));
 
       service.confirmDeleteAccount(challenge).subscribe(() => {
-        expect(apiService.deleteWithParams).toHaveBeenCalledWith('users/me', { challenge });
+        expect(apiService.deleteWithParams).toHaveBeenCalledWith('me', { challenge });
         expect(loggerService.info).toHaveBeenCalledWith(
           'Confirming account deletion with challenge',
         );

--- a/src/app/core/services/user.service.ts
+++ b/src/app/core/services/user.service.ts
@@ -49,7 +49,7 @@ export class UserService {
   // SEM@44287f3f5c43dfa5aaf5fa36290065fd39725079: fetch the authenticated user profile including admin status (reads DB)
   getCurrentUser(): Observable<UserProfile> {
     this.logger.info('Fetching current user profile');
-    return this.apiService.get<UserProfile>('users/me');
+    return this.apiService.get<UserProfile>('me');
   }
 
   /**
@@ -59,7 +59,7 @@ export class UserService {
   // SEM@fbed61cffb1a9a41593309e41f1b6f8a61a5f4d2: request an account-deletion challenge token from the API (reads DB)
   requestDeleteChallenge(): Observable<DeleteChallengeResponse> {
     this.logger.info('Requesting account deletion challenge');
-    return this.apiService.delete<DeleteChallengeResponse>('users/me');
+    return this.apiService.delete<DeleteChallengeResponse>('me');
   }
 
   /**
@@ -70,7 +70,7 @@ export class UserService {
   // SEM@fbed61cffb1a9a41593309e41f1b6f8a61a5f4d2: delete the authenticated user account by confirming a challenge token (reads DB)
   confirmDeleteAccount(challenge: string): Observable<void> {
     this.logger.info('Confirming account deletion with challenge');
-    return this.apiService.deleteWithParams<void>('users/me', { challenge });
+    return this.apiService.deleteWithParams<void>('me', { challenge });
   }
 
   /**


### PR DESCRIPTION
Three related fixes that unblock the E2E field-coverage suite.

## `fix:` account deletion called a non-existent endpoint (#880)

`UserService` called `DELETE /users/me` in three places. That path is not in the
API spec — the server returns `404: no matching operation was found`. The correct
endpoint is `DELETE /me`. This failed for **every** user on **every** auth provider;
it surfaced during SAML testing but was never SAML-specific.

## `fix:` drop the read-only `alias` field from the E2E seed spec

`alias` is read-only (server-assigned integer). Sending it aborted the whole seed
run, which is why `make e2e-seed` had been failing and the field-coverage suite was
running against an empty database.

## `test:` positive and negative dashboard visibility coverage (#885)

The dashboard's default `owner=self` identity filter is intended behavior, but the
suite had **no** visibility cases at all, so the filter's effect only ever showed up
as 43 unexplained failures.

- `Seed TM - Full Fields` is now owned by `test-user` (a non-reviewer) and
  security-reviewed by `test-reviewer`, so one model satisfies both roles' default filters.
- Added a fourth user `test-outsider` that owns nothing and is granted nothing —
  without such a user the negative case cannot be written. The spec notes it must stay that way.
- New `e2e/tests/workflows/dashboard-visibility.spec.ts` covers reviewer-sees-assigned,
  owner-sees-owned, and outsider-sees-nothing (both default and cleared filters).
- Each case captures the `GET /threat_models` response and asserts `ok()` plus the
  server's `total`. An empty dashboard looks identical whether the user has no access
  or the request failed, and both empty states render on error — the dev port-forward
  does drop connections, so this was a live risk.

**The negative test was proved able to fail:** granting `test-outsider` reader access
in the DB made the cleared-filter case fail `Expected 0, Received 1`; removing it
returned all four to green.

## Results

Field coverage went **51 passed / 47 failed → 97 passed / 16 failed / 3 not run**,
runtime **27m → 8.6m**.

### Regression check

The whole `workflows` suite was run against both the old and new seed to separate
cause from coincidence:

- **Caused by this change: 1** — `Dashboard Filters › Owner filter` filtered by
  `test-reviewer`, now `test-user`. Fixed in the same commit.
- **Pre-existing: 8** — fail on both seeds (cross-cutting-sweeps admin/webhooks
  translations, document-access-diagnostics, google-drive-unlinked-prompt, two
  markdown-sanitization cases, survey-admin clone, survey-cross-role lifecycle,
  triage list filters).
- **Flaky, not a regression: 1** — `confidential TM visibility`, filed as #887.

Closes #880
Closes #885

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhFFh7p2pVLfJm2qRLPxpE