### PR TITLE
test: use a real RelationshipType in the related-teams/projects dialog specs (#869)

### DIFF
--- a/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.spec.ts
+++ b/src/app/shared/components/related-projects-dialog/related-projects-dialog.component.spec.ts
@@ -72,7 +72,7 @@ describe('RelatedProjectsDialogComponent', () => {
   });
 
   it('should create, copying the related projects', () => {
-    const related = [{ related_project_id: 'proj-2', relationship: 'parent' }] as RelatedProject[];
+    const related: RelatedProject[] = [{ related_project_id: 'proj-2', relationship: 'parent' }];
     const component = build({ project: makeProject(related) });
 
     expect(component.relatedProjects).toEqual(related);
@@ -102,7 +102,7 @@ describe('RelatedProjectsDialogComponent', () => {
   describe('addRelated', () => {
     it('does nothing when no project is selected', () => {
       const component = build({ project: makeProject() });
-      component.addForm.get('relationship')?.setValue('peer');
+      component.addForm.get('relationship')?.setValue('related');
 
       component.addRelated();
 
@@ -112,13 +112,13 @@ describe('RelatedProjectsDialogComponent', () => {
     it('adds the selected project with its relationship and resets the form', () => {
       const component = build({ project: makeProject() });
       component.selectedProject = otherProject;
-      component.addForm.get('relationship')?.setValue('peer');
+      component.addForm.get('relationship')?.setValue('related');
 
       component.addRelated();
 
       expect(component.relatedProjects).toHaveLength(1);
       expect(component.relatedProjects[0].related_project_id).toBe('proj-9');
-      expect(component.relatedProjects[0].relationship).toBe('peer');
+      expect(component.relatedProjects[0].relationship).toBe('related');
       expect(component.projectNames.get('proj-9')).toBe('Other Project');
       expect(component.dirty).toBe(true);
       expect(component.showAddForm).toBe(false);
@@ -126,9 +126,7 @@ describe('RelatedProjectsDialogComponent', () => {
 
     it('does not add a duplicate related project', () => {
       const component = build({
-        project: makeProject([
-          { related_project_id: 'proj-9', relationship: 'related' },
-        ] as RelatedProject[]),
+        project: makeProject([{ related_project_id: 'proj-9', relationship: 'related' }]),
       });
       component.selectedProject = otherProject;
       component.addForm.get('relationship')?.setValue('parent');
@@ -145,7 +143,7 @@ describe('RelatedProjectsDialogComponent', () => {
         project: makeProject([
           { related_project_id: 'proj-2', relationship: 'related' },
           { related_project_id: 'proj-3', relationship: 'parent' },
-        ] as RelatedProject[]),
+        ]),
       });
 
       component.removeRelated({

--- a/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.spec.ts
+++ b/src/app/shared/components/related-teams-dialog/related-teams-dialog.component.spec.ts
@@ -72,7 +72,7 @@ describe('RelatedTeamsDialogComponent', () => {
   });
 
   it('should create, copying the related teams', () => {
-    const related = [{ related_team_id: 'team-2', relationship: 'parent' }] as RelatedTeam[];
+    const related: RelatedTeam[] = [{ related_team_id: 'team-2', relationship: 'parent' }];
     const component = build({ team: makeTeam(related) });
 
     expect(component.relatedTeams).toEqual(related);
@@ -100,7 +100,7 @@ describe('RelatedTeamsDialogComponent', () => {
   describe('addRelated', () => {
     it('does nothing when no team is selected', () => {
       const component = build({ team: makeTeam() });
-      component.addForm.get('relationship')?.setValue('peer');
+      component.addForm.get('relationship')?.setValue('related');
 
       component.addRelated();
 
@@ -110,13 +110,13 @@ describe('RelatedTeamsDialogComponent', () => {
     it('adds the selected team with its relationship and resets the form', () => {
       const component = build({ team: makeTeam() });
       component.selectedTeam = otherTeam;
-      component.addForm.get('relationship')?.setValue('peer');
+      component.addForm.get('relationship')?.setValue('related');
 
       component.addRelated();
 
       expect(component.relatedTeams).toHaveLength(1);
       expect(component.relatedTeams[0].related_team_id).toBe('team-9');
-      expect(component.relatedTeams[0].relationship).toBe('peer');
+      expect(component.relatedTeams[0].relationship).toBe('related');
       expect(component.teamNames.get('team-9')).toBe('Other Team');
       expect(component.dirty).toBe(true);
       expect(component.showAddForm).toBe(false);
@@ -124,7 +124,7 @@ describe('RelatedTeamsDialogComponent', () => {
 
     it('does not add a duplicate related team', () => {
       const component = build({
-        team: makeTeam([{ related_team_id: 'team-9', relationship: 'related' }] as RelatedTeam[]),
+        team: makeTeam([{ related_team_id: 'team-9', relationship: 'related' }]),
       });
       component.selectedTeam = otherTeam;
       component.addForm.get('relationship')?.setValue('parent');
@@ -141,7 +141,7 @@ describe('RelatedTeamsDialogComponent', () => {
         team: makeTeam([
           { related_team_id: 'team-2', relationship: 'related' },
           { related_team_id: 'team-3', relationship: 'parent' },
-        ] as RelatedTeam[]),
+        ]),
       });
 
       component.removeRelated({


### PR DESCRIPTION
The `related-teams-dialog` and `related-projects-dialog` specs drove their form
interactions with the string literal `'peer'`, which is not a member of
`RelationshipType`. The specs passed only because the value was cast, so they were
asserting against a relationship the application can never produce.

Replaced with a real `RelationshipType` member so the specs exercise a value the
form can actually hold.

Follow-up from the #858 spec-typecheck-at-zero work, alongside #866/#867/#868/#870.

Closes #869

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhFFh7p2pVLfJm2qRLPxpE